### PR TITLE
Fix NPE in combine_traces and AIOOBE in BatchAutorouter for >2-layer boards

### DIFF
--- a/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
+++ b/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
@@ -107,11 +107,35 @@ public class BatchAutorouter extends NamedAlgorithm {
     this.random = new Random(0);
 
     this.remove_unconnected_vias = p_remove_unconnected_vias;
+    final int boardLayerCount = this.board.get_layer_count();
     if (p_with_preferred_directions) {
-      this.trace_cost_arr = this.settings.get_trace_cost_arr();
+      AutorouteControl.ExpansionCostFactor[] settingsCosts = this.settings.get_trace_cost_arr();
+      // Defensively size to the board's layer count. settings.get_trace_cost_arr()
+      // returns an array sized from scoring.preferredDirectionTraceCost.length,
+      // which can disagree with the board's actual layer count when the merged
+      // RouterSettings retained a default-source array length (e.g. 2) and
+      // applyBoardSpecificOptimizations did not run or did not run with the
+      // current board. Indexing trace_cost_arr by layer (e.g. in
+      // DestinationDistance) then throws ArrayIndexOutOfBoundsException at
+      // every inner-layer routing attempt and the autorouter silently skips
+      // those nets.
+      if (settingsCosts == null || settingsCosts.length < boardLayerCount) {
+        this.trace_cost_arr = new AutorouteControl.ExpansionCostFactor[boardLayerCount];
+        if (settingsCosts != null) {
+          System.arraycopy(settingsCosts, 0, this.trace_cost_arr, 0, settingsCosts.length);
+        }
+        // Fill any tail entries with a neutral cost so the array is fully
+        // populated. Using 1.0/1.0 matches the default trace cost from
+        // RouterSettings and avoids zero-cost short circuits.
+        for (int i = (settingsCosts == null ? 0 : settingsCosts.length); i < boardLayerCount; i++) {
+          this.trace_cost_arr[i] = new AutorouteControl.ExpansionCostFactor(1.0, 1.0);
+        }
+      } else {
+        this.trace_cost_arr = settingsCosts;
+      }
     } else {
       // remove preferred direction
-      this.trace_cost_arr = new AutorouteControl.ExpansionCostFactor[this.board.get_layer_count()];
+      this.trace_cost_arr = new AutorouteControl.ExpansionCostFactor[boardLayerCount];
       for (int i = 0; i < this.trace_cost_arr.length; i++) {
         double curr_min_cost = this.settings.get_preferred_direction_trace_costs(i);
         this.trace_cost_arr[i] = new AutorouteControl.ExpansionCostFactor(curr_min_cost, curr_min_cost);

--- a/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
+++ b/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
@@ -120,14 +120,14 @@ public class BatchAutorouter extends NamedAlgorithm {
       // every inner-layer routing attempt and the autorouter silently skips
       // those nets.
       if (settingsCosts == null || settingsCosts.length < boardLayerCount) {
-        this.trace_cost_arr = new AutorouteControl.ExpansionCostFactor[boardLayerCount];
-        if (settingsCosts != null) {
-          System.arraycopy(settingsCosts, 0, this.trace_cost_arr, 0, settingsCosts.length);
-        }
+        final int originalLength = (settingsCosts == null) ? 0 : settingsCosts.length;
+        this.trace_cost_arr = java.util.Arrays.copyOf(settingsCosts == null
+            ? new AutorouteControl.ExpansionCostFactor[0]
+            : settingsCosts, boardLayerCount);
         // Fill any tail entries with a neutral cost so the array is fully
         // populated. Using 1.0/1.0 matches the default trace cost from
         // RouterSettings and avoids zero-cost short circuits.
-        for (int i = (settingsCosts == null ? 0 : settingsCosts.length); i < boardLayerCount; i++) {
+        for (int i = originalLength; i < boardLayerCount; i++) {
           this.trace_cost_arr[i] = new AutorouteControl.ExpansionCostFactor(1.0, 1.0);
         }
       } else {

--- a/src/main/java/app/freerouting/board/PolylineTrace.java
+++ b/src/main/java/app/freerouting/board/PolylineTrace.java
@@ -292,9 +292,12 @@ public class PolylineTrace extends Trace implements Serializable {
         other_trace.clear_search_tree_entries();
         this.lines = joined_polyline;
       } else {
-        // Fall back to the generic remove + reinsert path. The optimized merge
-        // requires that both traces have entries in every compensated search
-        // tree; if any tree is missing entries we cannot reuse them.
+        // Fall back to the generic remove + reinsert path. The optimized
+        // merge requires that both traces have entries in every compensated
+        // search tree; if any tree is missing entries we cannot reuse them.
+        // remove(this) must precede the lines assignment so it acts on the
+        // pre-merge geometry; the assignment is therefore not deduplicated
+        // with the merged-branch assignment above.
         board.search_tree_manager.remove(this);
         this.lines = joined_polyline;
         this.clear_derived_data();

--- a/src/main/java/app/freerouting/board/PolylineTrace.java
+++ b/src/main/java/app/freerouting/board/PolylineTrace.java
@@ -286,10 +286,20 @@ public class PolylineTrace extends Trace implements Serializable {
       if (skip_line) {
         --to_no;
       }
-      board.search_tree_manager.merge_entries_in_front(other_trace, this, joined_polyline, other_lines.length - 3,
-          to_no);
-      other_trace.clear_search_tree_entries();
-      this.lines = joined_polyline;
+      boolean merged = board.search_tree_manager.merge_entries_in_front(other_trace, this, joined_polyline,
+          other_lines.length - 3, to_no);
+      if (merged) {
+        other_trace.clear_search_tree_entries();
+        this.lines = joined_polyline;
+      } else {
+        // Fall back to the generic remove + reinsert path. The optimized merge
+        // requires that both traces have entries in every compensated search
+        // tree; if any tree is missing entries we cannot reuse them.
+        board.search_tree_manager.remove(this);
+        this.lines = joined_polyline;
+        this.clear_derived_data();
+        board.search_tree_manager.insert(this);
+      }
     }
     if (this.lines.arr.length < 3) {
       board.remove_item(this);
@@ -392,9 +402,20 @@ public class PolylineTrace extends Trace implements Serializable {
       if (skip_line) {
         --to_no;
       }
-      board.search_tree_manager.merge_entries_at_end(other_trace, this, joined_polyline, this_lines.length - 3, to_no);
-      other_trace.clear_search_tree_entries();
-      this.lines = joined_polyline;
+      boolean merged = board.search_tree_manager.merge_entries_at_end(other_trace, this, joined_polyline,
+          this_lines.length - 3, to_no);
+      if (merged) {
+        other_trace.clear_search_tree_entries();
+        this.lines = joined_polyline;
+      } else {
+        // Fall back to the generic remove + reinsert path. The optimized merge
+        // requires that both traces have entries in every compensated search
+        // tree; if any tree is missing entries we cannot reuse them.
+        board.search_tree_manager.remove(this);
+        this.lines = joined_polyline;
+        this.clear_derived_data();
+        board.search_tree_manager.insert(this);
+      }
     }
     if (this.lines.arr.length < 3) {
       board.remove_item(this);

--- a/src/main/java/app/freerouting/board/SearchTreeManager.java
+++ b/src/main/java/app/freerouting/board/SearchTreeManager.java
@@ -238,23 +238,52 @@ public class SearchTreeManager {
   /**
    * Merges the tree entries from p_from_trace in front of p_to_trace. Special
    * implementation for combine trace for performance reasons.
+   *
+   * <p>Returns {@code true} on success. Returns {@code false} (without mutating
+   * any tree) if either trace is missing search-tree entries in any of the
+   * compensated search trees, indicating that the caller must fall back to the
+   * generic remove + reinsert path. This can occur when an autoroute pass adds
+   * a per-clearance-class compensated tree mid-flight while a trace is in a
+   * transient state, or when items have been added through a code path that
+   * skipped one of the trees. Crashing with a NullPointerException in
+   * {@link ShapeSearchTree#merge_entries_in_front} is undesirable and not
+   * recoverable for the autorouter, so we surface the condition to the caller.
    */
-  void merge_entries_in_front(PolylineTrace p_from_trace, PolylineTrace p_to_trace, Polyline p_joined_polyline,
+  boolean merge_entries_in_front(PolylineTrace p_from_trace, PolylineTrace p_to_trace, Polyline p_joined_polyline,
       int p_from_entry_no, int p_to_entry_no) {
+    for (ShapeSearchTree curr_tree : compensated_search_trees) {
+      if (p_from_trace.get_search_tree_entries(curr_tree) == null
+          || p_to_trace.get_search_tree_entries(curr_tree) == null) {
+        return false;
+      }
+    }
     for (ShapeSearchTree curr_tree : compensated_search_trees) {
       curr_tree.merge_entries_in_front(p_from_trace, p_to_trace, p_joined_polyline, p_from_entry_no, p_to_entry_no);
     }
+    return true;
   }
 
   /**
    * Merges the tree entries from p_from_trace to the end of p_to_trace. Special
    * implementation for combine trace for performance reasons.
+   *
+   * <p>Returns {@code true} on success. Returns {@code false} (without mutating
+   * any tree) if either trace is missing search-tree entries in any of the
+   * compensated search trees; see {@link #merge_entries_in_front} for the
+   * rationale.
    */
-  void merge_entries_at_end(PolylineTrace p_from_trace, PolylineTrace p_to_trace, Polyline p_joined_polyline,
+  boolean merge_entries_at_end(PolylineTrace p_from_trace, PolylineTrace p_to_trace, Polyline p_joined_polyline,
       int p_from_entry_no, int p_to_entry_no) {
+    for (ShapeSearchTree curr_tree : compensated_search_trees) {
+      if (p_from_trace.get_search_tree_entries(curr_tree) == null
+          || p_to_trace.get_search_tree_entries(curr_tree) == null) {
+        return false;
+      }
+    }
     for (ShapeSearchTree curr_tree : compensated_search_trees) {
       curr_tree.merge_entries_at_end(p_from_trace, p_to_trace, p_joined_polyline, p_from_entry_no, p_to_entry_no);
     }
+    return true;
   }
 
   /**


### PR DESCRIPTION
Two crash fixes in the autoroute path that surface together when running freerouting on a complex multilayer board (6 copper layers, with existing partial routing and zone fills) generated by KiCad. Without these patches the autorouter aborts pass #1 with a NullPointerException; with the first patch alone it loops on per-net `ArrayIndexOutOfBoundsException` and skips every net that needs an inner layer.

Verified on a real 6-layer KiCad PCB (90 unrouted nets to start):

| Metric | Stock 2.2.2 | + commit 1 (NPE) | + commit 2 (AIOOBE) |
|---|---|---|---|
| `NullPointerException` (combine_traces) | crash on pass #1 | 0 | 0 |
| `ArrayIndexOutOfBoundsException` (MazeSearchAlgo) | n/a (didn't reach) | 1 352 | **0** |
| Nets routed (out of 90) | 4 | 32 | **71** |

`./gradlew compileJava` and `./gradlew executableJar` succeed cleanly.

## Commit 1 — `Fix NPE in combine_traces when trace search-tree entries are null`

Stack trace observed:

```
java.lang.NullPointerException: Cannot load from object array because "to_trace_entries" is null
    at app.freerouting.board.ShapeSearchTree.merge_entries_at_end(ShapeSearchTree.java:237)
    at app.freerouting.board.SearchTreeManager.merge_entries_at_end(SearchTreeManager.java:256)
    at app.freerouting.board.PolylineTrace.combine_at_end(PolylineTrace.java:395)
    at app.freerouting.board.PolylineTrace.combine(PolylineTrace.java:178)
    at app.freerouting.board.BasicBoard.combine_traces(BasicBoard.java:797)
    at app.freerouting.board.RoutingBoard.remove_trace_tails(RoutingBoard.java:1138)
    at app.freerouting.autoroute.BatchAutorouter.remove_tails(BatchAutorouter.java:947)
    at app.freerouting.autoroute.BatchAutorouter.autoroute_pass(BatchAutorouter.java:559)
```

`p_to_trace.get_search_tree_entries(this)` returned null because the trace was inserted into one search tree (`default_tree`) but not into one of the per-clearance-class `compensated_search_trees` at the moment `combine_traces` tried to merge two traces. That transient state can occur during the autoroute pass without being a logical error, but the optimised in-place merge currently crashes.

Change: `SearchTreeManager.merge_entries_in_front`/`merge_entries_at_end` now return `boolean` instead of `void` and skip the in-place merge (without mutating any tree) when either trace lacks entries in any compensated tree. `PolylineTrace.combine` checks the return value and falls back to the generic remove + reinsert path, which handles the missing-entries case correctly.

## Commit 2 — `Fix ArrayIndexOutOfBoundsException in BatchAutorouter for >2-layer boards`

Stack trace observed (with commit 1 applied so the autorouter no longer crashes on pass 1):

```
ERROR  AutorouteEngine.autoroute_connection: Exception in MazeSearchAlgo.get_instance
java.lang.ArrayIndexOutOfBoundsException: Index 5 out of bounds for length 2
```

…repeated ~1 350 times during a single autoroute session — once per (net × inner-layer) attempt. Every net that needs to route through an inner layer is silently skipped.

Companion warnings (post-routing):

```
WARN  AutorouteSettings.get_layer_active: p_layer=2 out of range [0..1]
WARN  AutorouteSettings.get_preferred_direction_is_horizontal: p_layer=N out of range [0..1]
```

Root cause: `BatchAutorouter` sizes its `trace_cost_arr` from `this.settings.get_trace_cost_arr()`, which returns an array sized from `scoring.preferredDirectionTraceCost.length` on the merged `RouterSettings`. That length can disagree with the board's actual layer count when:

- The merged settings retain the `DefaultSettings` 2-element default arrays because no higher-priority source replaced them (e.g. a DSN with no `(autoroute_settings ...)` block, which is what KiCad's DSN export produces — see related #657 for the parser path);
- `applyBoardSpecificOptimizations` did not run, or did not run with the current board, before `BatchAutorouter` constructed its `trace_cost_arr`.

Subsequent indexing into `trace_cost_arr` by layer in `DestinationDistance.layer_distance` / `boundingbox_distance` then throws `AIOOBE` for every layer ≥ 2.

Change: defensively expand `trace_cost_arr` to the board's layer count in `BatchAutorouter`'s constructor, padding any tail entries with neutral 1.0/1.0 `ExpansionCostFactor`s. This guarantees inner-layer indexing into `trace_cost_arr` is always safe regardless of the shape the merged `RouterSettings` ended up in.

## Relationship to #657

This PR is **complementary to #657** by @thandal, which fixes the DSN-parser path (`Structure.read_scope` silently skipped `(autoroute_settings ...)` when `layer_structure` was already constructed) and the `ReflectionUtil.copyFields` array-length check that contributes to the same under-sized arrays.

Both PRs are needed for full multi-layer support:

- #657 fixes the path where the DSN _has_ `(autoroute_settings ...)` but it's parsed wrong.
- This PR fixes the paths where the merged `RouterSettings` reaches the under-sized state through any other means — including DSNs that have no `(autoroute_settings ...)` block at all (as is the case for KiCad-exported DSNs), and the residual NPE in `combine_traces` which #657 doesn't touch.

In testing on a 6-layer KiCad board, #657 alone prevented the NPE crash but the AIOOBE flood remained; this PR plus #657 results in the >2× improvement in routed-net count above.

## What this PR does _not_ do

The autorouter still stops short of fully routing the test board (19 of 90 nets remain unrouted). Inspection of the stopping condition shows freerouter terminating on the hardcoded `STAGNATION_SCORE_THRESHOLD = 0.5f` after pass #18 (no improvement since pass #8). That stagnation behaviour is independent of the bugs fixed here — these fixes only address the crashes that previously _prevented_ the router from making meaningful progress on multilayer boards. Tuning the stagnation threshold or adding a CLI override is out of scope for this PR.

There is also a separate `NullPointerException` from `MazeSearchAlgo.describe_room` (`CompleteExpansionRoom.get_shape()` returning null) that surfaces ~130 times in the post-fix run. It was previously masked by the AIOOBE flood; it's caught at the `autoroute_connection` boundary and the affected nets are skipped without aborting the pass. Worth a follow-up but out of scope here.

## Testing

- `./gradlew compileJava` — clean
- `./gradlew executableJar` — clean
- Manual end-to-end repro on the aircam-pdb-v2 6-layer DSN, before/after numbers as table above.