### PR TITLE
Fix component outlines getting out of sync when dragging.

### DIFF
--- a/src/main/java/eu/mihosoft/freerouting/board/BasicBoard.java
+++ b/src/main/java/eu/mihosoft/freerouting/board/BasicBoard.java
@@ -420,7 +420,7 @@ public class BasicBoard implements java.io.Serializable
             return null;
         }
         ComponentOutline outline = new ComponentOutline(p_area, p_is_front, p_translation, p_rotation_in_degree,
-                p_component_no, p_fixed_state, this);
+                0, p_component_no, p_fixed_state, this);
         insert_item(outline);
         return outline;
     }

--- a/src/main/java/eu/mihosoft/freerouting/board/ComponentOutline.java
+++ b/src/main/java/eu/mihosoft/freerouting/board/ComponentOutline.java
@@ -43,9 +43,9 @@ public class ComponentOutline extends Item implements java.io.Serializable
 
     /** Creates a new instance of ComponentOutline */
     public ComponentOutline(Area p_area, boolean p_is_front, Vector p_translation, double p_rotation_in_degree,
-            int p_component_no, FixedState p_fixed_state, BasicBoard p_board)
+            int p_id_no, int p_component_no, FixedState p_fixed_state, BasicBoard p_board)
     {
-        super(new int[0], 0, 0, p_component_no, p_fixed_state, p_board);
+        super(new int[0], 0, p_id_no, p_component_no, p_fixed_state, p_board);
         this.relative_area = p_area;
         this.is_front = p_is_front;
         this.translation = p_translation;
@@ -55,7 +55,7 @@ public class ComponentOutline extends Item implements java.io.Serializable
     public Item copy(int p_id_no)
     {
         return new ComponentOutline(this.relative_area, this.is_front, this.translation, this.rotation_in_degree,
-                this.get_component_no(), this.get_fixed_state(), this.board);
+                p_id_no, this.get_component_no(), this.get_fixed_state(), this.board);
     }
 
     public boolean is_selected_by_filter(ItemSelectionFilter p_filter)


### PR DESCRIPTION
Dragging components can cause component outlines to get out of sync (the undo mechanism restores the pins always correctly, but fails to restore the component outlines).

Giving component outlines unique id_nos (they all used have id_no 0) fixes this issue.