### PR TITLE
Escape numerical padstack names (fixes #411)

### DIFF
--- a/src/main/java/app/freerouting/datastructures/IdentifierType.java
+++ b/src/main/java/app/freerouting/datastructures/IdentifierType.java
@@ -64,12 +64,18 @@ public class IdentifierType
         }
       }
 
+      if (!need_quotes) {
+        try {
+          Double.parseDouble(p_name);
+          need_quotes = true;
+        } catch (NumberFormatException e) {
+          // Not a number, do nothing
+        }
+      }
       if (need_quotes)
       {
         p_name = quote(p_name);
       }
-
-      // always put quotes around the identifiers even if they don't have illegal characters
       p_file.write(p_name);
     } catch (IOException e)
     {

--- a/src/main/java/app/freerouting/datastructures/IdentifierType.java
+++ b/src/main/java/app/freerouting/datastructures/IdentifierType.java
@@ -65,11 +65,8 @@ public class IdentifierType
       }
 
       if (!need_quotes) {
-        try {
-          Double.parseDouble(p_name);
-          need_quotes = true;
-        } catch (NumberFormatException e) {
-          // Not a number, do nothing
+        if (p_name.matches("^-?\\d.*")) {
+            need_quotes = true;
         }
       }
       if (need_quotes)

--- a/src/test/java/app/freerouting/datastructures/IdentifierTypeTest.java
+++ b/src/test/java/app/freerouting/datastructures/IdentifierTypeTest.java
@@ -1,0 +1,44 @@
+package app.freerouting.datastructures;
+
+import org.junit.jupiter.api.Test;
+import java.io.StringWriter;
+import java.io.OutputStreamWriter;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IdentifierTypeTest {
+
+    @Test
+    void testWrite() throws java.io.IOException {
+        String[] reserved_chars = {"(", ")", " ", "-"};
+        String string_quote = "\"";
+        IdentifierType identifierType = new IdentifierType(reserved_chars, string_quote);
+
+        // Test with a numeric string
+        java.io.ByteArrayOutputStream baos_numeric = new java.io.ByteArrayOutputStream();
+        OutputStreamWriter osw_numeric = new OutputStreamWriter(baos_numeric);
+        identifierType.write("600", osw_numeric);
+        osw_numeric.flush();
+        assertEquals("\"600\"", baos_numeric.toString());
+
+        // Test with a negative numeric string
+        java.io.ByteArrayOutputStream baos_neg_numeric = new java.io.ByteArrayOutputStream();
+        OutputStreamWriter osw_neg_numeric = new OutputStreamWriter(baos_neg_numeric);
+        identifierType.write("-600", osw_neg_numeric);
+        osw_neg_numeric.flush();
+        assertEquals("\"-600\"", baos_neg_numeric.toString());
+
+        // Test with a normal string
+        java.io.ByteArrayOutputStream baos_normal = new java.io.ByteArrayOutputStream();
+        OutputStreamWriter osw_normal = new OutputStreamWriter(baos_normal);
+        identifierType.write("test", osw_normal);
+        osw_normal.flush();
+        assertEquals("test", baos_normal.toString());
+
+        // Test with a string with reserved characters
+        java.io.ByteArrayOutputStream baos_reserved = new java.io.ByteArrayOutputStream();
+        OutputStreamWriter osw_reserved = new OutputStreamWriter(baos_reserved);
+        identifierType.write("test-with-reserved", osw_reserved);
+        osw_reserved.flush();
+        assertEquals("\"test-with-reserved\"", baos_reserved.toString());
+    }
+}

--- a/src/test/java/app/freerouting/datastructures/IdentifierTypeTest.java
+++ b/src/test/java/app/freerouting/datastructures/IdentifierTypeTest.java
@@ -40,5 +40,12 @@ class IdentifierTypeTest {
         identifierType.write("test-with-reserved", osw_reserved);
         osw_reserved.flush();
         assertEquals("\"test-with-reserved\"", baos_reserved.toString());
+
+        // Test with a string that starts with a number
+        java.io.ByteArrayOutputStream baos_start_with_number = new java.io.ByteArrayOutputStream();
+        OutputStreamWriter osw_start_with_number = new OutputStreamWriter(baos_start_with_number);
+        identifierType.write("600a", osw_start_with_number);
+        osw_start_with_number.flush();
+        assertEquals("\"600a\"", baos_start_with_number.toString());
     }
 }


### PR DESCRIPTION
> **NOTE**: The code of this PR was generated with [Jules](https://jules.google.com), an AI Coding Agent, however the changes have been manually reviewed and tested by a human.

### Description
Fixes #411: Quote padstack names in session files when they start with a number or are parsed as numbers. The change is made in the IdentifierType class, which is responsible for writing identifiers to the session file.

This prevents issues with KiCad and other tools that expect padstack names to be strings.

### Checklist
- [X] Code compiles correctly
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [ ] ~Extended the README / documentation, if necessary~