### PR TITLE
feat: allow GET /jobs/{jobId}/output to return partial output for in-progress jobs

### DIFF
--- a/docs/api/API_v1.md
+++ b/docs/api/API_v1.md
@@ -261,9 +261,14 @@ For complete details on how to configure and enable authentication on your own s
   **Parameters:**
     - `jobId` *(required)*: The unique identifier of the job.
 
-  **Description:** Retrieves the output data for a completed routing job.
+  **Description:** Retrieves the output data for a routing job in Specctra SES format.
 
-  **Response body:** Contains some details and the [Base64-encoded](https://en.wikipedia.org/wiki/Base64) Specctra SES data.
+  - If the job is **completed**, returns the final output with HTTP **200 OK**.
+  - If the job is **running, paused, or stopping**, returns the partial output generated so far with HTTP **202 Accepted**. The output will be updated as routing progresses; use `GET /jobs/{jobId}/output/stream` for real-time SSE updates.
+  - If the job is in progress but **no output data is available yet**, returns HTTP **204 No Content**.
+  - If the job **failed, was cancelled, timed out, or is invalid**, returns HTTP **400 Bad Request** with an error message.
+
+  **Response body (200 or 202):** Contains some details and the [Base64-encoded](https://en.wikipedia.org/wiki/Base64) Specctra SES data.
 
   ```json
   {

--- a/src/main/java/app/freerouting/api/v1/JobControllerV1.java
+++ b/src/main/java/app/freerouting/api/v1/JobControllerV1.java
@@ -498,12 +498,20 @@ public class JobControllerV1 extends BaseController {
     }
   }
 
-  /* Download the output of the job, typically in Specctra SES format. */
-  @Operation(summary = "Download job output file", description = "Downloads the output file of a completed routing job, typically in Specctra SES format. The file is returned as Base64-encoded data.")
+  /* Download the output of the job, typically in Specctra SES format.
+   * If the job is still running or paused, returns the partial output generated so far.
+   * If no output is available yet, returns a 202 Accepted response.
+   */
+  @Operation(summary = "Download job output file", description = "Downloads the output file of a routing job in Specctra SES format. "
+      + "If the job is completed, returns the final output. "
+      + "If the job is still running or paused, returns the partial output generated so far (202 Accepted). "
+      + "The file is returned as Base64-encoded data.")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "Output downloaded successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = BoardFilePayload.class))),
+      @ApiResponse(responseCode = "200", description = "Output downloaded successfully (job completed)", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = BoardFilePayload.class))),
+      @ApiResponse(responseCode = "202", description = "Partial output returned (job still in progress)", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = BoardFilePayload.class))),
+      @ApiResponse(responseCode = "204", description = "Job is in progress but no output data is available yet"),
       @ApiResponse(responseCode = "404", description = "Job not found"),
-      @ApiResponse(responseCode = "400", description = "Job not completed or invalid session")
+      @ApiResponse(responseCode = "400", description = "Job failed, was cancelled, or session is invalid")
   })
   @GET
   @Path("/{jobId}/output")
@@ -537,11 +545,35 @@ public class JobControllerV1 extends BaseController {
           .build();
     }
 
-    // Check if the job is completed
-    if (job.state != RoutingJobState.COMPLETED) {
+    // Reject jobs that have failed, been cancelled, or are in an invalid terminal state
+    if (job.state == RoutingJobState.TERMINATED
+        || job.state == RoutingJobState.CANCELLED
+        || job.state == RoutingJobState.TIMED_OUT
+        || job.state == RoutingJobState.INVALID) {
       return Response
           .status(Response.Status.BAD_REQUEST)
-          .entity("{\"error\":\"The job hasn't finished yet.\"}")
+          .entity("{\"error\":\"The job is in state '" + job.state + "' and has no valid output.\"}")
+          .build();
+    }
+
+    // For in-progress jobs (RUNNING, PAUSED, STOPPING), return partial output if available
+    boolean isInProgress = job.state == RoutingJobState.RUNNING
+        || job.state == RoutingJobState.PAUSED
+        || job.state == RoutingJobState.STOPPING;
+
+    // Check if output data is available
+    if (job.output == null || job.output.getData() == null) {
+      if (isInProgress) {
+        // Job is running but hasn't written any output yet
+        return Response
+            .status(Response.Status.NO_CONTENT)
+            .entity("{\"error\":\"The job is in progress but no output data is available yet. Use GET /{jobId}/output/stream for real-time updates.\"}")
+            .build();
+      }
+      // QUEUED or READY_TO_START
+      return Response
+          .status(Response.Status.BAD_REQUEST)
+          .entity("{\"error\":\"The job hasn't started yet.\"}")
           .build();
     }
 
@@ -560,6 +592,13 @@ public class JobControllerV1 extends BaseController {
     var response = GSON.toJson(result);
     FRAnalytics.apiEndpointCalled("GET v1/jobs/" + jobId + "/output", "",
         response.replace(result.dataBase64, TextManager.shortenString(result.dataBase64, 4)));
+
+    // Return 202 Accepted for in-progress jobs, 200 OK for completed jobs
+    if (isInProgress) {
+      return Response
+          .accepted(response)
+          .build();
+    }
     return Response
         .ok(response)
         .build();

--- a/src/main/java/app/freerouting/api/v1/JobControllerV1.java
+++ b/src/main/java/app/freerouting/api/v1/JobControllerV1.java
@@ -500,7 +500,7 @@ public class JobControllerV1 extends BaseController {
 
   /* Download the output of the job, typically in Specctra SES format.
    * If the job is still running or paused, returns the partial output generated so far.
-   * If no output is available yet, returns a 202 Accepted response.
+   * If no output is available yet, returns a 204 No Content response.
    */
   @Operation(summary = "Download job output file", description = "Downloads the output file of a routing job in Specctra SES format. "
       + "If the job is completed, returns the final output. "
@@ -541,7 +541,7 @@ public class JobControllerV1 extends BaseController {
     if (session == null) {
       return Response
           .status(Response.Status.BAD_REQUEST)
-          .entity("{\"error\":\"The session ID '" + job.sessionId + "' is invalid.\"}")
+          .entity(GSON.toJson(java.util.Map.of("error", "The session ID '" + job.sessionId + "' is invalid.")))
           .build();
     }
 
@@ -552,7 +552,7 @@ public class JobControllerV1 extends BaseController {
         || job.state == RoutingJobState.INVALID) {
       return Response
           .status(Response.Status.BAD_REQUEST)
-          .entity("{\"error\":\"The job is in state '" + job.state + "' and has no valid output.\"}")
+          .entity(GSON.toJson(java.util.Map.of("error", "The job is in state '" + job.state + "' and has no valid output.")))
           .build();
     }
 
@@ -564,16 +564,15 @@ public class JobControllerV1 extends BaseController {
     // Check if output data is available
     if (job.output == null || job.output.getData() == null) {
       if (isInProgress) {
-        // Job is running but hasn't written any output yet
+        // Job is running but hasn't written any output yet — return 204 No Content (no body per RFC 7231)
         return Response
             .status(Response.Status.NO_CONTENT)
-            .entity("{\"error\":\"The job is in progress but no output data is available yet. Use GET /{jobId}/output/stream for real-time updates.\"}")
             .build();
       }
       // QUEUED or READY_TO_START
       return Response
           .status(Response.Status.BAD_REQUEST)
-          .entity("{\"error\":\"The job hasn't started yet.\"}")
+          .entity(GSON.toJson(java.util.Map.of("error", "The job hasn't started yet.")))
           .build();
     }
 


### PR DESCRIPTION
## Summary

- Fixes #388 by removing the COMPLETED-only restriction from the `GET /jobs/{jobId}/output` endpoint
- When a job is **RUNNING**, **PAUSED**, or **STOPPING** and output data is already available (partial routes written so far), the endpoint now returns that data with **202 Accepted**
- When a job is in-progress but no output has been written yet, returns **204 No Content**
- Failed/cancelled/timed-out/invalid jobs return **400 Bad Request** with a descriptive error message
- **COMPLETED** jobs are unchanged — still return **200 OK**
- Updated `docs/api/API_v1.md` to document all new status codes and behavior

## Why this approach

The existing `/output/stream` SSE endpoint already reads `job.output.getData()` while the job is RUNNING, so partial output data *is* available — the non-streaming endpoint just wasn't exposing it. This change brings the polling endpoint in line with the streaming endpoint's behavior.

This allows callers like tscircuit.com to poll `/output` while routing progresses and render intermediate traces without requiring SSE.

## Test plan

- [ ] Verify COMPLETED job → 200 OK with full SES output (existing behavior preserved)
- [ ] Verify RUNNING job with partial output → 202 Accepted with partial SES data
- [ ] Verify RUNNING job with no output yet → 204 No Content
- [ ] Verify CANCELLED job → 400 Bad Request
- [ ] Verify non-existent job → 404 Not Found

/claim #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)