### PR TITLE
fix: make units and status bar readable on HiDPI monitor

### DIFF
--- a/src/main/java/app/freerouting/gui/BoardPanelStatus.java
+++ b/src/main/java/app/freerouting/gui/BoardPanelStatus.java
@@ -23,7 +23,6 @@ class BoardPanelStatus extends JPanel {
     ResourceBundle resources =
         ResourceBundle.getBundle("app.freerouting.gui.BoardPanelStatus", p_locale);
     this.setLayout(new BorderLayout());
-    this.setPreferredSize(new Dimension(300, 20));
 
     JPanel left_message_panel = new JPanel();
     left_message_panel.setLayout(new BorderLayout());

--- a/src/main/java/app/freerouting/gui/BoardToolbar.java
+++ b/src/main/java/app/freerouting/gui/BoardToolbar.java
@@ -190,15 +190,10 @@ class BoardToolbar extends JPanel {
 
     right_toolbar.setAutoscrolls(true);
     unit_label.setText(resources.getString("unit_button"));
-    unit_label.setMaximumSize(new Dimension(100, 30));
-    unit_label.setPreferredSize(new Dimension(65, 30));
     right_toolbar.add(unit_label);
 
     unit_factor_field.setHorizontalAlignment(JTextField.CENTER);
     unit_factor_field.setValue(1);
-    unit_factor_field.setMaximumSize(new Dimension(10, 30));
-    unit_factor_field.setMinimumSize(new Dimension(20, 30));
-    unit_factor_field.setPreferredSize(new Dimension(40, 30));
     unit_factor_field.addKeyListener(
         new KeyAdapter() {
           @Override
@@ -226,10 +221,7 @@ class BoardToolbar extends JPanel {
     unit_combo_box.setModel(new DefaultComboBoxModel<>(Unit.values()));
     unit_combo_box.setFocusTraversalPolicyProvider(true);
     unit_combo_box.setInheritsPopupMenu(true);
-    unit_combo_box.setMaximumSize(new Dimension(80, 30));
-    unit_combo_box.setMinimumSize(new Dimension(80, 30));
     unit_combo_box.setOpaque(false);
-    unit_combo_box.setPreferredSize(new Dimension(80, 30));
     unit_combo_box.addActionListener(
         evt -> {
           Unit new_unit =


### PR DESCRIPTION
Before:
![Screenshot from 2023-10-13 13-49-02](https://github.com/freerouting/freerouting/assets/61438920/548d5085-d68c-4528-8c64-f00c9a074f88)

After:
![Screenshot from 2023-10-13 13-53-19](https://github.com/freerouting/freerouting/assets/61438920/9b1f1d49-7dfd-49a9-9556-4b5a727ba620)

Layouts auto size components to reasonable defaults anyway, there is no need to specify constraints in this particular case.