### PR TITLE
Fix UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 ...

### DIFF
--- a/integrations/KiCad/kicad-freerouting/plugins/plugin.py
+++ b/integrations/KiCad/kicad-freerouting/plugins/plugin.py
@@ -78,7 +78,7 @@ class FreeroutingPlugin(pcbnew.ActionPlugin):
         self.bFirstLine = True
         self.bEatNextLine = False
         fw = open(self.module_input, "w")
-        fr = open(self.temp_input , "r")
+	fr = open(self.temp_input , "r", encoding="utf-8")
         for l in fr:
             if self.bFirstLine:
                 fw.writelines('(pcb ' + self.module_input + '\n')


### PR DESCRIPTION
This will fix the error i run into with KiCad 6.0.11 on MacOS starting freerouting as a plugin directly from KiCad.
The standalone mode, exporting the dsn from KiCad and opening in freerouting v1.7.0 works.  