### PR TITLE
Honor CLI max-pass limit

### DIFF
--- a/src/main/java/app/freerouting/Freerouting.java
+++ b/src/main/java/app/freerouting/Freerouting.java
@@ -341,8 +341,7 @@ public class Freerouting
 
     routingJob.tryToSetOutputFile(new File(globalSettings.design_output_filename));
 
-    routingJob.routerSettings = Freerouting.globalSettings.routerSettings.clone();
-    routingJob.routerSettings.setLayerCount(routingJob.input.statistics.layers.totalCount);
+  applyCliRouterSettings(routingJob, globalSettings);
     routingJob.state = RoutingJobState.READY_TO_START;
 
     // Wait for the RoutingJobScheduler to do its work
@@ -375,6 +374,15 @@ public class Freerouting
         FRLogger.error("Couldn't save the output file '" + globalSettings.design_output_filename + "'", e);
       }
     }
+  }
+
+  static void applyCliRouterSettings(RoutingJob routingJob, GlobalSettings globalSettings)
+  {
+    routingJob.routerSettings = Freerouting.globalSettings.routerSettings.clone();
+    routingJob.routerSettings.setLayerCount(routingJob.input.statistics.layers.totalCount);
+    routingJob.routerSettings.set_stop_pass_no(
+        routingJob.routerSettings.get_start_pass_no() + globalSettings.routerSettings.maxPasses - 1
+    );
   }
 
   private static void ShutdownApplication()

--- a/src/test/java/app/freerouting/FreeroutingCliTest.java
+++ b/src/test/java/app/freerouting/FreeroutingCliTest.java
@@ -1,0 +1,49 @@
+package app.freerouting;
+
+import app.freerouting.core.RoutingJob;
+import app.freerouting.settings.GlobalSettings;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FreeroutingCliTest
+{
+  @BeforeEach
+  void setUp()
+  {
+    Freerouting.globalSettings = new GlobalSettings();
+  }
+
+  @Test
+  void applyCliRouterSettingsUsesConfiguredMaxPasses() throws IOException
+  {
+    RoutingJob routingJob = new RoutingJob();
+    routingJob.setInput(findTestFile("Issue313-FastTest.dsn"));
+    Freerouting.globalSettings.routerSettings.maxPasses = 4;
+
+    Freerouting.applyCliRouterSettings(routingJob, Freerouting.globalSettings);
+
+    assertEquals(1, routingJob.routerSettings.get_start_pass_no());
+    assertEquals(4, routingJob.routerSettings.get_stop_pass_no());
+  }
+
+  private File findTestFile(String filename)
+  {
+    Path directory = Path.of(".").toAbsolutePath();
+    while (directory != null)
+    {
+      File candidate = directory.resolve("tests").resolve(filename).toFile();
+      if (candidate.exists())
+      {
+        return candidate;
+      }
+      directory = directory.getParent();
+    }
+    throw new IllegalArgumentException("Test fixture not found: " + filename);
+  }
+}


### PR DESCRIPTION
Hi!

This fixes a CLI-only bug where the configured -mp value was not propagated into the routing job’s effective stop-pass window.

Before this change, CLI runs could continue far beyond the requested max pass count because maxPasses was recorded in settings but never converted into stop_pass_no before the job started.

This patch adds a small CLI-specific helper to apply that translation at start. I added a regression test to lock the behavior down. On the original reproducer, the patched build now stops at pass 32 as expected instead of continuing into the hundreds.

Thanks!
Flavien