### PR TITLE
Correctly update max value in Clearance-Matrix

### DIFF
--- a/src/main/java/app/freerouting/rules/ClearanceMatrix.java
+++ b/src/main/java/app/freerouting/rules/ClearanceMatrix.java
@@ -142,11 +142,17 @@ public class ClearanceMatrix implements Serializable
     // assure, that the clearance value is positive and even, and round it up, if it is odd
     // NOTE: why does it need to be even?
     int value = Math.max(p_value, 0);
-    value += value % 2;
+    if (value % 2 != 0) {
+      if (value == Integer.MAX_VALUE) {
+        value--;
+      } else {
+        value++;
+      }
+    }
 
     curr_entry.layer[p_layer] = value;
-    curr_row.max_value[p_layer] = Math.max(curr_row.max_value[p_layer], p_value);
-    this.max_value_on_layer[p_layer] = Math.max(this.max_value_on_layer[p_layer], p_value);
+    curr_row.max_value[p_layer] = Math.max(curr_row.max_value[p_layer], value);
+    this.max_value_on_layer[p_layer] = Math.max(this.max_value_on_layer[p_layer], value);
   }
 
   /**

--- a/src/test/java/app/freerouting/rules/ClearanceMatrixTest.java
+++ b/src/test/java/app/freerouting/rules/ClearanceMatrixTest.java
@@ -1,0 +1,37 @@
+package app.freerouting.rules;
+
+import app.freerouting.board.Layer;
+import app.freerouting.board.LayerStructure;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ClearanceMatrixTest {
+
+  @Test
+  public void testSetValue() {
+    Layer[] layers = new Layer[]{new Layer("Top", true), new Layer("Bottom", true)};
+    LayerStructure layerStructure = new LayerStructure(layers);
+    String[] name_arr = new String[]{"default"};
+    ClearanceMatrix matrix = new ClearanceMatrix(1, layerStructure, name_arr);
+
+    // Test with an odd value
+    matrix.set_value(0, 0, 0, 5);
+    assertEquals(6, matrix.get_value(0, 0, 0, false));
+    assertEquals(6, matrix.max_value(0, 0));
+    assertEquals(6, matrix.max_value(0));
+
+    // Test with a negative value
+    matrix.set_value(0, 0, 0, -10);
+    assertEquals(0, matrix.get_value(0, 0, 0, false));
+    //The max_value should be 6, as it was set in the previous step and -10 is not greater than 6
+    assertEquals(6, matrix.max_value(0, 0));
+    assertEquals(6, matrix.max_value(0));
+
+    // Test with Integer.MAX_VALUE
+    matrix.set_value(0, 0, 0, Integer.MAX_VALUE);
+    assertEquals(Integer.MAX_VALUE - 1, matrix.get_value(0, 0, 0, false));
+    assertEquals(Integer.MAX_VALUE - 1, matrix.max_value(0, 0));
+    assertEquals(Integer.MAX_VALUE - 1, matrix.max_value(0));
+  }
+}


### PR DESCRIPTION
> **NOTE**: The code of this PR was generated with [Jules](https://jules.google.com), an AI Coding Agent, however the changes have been manually reviewed and tested by a human.

### Description
The `set_value` method in `ClearanceMatrix.java` was incorrectly updating the `max_value` and `max_value_on_layer` fields. It used the original `p_value` for the update, instead of the modified `value` that is actually stored in the matrix. This could lead to inconsistencies where the stored maximum values do not reflect the actual maximums in the clearance matrix.

This commit also fixes an integer overflow bug when the input `p_value` is `Integer.MAX_VALUE`. The previous implementation `value += value % 2;` caused an overflow in this case. The new implementation handles this edge case correctly.

A new test case is also added to verify the fix for both issues.

### Checklist
- [X] Code compiles correctly
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [ ] ~Extended the README / documentation, if necessary~