### PR TITLE
Fix via instantiation during DSN parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For more information please use the online help in the board editor. From here y
 
 
 
-### Additional steps for users of [pcb-rnd](https://www.repo.hu/projects/pcb-rnd)
+### Additional steps for users of [pcb-rnd](http://www.repo.hu/projects/pcb-rnd)
 
 Using the standalone freerouting application
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Using freerouting from within pcb-rnd
 
 2) Unzip it and rename the top directory freerouting-1.5.0-linux-x64 to freerouting.net (the default location is /opt/freerouting.net)
 
-3) Start pcb-rnd and ensure that this directory is specified in (File / Preferences / Config Tree / Plugins / arextern / freerouting_net...); the location of the executable can be customised.
+3) Start pcb-rnd and ensure that this directory is specified in (File / Preferences / Config Tree / Plugins / ar_extern / freerouting_net...); the location of the executable can be customised.
 
 4) Load your layout
 
@@ -103,7 +103,6 @@ Using freerouting from within pcb-rnd
 6) Select the freerouting.net tab, and push the "Route" button.
 
 7) Go back to the layout and inspect the autorouted networks. Track widths and clearances during autorouting are based on the currently selected route style when the autorouter is started.
-
 
 
 ## Using the command line arguments

--- a/README.md
+++ b/README.md
@@ -68,6 +68,44 @@ For more information please use the online help in the board editor. From here y
 6) Go back to KiCad's Pcbnew and import the results (File / Import Specctra Session...).
 
 
+
+### Additional steps for users of pcb-rnd
+
+Using the standalone freerouting application
+
+1) Download the latest freerouting-1.5.0.jar file from the [Releases](https://github.com/freerouting/freerouting/releases) page
+
+2) Start pcb-rnd and load your layout.
+
+3) Export the layout as Specctra DSN (File / Export... / Specctra DSN).
+
+4) Start the router by running the freerouting-executable.jar file, push the "Open Your Own Design" button and select the exported .dsn file in the file chooser.
+
+5) Do the routing.
+
+5) When you're finished, export the results into a Specctra session file (File / Export Specctra Session File). The router will generate a .ses file for you.
+
+6) Go back to pcb-rnd and import the results (File / Import autorouted dsn/ses file...). Track widths and clearances during autorouting are based on the currently selected route style during DSN export.
+
+
+Using freerouting from within pcb-rnd
+
+1) Download the latest freerouting-1.5.0-linux-x64.zip from the [Releases](https://github.com/freerouting/freerouting/releases) page
+
+2) Unzip it and rename the top directory freerouting-1.5.0-linux-x64 to freerouting.net (the default location is /opt/freerouting.net)
+
+3) Start pcb-rnd and ensure that this directory is specified in (File / Preferences / Config Tree / Plugins / arextern / freerouting_net...); the location of the executable can be customised.
+
+4) Load your layout
+
+5) Open the external autorouter window with (Connect / Automatic Routing / External autorouter...)
+
+6) Select the freerouting.net tab, and push the "Route" button.
+
+7) Go back to the layout and inspect the autorouted networks. Track widths and clearances during autorouting are based on the currently selected route style when the autorouter is started.
+
+
+
 ## Using the command line arguments
 
 Freerouter was designed as a GUI program, but it also can function as a command line tool. Typically you would have an input file (e.g. Specctra DSN) that you exported from you EDA (e.g. KiCad). If this file has unconnected routes, you would want to wire those with autorouter, and save the result in a format that you can then import back into your EDA.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ Using freerouting from within pcb-rnd
 7) Go back to the layout and inspect the autorouted networks. Track widths and clearances during autorouting are based on the currently selected route style when the autorouter is started.
 
 
+Using headless/GUI-less freerouting from within pcb-rnd
+
+1) Download the latest freerouting_cli from the svn [repo](http://repo.hu/projects/freerouting_cli/cli.html)
+
+2) cd freerouting_cli/trunk and run make, followed by sudo make install
+
+3) Start pcb-rnd and load your layout
+
+4) Open the external autorouter window with (Connect / Automatic Routing / External autorouter...)
+
+5) Select the freerouting_cli tab, and push the "Route" button.
+
+7) Go back to the layout and inspect the autorouted networks. Track widths and clearances during autorouting are based on the currently selected route style when the autorouter is started.
+
+
 ## Using the command line arguments
 
 Freerouter was designed as a GUI program, but it also can function as a command line tool. Typically you would have an input file (e.g. Specctra DSN) that you exported from you EDA (e.g. KiCad). If this file has unconnected routes, you would want to wire those with autorouter, and save the result in a format that you can then import back into your EDA.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Using freerouting from within pcb-rnd
 
 Using headless/GUI-less freerouting from within pcb-rnd
 
