### PR TITLE
fix: export for dto added, required when only API is run

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module app.freerouting {
   opens app.freerouting.api.dev to jakarta.ws.rs;
   opens app.freerouting.api.v1 to jakarta.ws.rs;
 
+  exports app.freerouting.api.dto to com.google.gson;
   exports app.freerouting.api.dev to org.glassfish.hk2.locator, jersey.server;
   exports app.freerouting.api.v1 to org.glassfish.hk2.locator, jersey.server;
   opens app.freerouting.core to com.google.gson;


### PR DESCRIPTION
### Description
When I wanted to run only the API, and then hitting the status `http://localhost:37864/api/v1/system/status` endpoint. I was receiving this export issue
`Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field public java.lang.String app.freerouting.api.dto.SystemStatus.status accessible: module app.freerouting does not "exports app.freerouting.api.dto" to module com.google.gson
`

This change fixes it

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary