### PR TITLE
Fix for 2 layer only routing bug

### DIFF
--- a/src/main/java/app/freerouting/settings/RouterSettings.java
+++ b/src/main/java/app/freerouting/settings/RouterSettings.java
@@ -221,7 +221,7 @@ public class RouterSettings implements Serializable, Cloneable {
 
   /**
    * Get the number of layers configured in the router settings.
-   * 
+   *
    * @return The layer count
    */
   public int getLayerCount() {
@@ -267,14 +267,18 @@ public class RouterSettings implements Serializable, Cloneable {
   @Override
   public RouterSettings clone() {
     RouterSettings result = new RouterSettings();
-    result.setLayerCount(this.getLayerCount());
+    int layerCount = this.getLayerCount();
+    if (layerCount > 0) {
+      result.setLayerCount(layerCount);
+    }
     result.algorithm = this.algorithm;
     result.jobTimeoutString = this.jobTimeoutString;
-    result.isLayerActive = this.isLayerActive.clone();
-    result.isPreferredDirectionHorizontalOnLayer = this.isPreferredDirectionHorizontalOnLayer.clone();
+    result.isLayerActive = (this.isLayerActive != null) ? this.isLayerActive.clone() : null;
+    result.isPreferredDirectionHorizontalOnLayer = (this.isPreferredDirectionHorizontalOnLayer != null)
+        ? this.isPreferredDirectionHorizontalOnLayer.clone() : null;
     result.maxPasses = this.maxPasses;
     result.maxItems = this.maxItems;
-    result.ignoreNetClasses = this.ignoreNetClasses.clone();
+    result.ignoreNetClasses = (this.ignoreNetClasses != null) ? this.ignoreNetClasses.clone() : null;
     result.trace_pull_tight_accuracy = this.trace_pull_tight_accuracy;
     result.enabled = this.enabled;
     result.vias_allowed = this.vias_allowed;
@@ -436,6 +440,9 @@ public class RouterSettings implements Serializable, Cloneable {
   }
 
   public AutorouteControl.ExpansionCostFactor[] get_trace_cost_arr() {
+    if (scoring.preferredDirectionTraceCost == null) {
+      return new AutorouteControl.ExpansionCostFactor[0];
+    }
     AutorouteControl.ExpansionCostFactor[] result = new AutorouteControl.ExpansionCostFactor[scoring.preferredDirectionTraceCost.length];
     for (int i = 0; i < result.length; i++) {
       result[i] = new AutorouteControl.ExpansionCostFactor(get_horizontal_trace_costs(i), get_vertical_trace_costs(i));

--- a/src/main/java/app/freerouting/settings/sources/DefaultSettings.java
+++ b/src/main/java/app/freerouting/settings/sources/DefaultSettings.java
@@ -4,7 +4,6 @@ import app.freerouting.autoroute.BoardUpdateStrategy;
 import app.freerouting.autoroute.ItemSelectionStrategy;
 import app.freerouting.settings.RouterSettings;
 import app.freerouting.settings.SettingsSource;
-import java.util.Arrays;
 
 /**
  * Provides hardcoded default values for all router settings.
@@ -16,10 +15,13 @@ public class DefaultSettings implements SettingsSource {
 
     @Override
     public RouterSettings getSettings() {
-        int defaultLayerCount = 2;
-
-        // Create a RouterSettings object with all default values
-        // These are the same defaults currently used in RouterSettings constructor
+        // Create a RouterSettings object with all default values.
+        // Layer-count-dependent arrays (isLayerActive, isPreferredDirectionHorizontalOnLayer,
+        // preferredDirectionTraceCost, undesiredDirectionTraceCost) are intentionally left null
+        // here. Their actual sizes must come from the board file (via DsnFileSettings) and are
+        // finalised by RouterSettings.applyBoardSpecificOptimizations() once the board is loaded.
+        // Hardcoding a size-2 default causes incorrect behaviour for any board that is not a
+        // 2-layer design.
         RouterSettings settings = new RouterSettings();
 
         settings.enabled = true;
@@ -34,12 +36,9 @@ public class DefaultSettings implements SettingsSource {
         settings.ignoreNetClasses = new String[0];
         settings.maxThreads = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
 
-        settings.isLayerActive = new boolean[defaultLayerCount];
-        settings.isPreferredDirectionHorizontalOnLayer = new boolean[defaultLayerCount];
-        for (int i = 0; i < defaultLayerCount; i++) {
-            settings.isLayerActive[i] = true;
-            settings.isPreferredDirectionHorizontalOnLayer[i] = i % 2 == 1;
-        }
+        // isLayerActive and isPreferredDirectionHorizontalOnLayer are left null intentionally –
+        // they will be populated by DsnFileSettings (from the DSN layer count) and then
+        // overwritten with board-geometry-aware values by applyBoardSpecificOptimizations().
 
         // Optimizer defaults
         settings.optimizer.enabled = false;
@@ -51,13 +50,10 @@ public class DefaultSettings implements SettingsSource {
         settings.optimizer.hybridRatio = "1:1";
         settings.optimizer.itemSelectionStrategy = ItemSelectionStrategy.PRIORITIZED;
 
-        // Scoring defaults
+        // Scalar trace-cost defaults (layer-specific arrays are omitted for the same reason as
+        // the layer arrays above – their sizes depend on the board).
         settings.scoring.defaultPreferredDirectionTraceCost = 1.0;
         settings.scoring.defaultUndesiredDirectionTraceCost = 1.0;
-        settings.scoring.preferredDirectionTraceCost = new double[defaultLayerCount];
-        Arrays.fill(settings.scoring.preferredDirectionTraceCost, settings.scoring.defaultPreferredDirectionTraceCost);
-        settings.scoring.undesiredDirectionTraceCost = new double[defaultLayerCount];
-        Arrays.fill(settings.scoring.undesiredDirectionTraceCost, settings.scoring.defaultUndesiredDirectionTraceCost);
 
         settings.scoring.via_costs = 50;
         settings.scoring.plane_via_costs = 5;

--- a/src/main/java/app/freerouting/settings/sources/DsnFileSettings.java
+++ b/src/main/java/app/freerouting/settings/sources/DsnFileSettings.java
@@ -43,7 +43,7 @@ public class DsnFileSettings implements SettingsSource {
         // Always seed the layer arrays from the actual DSN layer count so that any board
         // with more or fewer than 2 layers gets correctly-sized arrays in the merged result –
         // well before applyBoardSpecificOptimizations() is called.
-        if (layerCount > 0) {
+        if (layerCount > 0 && rs.getLayerCount() == 0) {
             rs.setLayerCount(layerCount);
         }
 

--- a/src/main/java/app/freerouting/settings/sources/DsnFileSettings.java
+++ b/src/main/java/app/freerouting/settings/sources/DsnFileSettings.java
@@ -28,11 +28,28 @@ public class DsnFileSettings implements SettingsSource {
     public DsnFileSettings(InputStream inputStream, String filename) {
         this.filename = filename;
         DsnReadResult result = DsnReader.readMetadata(inputStream);
-        this.settings = (result instanceof DsnReadResult.Success s && s.metadata() != null
-            && s.metadata().routerSettings() != null)
-            ? s.metadata().routerSettings()
-            : new RouterSettings();
-        FRLogger.debug("Loaded router settings from DSN file: " + filename);
+
+        RouterSettings extracted = null;
+        int layerCount = 0;
+
+        if (result instanceof DsnReadResult.Success s && s.metadata() != null) {
+            extracted = s.metadata().routerSettings(); // null when no (autoroute_settings …) block
+            layerCount = s.metadata().layerCount();
+        }
+
+        // Start with whatever the DSN's autoroute block provided (or a blank slate).
+        RouterSettings rs = (extracted != null) ? extracted : new RouterSettings();
+
+        // Always seed the layer arrays from the actual DSN layer count so that any board
+        // with more or fewer than 2 layers gets correctly-sized arrays in the merged result –
+        // well before applyBoardSpecificOptimizations() is called.
+        if (layerCount > 0) {
+            rs.setLayerCount(layerCount);
+        }
+
+        this.settings = rs;
+        FRLogger.debug("Loaded router settings from DSN file: " + filename
+            + " (" + layerCount + " layers)");
     }
 
     @Override

--- a/src/test/java/app/freerouting/fixtures/BbdMars64PerformanceRoutingTest.java
+++ b/src/test/java/app/freerouting/fixtures/BbdMars64PerformanceRoutingTest.java
@@ -1,6 +1,5 @@
 package app.freerouting.fixtures;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import app.freerouting.logger.FRLogger;
@@ -87,19 +86,11 @@ public class BbdMars64PerformanceRoutingTest extends RoutingFixtureTest {
               + ".");
     }
 
-    assertTrue(Duration
-        .between(job.startedAt, job.finishedAt)
-        .compareTo(Duration.ofMinutes(20)) < 0,
-        "Routing of the reference board 'BBD_Mars-64.dsn' should complete within 5 minutes.");
-
-    // Check if we could finish within 40 passes
-    assertTrue(job.getCurrentPass() >= 1, "The routing job should have at least 1 pass.");
-    assertTrue(job.getCurrentPass() <= 99, "The routing job should stop after at most 99 passes.");
-
-    // Check if we have at most 6 unrouted connections
-    assertTrue(job.board.get_statistics().connections.incompleteCount <= 7,
-            "Routing of the reference board 'BBD_Mars-64.dsn' should leave at most 7 unrouted connections.");
-
+    assertRoutingResult(job, "Issue555-BBD_Mars-64.dsn")
+        .maxDuration(Duration.ofMinutes(20))
+        .passCount(1, 99)
+        .maxIncompleteConnections(7)
+        .check();
   }
 
   @Test
@@ -132,16 +123,10 @@ public class BbdMars64PerformanceRoutingTest extends RoutingFixtureTest {
               + ".");
     }
 
-    // Check if we could finish within 1 minute
-    assertTrue(job.getDuration().compareTo(Duration.ofMinutes(1)) < 0,
-        "Routing of the reference board 'Issue555-CNH_Functional_Tester_1.dsn' should complete within 1 minute.");
-
-    // Check if we could finish within 40 passes
-    assertTrue(job.getCurrentPass() >= 1, "The routing job should have at least 1 pass.");
-    assertTrue(job.getCurrentPass() <= 40, "The routing job should stop after at most 40 passes.");
-
-    // Check if we have at most 6 unrouted connections
-    assertTrue(job.board.get_statistics().connections.incompleteCount <= 6,
-        "Routing of the reference board 'Issue555-CNH_Functional_Tester_1.dsn' should leave at most 6 unrouted connections.");
+    assertRoutingResult(job, "Issue555-CNH_Functional_Tester_1.dsn")
+        .maxDuration(Duration.ofMinutes(1))
+        .passCount(1, 40)
+        .maxIncompleteConnections(6)
+        .check();
   }
 }

--- a/src/test/java/app/freerouting/fixtures/Dac2020BenchmarkRoutingTest.java
+++ b/src/test/java/app/freerouting/fixtures/Dac2020BenchmarkRoutingTest.java
@@ -7,6 +7,7 @@ import app.freerouting.core.RoutingJob;
 import app.freerouting.logger.FRLogger;
 import app.freerouting.management.RoutingJobScheduler;
 import app.freerouting.settings.sources.TestingSettings;
+import java.time.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,8 +30,9 @@ public class Dac2020BenchmarkRoutingTest extends RoutingFixtureTest {
 
     RunRoutingJob(job);
 
-    assertTrue(GetBoardStatistics(job).connections.incompleteCount <= 194,
-        "Routing of the reference board 'Issue508-DAC2020_bm01.dsn' should result in 194 or less incomplete connections with the target of 2 items to route.");
+    assertRoutingResult(job, "Issue508-DAC2020_bm01.dsn")
+        .maxIncompleteConnections(194)
+        .check();
   }
 
   @Test
@@ -46,8 +48,9 @@ public class Dac2020BenchmarkRoutingTest extends RoutingFixtureTest {
 
     RunRoutingJob(job);
 
-    assertTrue(GetBoardStatistics(job).connections.incompleteCount <= 161,
-            "Routing of the reference board 'Issue508-DAC2020_bm01.dsn' should result in 161 or less incomplete connections with the target of 43 items to route.");
+    assertRoutingResult(job, "Issue508-DAC2020_bm01.dsn")
+        .maxIncompleteConnections(161)
+        .check();
   }
 
   @Test
@@ -63,8 +66,9 @@ public class Dac2020BenchmarkRoutingTest extends RoutingFixtureTest {
 
     RunRoutingJob(job);
 
-    assertTrue(GetBoardStatistics(job).connections.incompleteCount <= 147,
-            "Routing of the reference board 'Issue508-DAC2020_bm01.dsn' should result in 147 or less incomplete connections with the target of 61 items to route.");
+    assertRoutingResult(job, "Issue508-DAC2020_bm01.dsn")
+        .maxIncompleteConnections(147)
+        .check();
   }
 
   @Test
@@ -80,8 +84,9 @@ public class Dac2020BenchmarkRoutingTest extends RoutingFixtureTest {
 
     RunRoutingJob(job);
 
-    assertTrue(GetBoardStatistics(job).connections.incompleteCount <= 134,
-            "Routing of the reference board 'Issue508-DAC2020_bm01.dsn' should result in 134 or less incomplete connections with the target of 111 items to route.");
+    assertRoutingResult(job, "Issue508-DAC2020_bm01.dsn")
+        .maxIncompleteConnections(134)
+        .check();
   }
 
   @Test
@@ -97,8 +102,9 @@ public class Dac2020BenchmarkRoutingTest extends RoutingFixtureTest {
 
     RunRoutingJob(job);
 
-    assertTrue(GetBoardStatistics(job).connections.incompleteCount <= 126,
-            "Routing of the reference board 'Issue508-DAC2020_bm01.dsn' should result in 126 or less incomplete connections with the target of 151 items to route.");
+    assertRoutingResult(job, "Issue508-DAC2020_bm01.dsn")
+        .maxIncompleteConnections(126)
+        .check();
   }
 
   @Test
@@ -113,8 +119,9 @@ public class Dac2020BenchmarkRoutingTest extends RoutingFixtureTest {
     // Run the job
     RunRoutingJob(job);
 
-    assertTrue(job.board.get_statistics().connections.incompleteCount <= 56,
-            "Routing of the reference board 'Issue508-DAC2020_bm01.dsn' should result in 56 or less unrouted connections after the first pass.");
+    assertRoutingResult(job, "Issue508-DAC2020_bm01.dsn")
+        .maxIncompleteConnections(56)
+        .check();
   }
 
   @Test
@@ -129,8 +136,9 @@ public class Dac2020BenchmarkRoutingTest extends RoutingFixtureTest {
     // Run the job
     RunRoutingJob(job);
 
-    assertTrue(job.board.get_statistics().connections.incompleteCount <= 28,
-            "Routing of the reference board 'Issue508-DAC2020_bm01.dsn' should result in 28 or less unrouted connections after the first 2 passes.");
+    assertRoutingResult(job, "Issue508-DAC2020_bm01.dsn")
+        .maxIncompleteConnections(28)
+        .check();
   }
 
   @Test
@@ -143,14 +151,12 @@ public class Dac2020BenchmarkRoutingTest extends RoutingFixtureTest {
 
     // Run the job and measure elapsed time via the job's own timestamps
     RunRoutingJob(job);
-    long elapsedMs = java.time.Duration.between(job.startedAt, job.finishedAt).toMillis();
 
-    assertTrue(elapsedMs < 30_000,
-            "Routing of the reference board 'Issue508-DAC2020_bm07.dsn' should complete in less than 30 seconds, but took " + elapsedMs + " ms.");
-    assertTrue(job.getCurrentPass() <= 9,
-            "Routing of the reference board 'Issue508-DAC2020_bm07.dsn' should complete within the first 9 passes, but required " + job.getCurrentPass() + " passes.");
-    assertTrue(job.board.get_statistics().connections.incompleteCount <= 0,
-            "Routing of the reference board 'Issue508-DAC2020_bm07.dsn' should result in 0 unrouted connections after the first pass.");
+    assertRoutingResult(job, "Issue508-DAC2020_bm07.dsn")
+        .maxDuration(Duration.ofSeconds(30))
+        .maxPasses(9)
+        .exactIncompleteConnections(0)
+        .check();
   }
 
   @Test
@@ -163,14 +169,12 @@ public class Dac2020BenchmarkRoutingTest extends RoutingFixtureTest {
 
     // Run the job and measure elapsed time via the job's own timestamps
     RunRoutingJob(job);
-    long elapsedMs = java.time.Duration.between(job.startedAt, job.finishedAt).toMillis();
 
-    assertTrue(elapsedMs < 20_000,
-            "Routing of the reference board 'Issue508-DAC2020_bm08.dsn' should complete in less than 20 seconds, but took " + elapsedMs + " ms.");
-    assertTrue(job.getCurrentPass() <= 2,
-            "Routing of the reference board 'Issue508-DAC2020_bm08.dsn' should complete within the first 2 passes, but required " + job.getCurrentPass() + " passes.");
-    assertTrue(job.board.get_statistics().connections.incompleteCount <= 0,
-            "Routing of the reference board 'Issue508-DAC2020_bm08.dsn' should result in 0 unrouted connections after the first pass.");
+    assertRoutingResult(job, "Issue508-DAC2020_bm08.dsn")
+        .maxDuration(Duration.ofSeconds(20))
+        .maxPasses(2)
+        .exactIncompleteConnections(0)
+        .check();
   }
 
   @AfterEach

--- a/src/test/java/app/freerouting/fixtures/Dac2020Bm01RoutingTest.java
+++ b/src/test/java/app/freerouting/fixtures/Dac2020Bm01RoutingTest.java
@@ -1,7 +1,5 @@
 package app.freerouting.fixtures;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import app.freerouting.Freerouting;
 import app.freerouting.core.RoutingJob;
 import app.freerouting.logger.FRLogger;
@@ -37,7 +35,8 @@ public class Dac2020Bm01RoutingTest extends RoutingFixtureTest {
     // There are 195 connections in total on the board
     // If both net (99 and 98) are routed, there should be 193 incomplete connections left
     // If only net 99 is routed, there should be 194 incomplete connections left
-    assertTrue(GetBoardStatistics(job).connections.incompleteCount <= 194,
-        "Routing of the reference board 'Issue508-DAC2020_bm01.dsn' should result in 193 incomplete connections with the target of 2 items to route.");
+    assertRoutingResult(job, "Issue508-DAC2020_bm01.dsn")
+        .maxIncompleteConnections(194)
+        .check();
   }
 }

--- a/src/test/java/app/freerouting/fixtures/DevBoardClearanceRoutingTest.java
+++ b/src/test/java/app/freerouting/fixtures/DevBoardClearanceRoutingTest.java
@@ -1,7 +1,5 @@
 package app.freerouting.fixtures;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -13,9 +11,9 @@ public class DevBoardClearanceRoutingTest extends RoutingFixtureTest {
 
     job = RunRoutingJob(job);
 
-    var statsAfter = GetBoardStatistics(job);
-
-    assertEquals(0, statsAfter.connections.incompleteCount, "The incomplete count should be 0");
-    assertEquals(0, statsAfter.clearanceViolations.totalCount, "The total count of clearance violations should be 0");
+    assertRoutingResult(job, "Issue558-dev-board.dsn")
+        .exactIncompleteConnections(0)
+        .exactClearanceViolations(0)
+        .check();
   }
 }

--- a/src/test/java/app/freerouting/fixtures/Display8DigitRoutingTest.java
+++ b/src/test/java/app/freerouting/fixtures/Display8DigitRoutingTest.java
@@ -1,8 +1,5 @@
 package app.freerouting.fixtures;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
 
 /**
@@ -53,10 +50,9 @@ public class Display8DigitRoutingTest extends RoutingFixtureTest {
     // some connections may remain incomplete; we accept up to 50 incomplete connections.
     job = RunRoutingJob(job);
 
-    var statsAfter = GetBoardStatistics(job);
-
-    assertEquals(0, statsAfter.clearanceViolations.totalCount, "The total count of clearance violations should be 0");
-    assertTrue(statsAfter.connections.incompleteCount <= 20,
-        "Expected at most 20 incomplete connections, but got " + statsAfter.connections.incompleteCount);
+    assertRoutingResult(job, "Issue229-display-8-digit-hc595.dsn")
+        .exactClearanceViolations(0)
+        .maxIncompleteConnections(20)
+        .check();
   }
 }

--- a/src/test/java/app/freerouting/fixtures/DrcViolationRoutingTest.java
+++ b/src/test/java/app/freerouting/fixtures/DrcViolationRoutingTest.java
@@ -1,7 +1,5 @@
 package app.freerouting.fixtures;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import app.freerouting.core.RoutingJob;
 import app.freerouting.management.RoutingJobScheduler;
 import app.freerouting.settings.sources.TestingSettings;
@@ -19,16 +17,13 @@ public class DrcViolationRoutingTest extends RoutingFixtureTest {
     TestingSettings testingSettings = new TestingSettings();
     testingSettings.setEnabled(false);
 
-    // Get a routing job
     job = GetRoutingJob("Issue575-drc_BBD_Mars-64_6_track_1_hole_clearance_violations.dsn", testingSettings);
-
-    // Run the job
     RunRoutingJob(job);
 
-    var statsAfter = GetBoardStatistics(job);
-
-    assertEquals(0, statsAfter.connections.incompleteCount, "The incomplete count should be 0");
-    assertEquals(7, statsAfter.clearanceViolations.totalCount, "The total count of clearance violations should be 7");
+    assertRoutingResult(job, "Issue575-drc_BBD_Mars-64_6_track_1_hole_clearance_violations.dsn")
+        .exactIncompleteConnections(0)
+        .exactClearanceViolations(7)
+        .check();
   }
 
   @Test
@@ -37,16 +32,13 @@ public class DrcViolationRoutingTest extends RoutingFixtureTest {
     TestingSettings testingSettings = new TestingSettings();
     testingSettings.setEnabled(false);
 
-    // Get a routing job
     job = GetRoutingJob("Issue575-drc_dev-board_4_hole_clearance_violations.dsn", testingSettings);
-
-    // Run the job
     RunRoutingJob(job);
 
-    var statsAfter = GetBoardStatistics(job);
-
-    assertEquals(0, statsAfter.connections.incompleteCount, "The incomplete count should be 0");
-    assertEquals(4, statsAfter.clearanceViolations.totalCount, "The total count of clearance violations should be 4");
+    assertRoutingResult(job, "Issue575-drc_dev-board_4_hole_clearance_violations.dsn")
+        .exactIncompleteConnections(0)
+        .exactClearanceViolations(4)
+        .check();
   }
 
   @Test
@@ -55,16 +47,13 @@ public class DrcViolationRoutingTest extends RoutingFixtureTest {
     TestingSettings testingSettings = new TestingSettings();
     testingSettings.setEnabled(false);
 
-    // Get a routing job
     job = GetRoutingJob("Issue575-drc_Natural_Tone_Preamp_7_unconnected_items.dsn", testingSettings);
-
-    // Run the job
     RunRoutingJob(job);
 
-    var statsAfter = GetBoardStatistics(job);
-
-    assertEquals(7, statsAfter.connections.incompleteCount, "The incomplete count should be 7");
-    assertEquals(0, statsAfter.clearanceViolations.totalCount, "The total count of clearance violations should be 0");
+    assertRoutingResult(job, "Issue575-drc_Natural_Tone_Preamp_7_unconnected_items.dsn")
+        .exactIncompleteConnections(7)
+        .exactClearanceViolations(0)
+        .check();
   }
 
   @AfterEach

--- a/src/test/java/app/freerouting/fixtures/InactiveLayerRoutingTest.java
+++ b/src/test/java/app/freerouting/fixtures/InactiveLayerRoutingTest.java
@@ -6,7 +6,6 @@ import app.freerouting.settings.sources.TestingSettings;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests related to GitHub Issue #230: "Auto-router uses inactive layers if via cost set to 45 or lower"
@@ -138,20 +137,15 @@ public class InactiveLayerRoutingTest extends RoutingFixtureTest {
     // Get a routing job
     job = GetRoutingJob("Issue230-CNH_Functional_Tester_1.dsn", testingSettings);
 
-    // Run the job and measure elapsed time via the job's own timestamps
+    // Run the job
     RunRoutingJob(job);
-    long elapsedMs = java.time.Duration.between(job.startedAt, job.finishedAt).toMillis();
 
-    // --- Timing ---
-    assertTrue(elapsedMs < 300_000,
-        "Routing of 'Issue230-CNH_Functional_Tester_1.dsn' should complete in under 5 minutes, but took " + elapsedMs + " ms.");
-
-    // --- Routing quality (based on observed realistic results for this board) ---
-    assertTrue(job.getCurrentPass() <= 20,
-        "Routing of 'Issue230-CNH_Functional_Tester_1.dsn' required too many passes: " + job.getCurrentPass() + " (expected <= 20).");
-    assertTrue(job.board.get_statistics().connections.incompleteCount <= 5,
-        "Routing of 'Issue230-CNH_Functional_Tester_1.dsn' left too many unrouted connections: "
-            + job.board.get_statistics().connections.incompleteCount + " (expected <= 5).");
+    // --- Timing, pass count, and routing quality ---
+    assertRoutingResult(job, "Issue230-CNH_Functional_Tester_1.dsn")
+        .maxDuration(java.time.Duration.ofMillis(300_000))
+        .maxPasses(20)
+        .maxIncompleteConnections(5)
+        .check();
 
     // --- Core bug check for Issue #230 ---
     // The board has 4 copper layers: F.Cu (0, signal/active), In1.Cu (1, power/inactive),

--- a/src/test/java/app/freerouting/fixtures/Issue420ContributionBoardRoutingTest.java
+++ b/src/test/java/app/freerouting/fixtures/Issue420ContributionBoardRoutingTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import app.freerouting.core.RoutingJob;
 import app.freerouting.core.RoutingJobState;
-import app.freerouting.core.scoring.BoardStatistics;
 import app.freerouting.logger.FRLogger;
 import app.freerouting.settings.sources.TestingSettings;
 import java.time.Duration;
@@ -111,16 +110,15 @@ public class Issue420ContributionBoardRoutingTest extends RoutingFixtureTest {
         "RoutingJob.board must be non-null after routing+optimization run");
 
     // The optimizer must not introduce clearance violations.
-    BoardStatistics statsAfter = GetBoardStatistics(completed);
-    assertTrue(statsAfter.clearanceViolations.totalCount == 0,
-        "Optimizer must not introduce clearance violations; found: "
-            + statsAfter.clearanceViolations.totalCount);
+    assertRoutingResult(completed, FIXTURE_FILE)
+        .exactClearanceViolations(0)
+        .check();
 
     Duration duration = completed.getDuration();
+    var statsAfter = GetBoardStatistics(completed);
     IO.println("Issue420 optimizer test completed in "
         + FRLogger.formatDuration(duration.toSeconds())
         + " with " + statsAfter.connections.incompleteCount + " incomplete connections"
         + " and " + statsAfter.clearanceViolations.totalCount + " clearance violations.");
   }
 }
-

--- a/src/test/java/app/freerouting/fixtures/J2ReferenceRoutingTest.java
+++ b/src/test/java/app/freerouting/fixtures/J2ReferenceRoutingTest.java
@@ -1,6 +1,5 @@
 package app.freerouting.fixtures;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -15,13 +14,17 @@ public class J2ReferenceRoutingTest extends RoutingFixtureTest {
 
     var statsAfter = GetBoardStatistics(job);
 
-    assertTrue(statsAfter.items.drillItemCount < 60, "The drill item count should be less than 60");
+    // The drill item count is a board-specific guard unrelated to routing quality;
+    // keep as a standalone check since assertRoutingResult does not cover it.
+    assertTrue(statsAfter.items.drillItemCount < 60,
+        "The drill item count should be less than 60, but was " + statsAfter.items.drillItemCount + ".");
+
     // The board has 3 items that are genuinely hard to route due to tight geometry;
     // the router should stop promptly (stagnation detection) rather than loop endlessly.
-    assertTrue(statsAfter.connections.incompleteCount <= 3,
-        "The incomplete count should be at most 3 (the router aborted after detecting no improvement)");
-    assertTrue(job.getCurrentPass() < 100,
-        "The router should stop before reaching the max pass limit when stagnation is detected");
-    assertEquals(0, statsAfter.clearanceViolations.totalCount, "The total count of clearance violations should be 0");
+    assertRoutingResult(job, "Issue026-J2_reference.dsn")
+        .maxPasses(99)
+        .maxIncompleteConnections(3)
+        .exactClearanceViolations(0)
+        .check();
   }
 }

--- a/src/test/java/app/freerouting/fixtures/MultiLayerBoardRoutingTest.java
+++ b/src/test/java/app/freerouting/fixtures/MultiLayerBoardRoutingTest.java
@@ -1,0 +1,153 @@
+package app.freerouting.fixtures;
+
+import app.freerouting.board.Trace;
+import app.freerouting.core.RoutingJob;
+import app.freerouting.settings.sources.TestingSettings;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests that validate correct multi-layer board handling.
+ *
+ * <p><b>Background:</b><br>
+ * {@code DefaultSettings} previously hard-coded a {@code defaultLayerCount = 2} and initialized
+ * the layer arrays ({@code isLayerActive}, {@code isPreferredDirectionHorizontalOnLayer}, and the
+ * per-layer trace-cost arrays) with exactly 2 entries. Any board that has more than 2 signal
+ * layers therefore received incorrectly-sized arrays from the settings merger before
+ * {@code applyBoardSpecificOptimizations()} was called, leading to:
+ * <ul>
+ *   <li>Inner layers being invisible to (or silently ignored by) the router until the first call
+ *       to {@code applyBoardSpecificOptimizations}.</li>
+ *   <li>Settings sources at lower priority than {@code DsnFileSettings} (e.g. CLI or API) being
+ *       able to overwrite the correctly-sized arrays with the stale size-2 defaults.</li>
+ *   <li>Any code that reads layer settings between {@code merger.merge()} and
+ *       {@code applyBoardSpecificOptimizations()} seeing wrong data.</li>
+ * </ul>
+ *
+ * <p><b>Fix:</b><br>
+ * {@code DefaultSettings} no longer initialises the layer arrays at all (they are left
+ * {@code null}). {@code DsnFileSettings} always calls {@code RouterSettings.setLayerCount(n)}
+ * using the layer count extracted from the DSN {@code (structure (layer …))} declarations, so
+ * the merged settings have correctly-sized arrays as soon as the DSN file is parsed –
+ * independently of whether an {@code (autoroute_settings …)} block is present in the file.
+ * {@code applyBoardSpecificOptimizations()} then refines the per-layer cost values based on
+ * the actual board geometry.
+ *
+ * <p><b>Covered boards:</b><br>
+ * <ul>
+ *   <li>{@code Issue066-Project_GP8B.dsn} — 4-layer board (F.Cu / In1.Cu / In2.Cu / B.Cu),
+ *       266 connections, no {@code (autoroute_settings)} block (exercises the "DsnFileSettings
+ *       must set layer count even without an autoroute block" path).</li>
+ *   <li>{@code Issue289-Autorouter_PCB_FHT-8086_2024-03-08.dsn} — 6-layer board
+ *       (layers 1, 2, 21, 22, 23, 24), 142 connections, no {@code (autoroute_settings)} block.</li>
+ * </ul>
+ */
+public class MultiLayerBoardRoutingTest extends RoutingFixtureTest {
+
+    /**
+     * Verifies that a 4-layer board is correctly handled by the settings merger.
+     *
+     * <p>Specifically:
+     * <ol>
+     *   <li>After {@code GetRoutingJob} (which runs {@code merger.merge()} but NOT yet
+     *       {@code applyBoardSpecificOptimizations}), the layer count in
+     *       {@code job.routerSettings} must already be 4 — not the former hard-coded 2.</li>
+     *   <li>After routing, traces must be present on at least one inner layer
+     *       (layer index 1 or 2), confirming that the router actually used the full
+     *       4-layer stack rather than being constrained to the outer 2 layers.</li>
+     * </ol>
+     */
+    @Test
+    void test_4layer_board_issue066_layer_count_and_inner_layer_usage() {
+        TestingSettings testingSettings = new TestingSettings();
+        // Keep CI-friendly: 2 passes over a bounded set of connections is enough to
+        // drive the router onto inner layers for a complex 4-layer board.
+        testingSettings.setMaxPasses(2);
+        testingSettings.setMaxItems(60);
+        testingSettings.setJobTimeoutString("00:02:00");
+
+        RoutingJob job = GetRoutingJob("Issue066-Project_GP8B.dsn", testingSettings);
+
+        // --- Pre-routing: layer count must be read from the DSN, not defaulted to 2 ---
+        // The merger has run but applyBoardSpecificOptimizations has NOT yet been called.
+        // With the fix DsnFileSettings seeds the layer arrays from the DSN metadata (4 layers),
+        // so getLayerCount() must already return 4 here.
+        assertEquals(4, job.routerSettings.getLayerCount(),
+            "Before routing, routerSettings.getLayerCount() should be 4 for"
+                + " 'Issue066-Project_GP8B.dsn' (F.Cu / In1.Cu / In2.Cu / B.Cu)."
+                + " If it returns 2 the DefaultSettings hard-coded layer count is still active.");
+
+        RunRoutingJob(job);
+
+        // --- Post-routing: layer count must still be 4 ---
+        assertEquals(4, job.routerSettings.getLayerCount(),
+            "After routing, routerSettings.getLayerCount() should be 4 for"
+                + " 'Issue066-Project_GP8B.dsn'.");
+
+        // --- Post-routing: at least one trace must exist on an inner layer ---
+        // For a 4-layer board the inner signal layers are indices 1 (In1.Cu) and 2 (In2.Cu).
+        // If the router was inadvertently restricted to size-2 layer arrays before the fix,
+        // it would never place traces on these layers.
+        Set<Integer> layersWithTraces = job.board.get_traces().stream()
+            .map(Trace::get_layer)
+            .collect(Collectors.toSet());
+
+        assertTrue(layersWithTraces.contains(1) || layersWithTraces.contains(2),
+            "After routing 'Issue066-Project_GP8B.dsn', at least one trace should exist"
+                + " on an inner layer (In1.Cu=1 or In2.Cu=2). Layers with traces: "
+                + layersWithTraces + ". If no inner-layer traces exist the router may"
+                + " still be constrained to 2 layers.");
+    }
+
+    /**
+     * Verifies that a 6-layer board is correctly handled by the settings merger.
+     *
+     * <p>Specifically:
+     * <ol>
+     *   <li>After {@code GetRoutingJob}, the layer count in {@code job.routerSettings} must
+     *       be 6 — not the former hard-coded 2.</li>
+     *   <li>After routing, at least one trace must exist on an inner layer
+     *       (layer index ≥ 1 and ≤ 4), confirming the router uses the full 6-layer stack.</li>
+     * </ol>
+     */
+    @Test
+    void test_6layer_board_issue289_layer_count_and_inner_layer_usage() {
+        TestingSettings testingSettings = new TestingSettings();
+        testingSettings.setMaxPasses(2);
+        testingSettings.setMaxItems(50);
+        testingSettings.setJobTimeoutString("00:02:00");
+
+        RoutingJob job = GetRoutingJob("Issue289-Autorouter_PCB_FHT-8086_2024-03-08.dsn", testingSettings);
+
+        // --- Pre-routing: layer count must be read from the DSN, not defaulted to 2 ---
+        assertEquals(6, job.routerSettings.getLayerCount(),
+            "Before routing, routerSettings.getLayerCount() should be 6 for"
+                + " 'Issue289-Autorouter_PCB_FHT-8086_2024-03-08.dsn' (layers 1/2/21/22/23/24)."
+                + " If it returns 2 the DefaultSettings hard-coded layer count is still active.");
+
+        RunRoutingJob(job);
+
+        // --- Post-routing: layer count must still be 6 ---
+        assertEquals(6, job.routerSettings.getLayerCount(),
+            "After routing, routerSettings.getLayerCount() should be 6 for"
+                + " 'Issue289-Autorouter_PCB_FHT-8086_2024-03-08.dsn'.");
+
+        // --- Post-routing: at least one trace must exist on an inner layer ---
+        // For this 6-layer board the inner signal layers are indices 1 through 4.
+        Set<Integer> layersWithTraces = job.board.get_traces().stream()
+            .map(Trace::get_layer)
+            .collect(Collectors.toSet());
+
+        boolean hasInnerLayerTrace = layersWithTraces.stream().anyMatch(l -> l >= 1 && l <= 4);
+        assertTrue(hasInnerLayerTrace,
+            "After routing 'Issue289-Autorouter_PCB_FHT-8086_2024-03-08.dsn', at least one"
+                + " trace should exist on an inner layer (index 1-4). Layers with traces: "
+                + layersWithTraces + ". If no inner-layer traces exist the router may"
+                + " still be constrained to 2 layers.");
+    }
+}

--- a/src/test/java/app/freerouting/fixtures/RoutingFixtureTest.java
+++ b/src/test/java/app/freerouting/fixtures/RoutingFixtureTest.java
@@ -1,5 +1,8 @@
 package app.freerouting.fixtures;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import app.freerouting.Freerouting;
 import app.freerouting.board.ItemIdentificationNumberGenerator;
 import app.freerouting.board.RoutingBoard;
@@ -9,6 +12,7 @@ import app.freerouting.core.Session;
 import app.freerouting.core.scoring.BoardStatistics;
 import app.freerouting.gui.FileFormat;
 import app.freerouting.interactive.HeadlessBoardManager;
+import app.freerouting.logger.FRLogger;
 import app.freerouting.management.RoutingJobScheduler;
 import app.freerouting.management.SessionManager;
 import app.freerouting.management.TextManager;
@@ -20,10 +24,9 @@ import app.freerouting.settings.sources.TestingSettings;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
-
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class RoutingFixtureTest {
 
@@ -141,5 +144,211 @@ public class RoutingFixtureTest {
 
     return new BoardStatistics(job.board);
   }
-}
 
+  /**
+   * Creates a fluent assertion builder for checking routing result properties.
+   *
+   * <p>Usage:
+   * <pre>{@code
+   * assertRoutingResult(job, "MyBoard.dsn")
+   *     .maxDuration(Duration.ofMinutes(5))
+   *     .passCount(1, 40)
+   *     .maxIncompleteConnections(3)
+   *     .exactClearanceViolations(0)
+   *     .check();
+   * }</pre>
+   *
+   * <p>Pass {@code null} (or simply omit a setter call) for any property you do not want to
+   * check. A missing check is silently skipped.
+   *
+   * @param job       the completed routing job to inspect
+   * @param boardName human-readable board file name for use in failure messages
+   * @return a new {@link RoutingResultAssertions} builder bound to {@code job}
+   */
+  protected RoutingResultAssertions assertRoutingResult(RoutingJob job, String boardName) {
+    return new RoutingResultAssertions(job, boardName);
+  }
+
+  /**
+   * Fluent builder for asserting routing result properties.
+   *
+   * <p>All setter methods return {@code this} so calls can be chained. Call {@link #check()} at
+   * the end to execute every configured assertion. Assertions where the expected value was never
+   * set (i.e. remains {@code null}) are silently skipped, making it easy to add new checks
+   * without breaking tests that do not need them.
+   *
+   * <p>Failure messages always include both the expected constraint and the actual value measured
+   * from the job, so a CI failure immediately indicates what went wrong and by how much.
+   */
+  public static final class RoutingResultAssertions {
+
+    private final RoutingJob job;
+    private final String boardName;
+
+    private Duration maxDuration;
+    private Integer minPasses;
+    private Integer maxPasses;
+    private Integer maxIncompleteConnections;
+    private Integer exactIncompleteConnections;
+    private Integer maxClearanceViolations;
+    private Integer exactClearanceViolations;
+
+    RoutingResultAssertions(RoutingJob job, String boardName) {
+      this.job = job;
+      this.boardName = boardName;
+    }
+
+    /**
+     * Asserts that the routing job completed within the given wall-clock duration.
+     * Uses {@link RoutingJob#getDuration()} which returns the interval between
+     * {@code startedAt} and {@code finishedAt}.
+     */
+    public RoutingResultAssertions maxDuration(Duration max) {
+      this.maxDuration = max;
+      return this;
+    }
+
+    /**
+     * Convenience setter that configures both {@link #minPasses} and {@link #maxPasses}
+     * in one call.
+     */
+    public RoutingResultAssertions passCount(int min, int max) {
+      this.minPasses = min;
+      this.maxPasses = max;
+      return this;
+    }
+
+    /** Asserts that the router performed at least {@code min} routing passes. */
+    public RoutingResultAssertions minPasses(int min) {
+      this.minPasses = min;
+      return this;
+    }
+
+    /** Asserts that the router stopped at or before {@code max} routing passes. */
+    public RoutingResultAssertions maxPasses(int max) {
+      this.maxPasses = max;
+      return this;
+    }
+
+    /**
+     * Asserts that the number of unrouted connections is at most {@code max}.
+     * Mutually exclusive with {@link #exactIncompleteConnections(int)}; set only one.
+     */
+    public RoutingResultAssertions maxIncompleteConnections(int max) {
+      this.maxIncompleteConnections = max;
+      return this;
+    }
+
+    /**
+     * Asserts that the number of unrouted connections is exactly {@code expected}.
+     * Uses {@code assertEquals} internally, producing a clear diff in test output.
+     * Mutually exclusive with {@link #maxIncompleteConnections(int)}; set only one.
+     */
+    public RoutingResultAssertions exactIncompleteConnections(int expected) {
+      this.exactIncompleteConnections = expected;
+      return this;
+    }
+
+    /**
+     * Asserts that the number of clearance violations is at most {@code max}.
+     * Mutually exclusive with {@link #exactClearanceViolations(int)}; set only one.
+     */
+    public RoutingResultAssertions maxClearanceViolations(int max) {
+      this.maxClearanceViolations = max;
+      return this;
+    }
+
+    /**
+     * Asserts that the number of clearance violations is exactly {@code expected}.
+     * Uses {@code assertEquals} internally, producing a clear diff in test output.
+     * Mutually exclusive with {@link #maxClearanceViolations(int)}; set only one.
+     */
+    public RoutingResultAssertions exactClearanceViolations(int expected) {
+      this.exactClearanceViolations = expected;
+      return this;
+    }
+
+    /**
+     * Executes all configured assertions against the job supplied at construction time.
+     *
+     * <p>Assertions are evaluated in the following order:
+     * <ol>
+     *   <li>Maximum wall-clock duration</li>
+     *   <li>Minimum routing-pass count</li>
+     *   <li>Maximum routing-pass count</li>
+     *   <li>Maximum incomplete-connection count (or exact equality)</li>
+     *   <li>Maximum clearance-violation count (or exact equality)</li>
+     * </ol>
+     *
+     * <p>If both an exact and a maximum value are configured for the same property, both
+     * checks run independently. In practice, set only one per property.
+     */
+    public void check() {
+      Duration actualDuration = job.getDuration();
+      int actualPasses = job.getCurrentPass();
+      BoardStatistics stats = new BoardStatistics(job.board);
+      int actualIncomplete = stats.connections.incompleteCount;
+      int actualViolations = stats.clearanceViolations.totalCount;
+
+      if (maxDuration != null) {
+        assertTrue(
+            actualDuration != null && actualDuration.compareTo(maxDuration) < 0,
+            String.format(
+                "'%s' should complete within %s, but took %s.",
+                boardName,
+                FRLogger.formatDuration(maxDuration.toSeconds()),
+                actualDuration != null ? FRLogger.formatDuration(actualDuration.toSeconds()) : "N/A"));
+      }
+
+      if (minPasses != null) {
+        assertTrue(
+            actualPasses >= minPasses,
+            String.format(
+                "'%s' should have performed at least %d routing pass(es), but only had %d.",
+                boardName, minPasses, actualPasses));
+      }
+
+      if (maxPasses != null) {
+        assertTrue(
+            actualPasses <= maxPasses,
+            String.format(
+                "'%s' should complete within at most %d routing pass(es), but required %d.",
+                boardName, maxPasses, actualPasses));
+      }
+
+      if (maxIncompleteConnections != null) {
+        assertTrue(
+            actualIncomplete <= maxIncompleteConnections,
+            String.format(
+                "'%s' should have at most %d unrouted connection(s), but had %d.",
+                boardName, maxIncompleteConnections, actualIncomplete));
+      }
+
+      if (exactIncompleteConnections != null) {
+        assertEquals(
+            exactIncompleteConnections,
+            actualIncomplete,
+            String.format(
+                "'%s' should have exactly %d unrouted connection(s).",
+                boardName, exactIncompleteConnections));
+      }
+
+      if (maxClearanceViolations != null) {
+        assertTrue(
+            actualViolations <= maxClearanceViolations,
+            String.format(
+                "'%s' should have at most %d clearance violation(s), but had %d.",
+                boardName, maxClearanceViolations, actualViolations));
+      }
+
+      if (exactClearanceViolations != null) {
+        assertEquals(
+            exactClearanceViolations,
+            actualViolations,
+            String.format(
+                "'%s' should have exactly %d clearance violation(s).",
+                boardName, exactClearanceViolations));
+      }
+    }
+  }
+}

--- a/src/test/java/app/freerouting/fixtures/SetonixRoutingTest.java
+++ b/src/test/java/app/freerouting/fixtures/SetonixRoutingTest.java
@@ -1,8 +1,5 @@
 package app.freerouting.fixtures;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
 
 /**
@@ -55,10 +52,9 @@ public class SetonixRoutingTest extends RoutingFixtureTest {
 
     job = RunRoutingJob(job);
 
-    var statsAfter = GetBoardStatistics(job);
-
-    assertTrue(statsAfter.connections.incompleteCount <= 4,
-            "The incomplete count should be at most 4");
-    assertEquals(0, statsAfter.clearanceViolations.totalCount, "The total count of clearance violations should be 0");
+    assertRoutingResult(job, "Issue159-setonix_2hp-pcb.dsn")
+        .maxIncompleteConnections(4)
+        .exactClearanceViolations(0)
+        .check();
   }
 }

--- a/src/test/java/app/freerouting/settings/sources/DsnFileSettingsTest.java
+++ b/src/test/java/app/freerouting/settings/sources/DsnFileSettingsTest.java
@@ -17,18 +17,52 @@ class DsnFileSettingsTest {
     Freerouting.globalSettings = new GlobalSettings();
   }
 
+  /**
+   * Verifies that {@code DsnFileSettings} reads the layer count directly from the DSN file's
+   * {@code (structure (layer ...))} entries, even when the file has no
+   * {@code (autoroute_settings ...)} scope.
+   *
+   * <p>{@code Issue413-test.dsn} is a 2-layer board (F.Cu + B.Cu) <em>without</em> an
+   * {@code (autoroute_settings)} block. The old {@code DefaultSettings} hard-coded
+   * {@code defaultLayerCount = 2} for every board regardless of its actual layer stack.
+   * The fix made {@code DsnFileSettings} extract the layer count from the DSN metadata and call
+   * {@code RouterSettings.setLayerCount(n)}, so the merged settings always reflect what the board
+   * file actually declares.
+   *
+   * <p>This test asserts {@code == 2} (not {@code != 2}) because the DSN file genuinely has
+   * 2 signal layers. Asserting the exact match is the strongest proof that the layer count comes
+   * from the file, not from some coincidental hard-coded constant.
+   */
   @Test
-  void dsnFileSettingsNoLongerReturnsStubLayerCount() {
-    // rpi_splitter.dsn is a 2-layer board; the old stub always returned 2 coincidentally.
-    // Issue413-test.dsn has no (autoroute_settings ...) scope, so DsnFileSettings
-    // falls back to a plain new RouterSettings() whose getLayerCount() returns 0.
-    // This proves the old hardcoded setLayerCount(2) stub has been removed.
+  void dsnFileSettings_reads2LayerCount_from2LayerBoardWithoutAutorouteBlock() {
+    // Issue413-test.dsn: 2 signal layers (F.Cu, B.Cu), no (autoroute_settings ...) block.
     InputStream in = DsnTestFixtures.openResource("Issue413-test.dsn");
     DsnFileSettings settings = new DsnFileSettings(in, "Issue413-test.dsn");
 
-    // Old stub returned 2 regardless; correct implementation does not hard-code 2
-    assertNotEquals(2, settings.getSettings().getLayerCount(),
-        "DsnFileSettings must not return the old hard-coded stub layer count of 2");
+    assertEquals(2, settings.getSettings().getLayerCount(),
+        "DsnFileSettings should read the layer count from the DSN structure section (2 layers: "
+            + "F.Cu and B.Cu) even when the file has no (autoroute_settings ...) block.");
+  }
+
+  /**
+   * Verifies that {@code DsnFileSettings} reads the correct layer count for a 4-layer board
+   * without an {@code (autoroute_settings ...)} scope.
+   *
+   * <p>{@code Issue066-Project_GP8B.dsn} has 4 signal layers (F.Cu / In1.Cu / In2.Cu / B.Cu)
+   * and no {@code (autoroute_settings)} block. This is the canonical multi-layer regression case:
+   * the old hard-coded size-2 layer arrays would have been wrong here, while the correct
+   * implementation must return 4.
+   */
+  @Test
+  void dsnFileSettings_reads4LayerCount_from4LayerBoardWithoutAutorouteBlock() {
+    // Issue066-Project_GP8B.dsn: 4 signal layers (F.Cu, In1.Cu, In2.Cu, B.Cu),
+    // no (autoroute_settings ...) block.
+    InputStream in = DsnTestFixtures.openResource("Issue066-Project_GP8B.dsn");
+    DsnFileSettings settings = new DsnFileSettings(in, "Issue066-Project_GP8B.dsn");
+
+    assertEquals(4, settings.getSettings().getLayerCount(),
+        "DsnFileSettings should read the layer count from the DSN structure section (4 layers: "
+            + "F.Cu, In1.Cu, In2.Cu, B.Cu) even when the file has no (autoroute_settings ...) block.");
   }
 
   @Test
@@ -55,4 +89,3 @@ class DsnFileSettingsTest {
     assertTrue(settings.getSourceName().contains("Issue143-rpi_splitter.dsn"));
   }
 }
-


### PR DESCRIPTION
This pull request introduces improvements to how router settings handle layer-dependent arrays and refactors several test cases for better clarity and maintainability. The most significant changes are in the initialization and propagation of layer-specific settings, ensuring they are correctly sized based on the board data rather than hardcoded defaults. Additionally, test assertions are refactored to use a fluent interface, making them more readable and consistent.

**Router settings initialization and propagation:**

* `RouterSettings.java`, `DefaultSettings.java`, `DsnFileSettings.java`: Layer-dependent arrays (such as `isLayerActive`, `isPreferredDirectionHorizontalOnLayer`, and trace cost arrays) are no longer initialized with hardcoded sizes. Instead, their sizes are determined by the board file's layer count, ensuring correct behavior for boards with any number of layers. Null checks are added to cloning and cost array methods to prevent errors when arrays are not initialized. [[1]](diffhunk://#diff-e762b7026548c01bea5f719e2c0f05262eec141eeb211428cb5a87290ebc0b16L270-R281) [[2]](diffhunk://#diff-a622785b6943dbd6650699a4d7b129c3cc8deae449c2ba23bb9157b3e48e45b7L19-R24) [[3]](diffhunk://#diff-a622785b6943dbd6650699a4d7b129c3cc8deae449c2ba23bb9157b3e48e45b7L37-R41) [[4]](diffhunk://#diff-a622785b6943dbd6650699a4d7b129c3cc8deae449c2ba23bb9157b3e48e45b7L54-L60) [[5]](diffhunk://#diff-d90726827296f8b1ebe730171b149b7e6afd9942fba1471fe5f872d2e00f38f5L31-R52) [[6]](diffhunk://#diff-e762b7026548c01bea5f719e2c0f05262eec141eeb211428cb5a87290ebc0b16R443-R445)

**Test refactoring and improvements:**

* Multiple test files (`BbdMars64PerformanceRoutingTest.java`, `Dac2020BenchmarkRoutingTest.java`, `Dac2020Bm01RoutingTest.java`, `DevBoardClearanceRoutingTest.java`): Test assertions are refactored to use a fluent `assertRoutingResult` interface, improving readability and reducing repetitive code. This change also standardizes how routing results are checked across different tests. [[1]](diffhunk://#diff-6366cfd9c706912abc5531b1d4ee4a32167c18a5abc7aab8cb7169bb836309f8L90-R93) [[2]](diffhunk://#diff-6366cfd9c706912abc5531b1d4ee4a32167c18a5abc7aab8cb7169bb836309f8L135-R130) [[3]](diffhunk://#diff-157a63b524d60e0bb78afdb3cf62fdfd01cb26a9b2d128e956fa8b6e99a94f0fL32-R35) [[4]](diffhunk://#diff-157a63b524d60e0bb78afdb3cf62fdfd01cb26a9b2d128e956fa8b6e99a94f0fL49-R53) [[5]](diffhunk://#diff-157a63b524d60e0bb78afdb3cf62fdfd01cb26a9b2d128e956fa8b6e99a94f0fL66-R71) [[6]](diffhunk://#diff-157a63b524d60e0bb78afdb3cf62fdfd01cb26a9b2d128e956fa8b6e99a94f0fL83-R89) [[7]](diffhunk://#diff-157a63b524d60e0bb78afdb3cf62fdfd01cb26a9b2d128e956fa8b6e99a94f0fL100-R107) [[8]](diffhunk://#diff-157a63b524d60e0bb78afdb3cf62fdfd01cb26a9b2d128e956fa8b6e99a94f0fL116-R124) [[9]](diffhunk://#diff-157a63b524d60e0bb78afdb3cf62fdfd01cb26a9b2d128e956fa8b6e99a94f0fL132-R141) [[10]](diffhunk://#diff-157a63b524d60e0bb78afdb3cf62fdfd01cb26a9b2d128e956fa8b6e99a94f0fL146-R159) [[11]](diffhunk://#diff-157a63b524d60e0bb78afdb3cf62fdfd01cb26a9b2d128e956fa8b6e99a94f0fL166-R177) [[12]](diffhunk://#diff-67f8a8d9c51031bc21ea2a5ff3a28c4157805abae803573edd7de7ed38d09fd5L40-R40) [[13]](diffhunk://#diff-989b219560e1feb2bc62b61857f3be7fc88d4975203b540316a279969f9f9d8aL16-R17)

**Minor cleanup:**

* Unused imports are removed from several test files for cleanliness. [[1]](diffhunk://#diff-a622785b6943dbd6650699a4d7b129c3cc8deae449c2ba23bb9157b3e48e45b7L7) [[2]](diffhunk://#diff-6366cfd9c706912abc5531b1d4ee4a32167c18a5abc7aab8cb7169bb836309f8L3) [[3]](diffhunk://#diff-67f8a8d9c51031bc21ea2a5ff3a28c4157805abae803573edd7de7ed38d09fd5L3-L4) [[4]](diffhunk://#diff-989b219560e1feb2bc62b61857f3be7fc88d4975203b540316a279969f9f9d8aL3-L4) [[5]](diffhunk://#diff-6274aebff8d8306fbea6759bacd9bf4a7d44a3b45dc03f89125d38f509f00b5cL3-L5)

These changes collectively improve the flexibility and robustness of router settings, especially for boards with varying layer counts, and make the test suite easier to maintain and extend.