-1) Download the latest freerouting_cli from the svn [repo](http://repo.hu/projects/freerouting_cli/cli.html)
+1) Download the latest freerouting_cli from the svn [repo](http://repo.hu/projects/freerouting_cli/)
 
 2) cd freerouting_cli/trunk and run make, followed by sudo make install
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For more information please use the online help in the board editor. From here y
 
 
 
-### Additional steps for users of pcb-rnd
+### Additional steps for users of pcb-rnd [pcb-rnd](https://www.repo.hu/projects/pcb-rnd)
 
 Using the standalone freerouting application
 
@@ -103,22 +103,6 @@ Using freerouting from within pcb-rnd
 6) Select the freerouting.net tab, and push the "Route" button.
 
 7) Go back to the layout and inspect the autorouted networks. Track widths and clearances during autorouting are based on the currently selected route style when the autorouter is started.
-
-
-Using headless/GUI-less freerouting from within pcb-rnd
-
-1) Download the latest freerouting_cli from the svn [repo](http://repo.hu/projects/freerouting_cli/)
-
-2) cd freerouting_cli/trunk and run make, followed by sudo make install
-
-3) Start pcb-rnd and load your layout
-
-4) Open the external autorouter window with (Connect / Automatic Routing / External autorouter...)
-
-5) Select the freerouting_cli tab, and push the "Route" button.
-
-7) Go back to the layout and inspect the autorouted networks. Track widths and clearances during autorouting are based on the currently selected route style when the autorouter is started.
-
 
 ## Using the command line arguments
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For more information please use the online help in the board editor. From here y
 
 
 
-### Additional steps for users of pcb-rnd [pcb-rnd](https://www.repo.hu/projects/pcb-rnd)
+### Additional steps for users of [pcb-rnd](https://www.repo.hu/projects/pcb-rnd)
 
 Using the standalone freerouting application
 

--- a/src/main/java/app/freerouting/designforms/specctra/Library.java
+++ b/src/main/java/app/freerouting/designforms/specctra/Library.java
@@ -77,36 +77,6 @@ public class Library extends ScopeKeyword
             }
         }
         
-        // Set the via padstacks.
-        if (p_par.via_padstack_names != null)
-        {
-            app.freerouting.library.Padstack[] via_padstacks = new app.freerouting.library.Padstack[p_par.via_padstack_names.size()];
-            Iterator<String> it = p_par.via_padstack_names.iterator();
-            int found_padstack_count = 0;
-            for (int i = 0; i < via_padstacks.length; ++i)
-            {
-                String curr_padstack_name = it.next();
-                app.freerouting.library.Padstack curr_padstack = board.library.padstacks.get(curr_padstack_name);
-                if (curr_padstack != null)
-                {
-                    via_padstacks[found_padstack_count] = curr_padstack;
-                    ++found_padstack_count;
-                }
-                else
-                {
-                    FRLogger.warn("Library.read_scope: via padstack with name '" + curr_padstack_name + " not found");
-                }
-            }
-            if (found_padstack_count != via_padstacks.length)
-            {
-                // Some via padstacks were not found in the padstacks scope of the dsn-file.
-                app.freerouting.library.Padstack[] corrected_padstacks = new app.freerouting.library.Padstack[found_padstack_count];
-                System.arraycopy(via_padstacks, 0, corrected_padstacks, 0, found_padstack_count);
-                via_padstacks = corrected_padstacks;
-            }
-            board.library.set_via_padstacks(via_padstacks);
-        }
-        
         // Create the library packages on the board
         board.library.packages = new app.freerouting.library.Packages(board.library.padstacks);
         Iterator<Package> it = package_list.iterator();

--- a/src/main/java/app/freerouting/designforms/specctra/SpecctraFileScanner.java
+++ b/src/main/java/app/freerouting/designforms/specctra/SpecctraFileScanner.java
@@ -1,4 +1,6 @@
 package app.freerouting.designforms.specctra;
+import app.freerouting.logger.FRLogger;
+
 @SuppressWarnings("all")
 
 /**
@@ -1401,7 +1403,9 @@ class SpecctraFileScanner implements Scanner {
           }
         case 230: break;
         case 2: 
-          { throw new Error("Illegal character '"+yytext()+"' was found at position " + zzCurrentPos);
+          { string.append("X");
+            FRLogger.warn("Illegal character '" + yytext() + "' found at position "
+                           + zzCurrentPos + " replaced with 'X'.");
           }
         case 231: break;
         case 95: 


### PR DESCRIPTION
Valid DSN files may not necessarily name padstacks for use as vias in the Structure section, instead naming them in the Circuit section of Netclasses. This patch moves the instantiation from LIbrary.java to Network.java to ensure that any padstacks named in the Network section for use as vias are included during via instantiation. 