### PR TITLE
improve Java version checking

### DIFF
--- a/integrations/KiCad/checkjava.py
+++ b/integrations/KiCad/checkjava.py
@@ -6,6 +6,8 @@ def get_java_version():
     javaPath = 'java'
 
     javaInfo = subprocess.check_output(javaPath + ' -version', shell=True, stderr=subprocess.STDOUT)
-    print(javaInfo.decode().splitlines()[0])
-    javaVersion = re.search(r'([0-9\._]+)', javaInfo.decode().splitlines()[0]).group(1).replace('"', '')
-    print(javaVersion)
+    javaVersions = [re.search(r'([0-9\._]+)', v).group(1).replace('"', '') for v in javaInfo.decode().splitlines()]
+    print(javaVersions)
+    for v in javaVersions:
+        if v.split(".")[0].isdigit():
+            print(v)

--- a/integrations/KiCad/kicad-freerouting/plugins/plugin.py
+++ b/integrations/KiCad/kicad-freerouting/plugins/plugin.py
@@ -255,11 +255,15 @@ def wx_show_error(text):
 def get_java_version():
     javaPath = 'java'
     try:
-	    javaInfo = subprocess.check_output(javaPath + ' -version', shell=True, stderr=subprocess.STDOUT)
-	    javaVersion = re.search(r'([0-9\._]+)', javaInfo.decode().splitlines()[0]).group(1).replace('"', '')
-	    return javaVersion
+        javaInfo = subprocess.check_output(javaPath + ' -version', shell=True, stderr=subprocess.STDOUT)
+        javaVersions = [re.search(r'([0-9\._]+)', v).group(1).replace('"', '') for v in javaInfo.decode().splitlines()]
+
+        for v in javaVersions:
+            if v.split(".")[0].isdigit():
+                return v
     except:
-        return "0.0.0.0"
+        pass
+    return "0.0.0.0"
 
 
 # prompt user to cancel pending action; allow to cancel programmatically


### PR DESCRIPTION
This fixes an issue with assuming that the first line of `java -version` contains the java version when it doesnt for openJDK when having a configuration option set.

Issue:
```
$ java -version
Picked up _JAVA_OPTIONS: -Djava.util.prefs.userRoot=/home/stefan/.config/java
openjdk version "17.0.6" 2023-01-17
OpenJDK Runtime Environment (build 17.0.6+10)
OpenJDK 64-Bit Server VM (build 17.0.6+10, mixed mode)
```