### PR TITLE
Create a docker build and push workflow for ghcr (Github Container Registry)

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -1,0 +1,43 @@
+name: Docker Build and Push
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
### Description

This will automatically push the latest version of freerouting to ghcr.io with the latest tag

Here's an example of what it looks like when pushed: https://github.com/tscircuit/freerouting/pkgs/container/freerouting

It would be good to have version numbers on each docker package eventually as well, but maybe this is a good first/incremental step to just keep pushing up latest?

(If this is annoying to maintain, feel free to close!)

### Usage

You have to authenticate with ghcr.io to use these types of packages. [Here's the guide](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic)

Basically you login to ghcr.io then you can do this to get the image:

```bash
docker pull ghcr.io/tscircuit/freerouting:master
```
