### PR TITLE
Remove Unicode character PHI (U+03A6) in Kicad-plugin

### DIFF
--- a/integrations/KiCad/kicad-freerouting/plugins/plugin.py
+++ b/integrations/KiCad/kicad-freerouting/plugins/plugin.py
@@ -95,7 +95,7 @@ def get_local_java_executable_path(os_name):
 
 # Remove java offending characters
 def search_n_strip(s):
-    s = re.sub('[Ωµ]', '', s)
+    s = re.sub('[ΩµΦ]', '', s)
     return s
 
 


### PR DESCRIPTION
### Description

Using the Kicad plugin I was getting a following error when the PCB had a symbol containing character phi Φ (U+03A6).
```
UnicodeEncodeError: 'ascii' codec can't encode character '\u03a6' in position 0: ordinal not in range(128)
```

This is literally a one character change that fixed it for me. I'm not familiar with the codebase so I can't say if this is the correct way to fix it but it worked for me so I was hoping it could also fix it for others as well.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary