### PR TITLE
fix: don't use deprecated Character constructor

### DIFF
--- a/src/main/java/app/freerouting/designforms/specctra/SpecctraDsnFileReader.java
+++ b/src/main/java/app/freerouting/designforms/specctra/SpecctraDsnFileReader.java
@@ -1696,7 +1696,7 @@ class SpecctraDsnFileReader implements IJFlexScanner {
       // let's ignore the leading spaces, tabs
       skipLeading = new ArrayList<>(Arrays.asList(stringSkipTrailing));
     }
-    skipLeading.add(new Character(leading));
+    skipLeading.add(Character.valueOf(leading));
 
     while ((zzMarkedPos + i < zzBuffer.length)
         && (skipLeading.contains(zzBuffer[zzMarkedPos + i]))) {
@@ -1711,7 +1711,7 @@ class SpecctraDsnFileReader implements IJFlexScanner {
       skipLastChar = true;
     } else {
       stopAt = new ArrayList<>(Arrays.asList(stringStopAt));
-      stopAt.add(new Character(leading));
+      stopAt.add(Character.valueOf(leading));
     }
 
     // read the actual string until we have a space/tab/new line


### PR DESCRIPTION
This change fixes the following compiler warnings:
```
/home/kikaitachi/Projects/freerouting/src/main/java/app/freerouting/designforms/specctra/SpecctraDsnFileReader.java:1699: warning: [removal] Character(char) in Character has been deprecated and marked for removal
    skipLeading.add(new Character(leading));
                    ^
/home/kikaitachi/Projects/freerouting/src/main/java/app/freerouting/designforms/specctra/SpecctraDsnFileReader.java:1714: warning: [removal] Character(char) in Character has been deprecated and marked for removal
      stopAt.add(new Character(leading));
                 ^
```

Following recommented fix from [Oracle documentation](https://docs.oracle.com/en/java/javase/17/docs/api/deprecated-list.html):
![Screenshot from 2023-10-13 14-10-39](https://github.com/freerouting/freerouting/assets/61438920/1365b713-7c54-4664-b9bd-d973aecd7165)
