### PR TITLE
Minor improvements to unit tests, extra exception checks

### DIFF
--- a/fixtures/Issue684-Autorouter_PCB1_2026-5-8.dsn
+++ b/fixtures/Issue684-Autorouter_PCB1_2026-5-8.dsn
@@ -1,0 +1,952 @@
+(PCB "PCB1"
+  (parser
+    (host_cad "EasyEDA Pro")
+    (host_version "2.2.47.7")
+  )
+  (resolution mil 1000)
+  (structure
+    (boundary(path signal 0 0 0 0 771 911 771 911 0 0 0 )
+    )
+    (via via0
+    )
+    (grid via   0.25)
+    (grid wire   0.25)
+    (grid place   0.25)
+    (rule(clear 0.8))
+    (rule(clear 0.8 (type default_smd)))
+    (rule(clear 0.8 (type smd_smd)))
+    (rule(width 15.75))
+    (layer 1
+      (type signal)
+    )
+    (layer 2
+      (type signal)
+    )
+    (layer 15
+      (type signal)
+    )
+    (layer 16
+      (type signal)
+    )
+  )
+
+  (placement
+    (component u1
+      (place u1 0 0 front 0
+      )
+    )
+  )
+  (library
+    (image u1
+      (pin p0e29 0e29 332.44 503.16)
+      (pin p0e29 0e30 332.44 513)
+      (pin p0e31 0e31 312.56 493.12)
+      (pin p0e31 0e32 312.56 532.88)
+      (pin p2e7 2e7 463.73 594.26)
+      (pin p2e7 2e8 476.27 594.26)
+      (pin p3e15 3e15 465.56 588.5)
+      (pin p3e15 3e16 473.44 588.5)
+      (pin p3e15 4e15 465.56 582.5)
+      (pin p3e15 4e16 473.44 582.5)
+      (pin p5e15 5e15 344 577)
+      (pin p0e29 5e16 354 577)
+      (pin p0e29 5e17 344 567)
+      (pin p0e29 5e18 354 567)
+      (pin p0e29 5e19 344 557)
+      (pin p0e29 5e20 354 557)
+      (pin p6e7 6e7 464.03 600.5)
+      (pin p6e7 6e8 469.97 600.5)
+      (pin p6e7 7e7 470.53 600.5)
+      (pin p6e7 7e8 476.47 600.5)
+      (pin p6e7 8e7 477.03 600.5)
+      (pin p6e7 8e8 482.97 600.5)
+      (pin p9e7 9e7 483.97 571.5)
+      (pin p9e7 9e8 478.03 571.5)
+      (pin p10e12 10e12 491.94 578)
+      (pin p10e12 10e13 484.06 578)
+      (pin p10e12 11e12 491.94 583)
+      (pin p10e12 11e13 484.06 583)
+      (pin p10e12 12e12 483.94 579.5)
+      (pin p10e12 12e13 476.06 579.5)
+      (pin p10e12 13e12 491.94 589.5)
+      (pin p10e12 13e13 484.06 589.5)
+      (pin p9e7 14e7 483.97 589.5)
+      (pin p9e7 14e8 478.03 589.5)
+      (pin p10e12 15e12 492.44 571.5)
+      (pin p10e12 15e13 484.56 571.5)
+      (pin p0e29 16e16 498 603.9)
+      (pin p0e29 16e17 498 591.3)
+      (pin p0e29 16e18 498 578.7)
+      (pin p0e29 16e19 498 566.1)
+      (pin p0e29 17e16 458 603.9)
+      (pin p0e29 17e17 458 591.3)
+      (pin p0e29 17e18 458 578.7)
+      (pin p0e29 17e19 458 566.1)
+      (pin p18e16 18e16 432 548.1)
+      (pin p18e16 18e17 413.5 548.1)
+      (pin p18e16 18e18 395 548.1)
+      (pin p18e16 18e19 395 567)
+      (pin p18e16 18e20 413.5 567)
+      (pin p18e16 18e21 432 567)
+      (pin p18e16 18e22 395 585.9)
+      (pin p18e16 18e23 413.5 585.9)
+      (pin p18e16 18e24 432 585.9)
+      (pin p19e16 19e16 378.5 557)
+      (pin p19e16 19e17 368.5 557)
+      (pin p19e16 19e18 378.5 567)
+      (pin p19e16 19e19 368.5 567)
+      (pin p19e16 19e20 378.5 577)
+      (pin p19e21 19e21 368.5 577)
+      (pin p21e7 21e7 535.5 598.97)
+      (pin p21e7 21e8 535.5 587.03)
+      (pin p22e7 22e7 544.5 564.97)
+      (pin p22e7 22e8 544.5 553.03)
+      (pin p22e7 23e7 533 559.47)
+      (pin p22e7 23e8 533 547.53)
+      (pin p24e7 24e7 544.53 578)
+      (pin p24e7 24e8 556.47 578)
+      (pin p25e7 25e7 558.5 583.53)
+      (pin p25e7 25e8 558.5 595.47)
+      (pin p26e7 26e7 518.94 550.5)
+      (pin p26e8 26e8 515.32 566.38)
+      (pin p26e8 26e9 522.56 566.38)
+      (pin p27e7 27e7 527.24 565.5)
+      (pin p27e7 27e8 532.76 565.5)
+      (pin p28e12 28e12 522.5 581.94)
+      (pin p28e12 28e13 522.5 574.06)
+      (pin p9e7 29e7 533.97 582)
+      (pin p9e7 29e8 528.03 582)
+      (pin p30e12 30e12 590 585.56)
+      (pin p30e12 30e13 590 593.44)
+      (pin p31e7 31e7 561.5 604.47)
+      (pin p31e7 31e8 561.5 598.53)
+      (pin p32e7 32e7 567.47 606.5)
+      (pin p32e7 32e8 561.53 606.5)
+      (pin p33e12 33e12 581.56 577.5)
+      (pin p33e12 33e13 589.44 577.5)
+      (pin p33e12 34e12 581.56 583.5)
+      (pin p33e12 34e13 589.44 583.5)
+      (pin p28e12 35e12 592 576.44)
+      (pin p28e12 35e13 592 568.56)
+      (pin p0e29 36e16 576.5 606.4)
+      (pin p0e29 36e17 576.5 593.8)
+      (pin p0e29 36e18 576.5 581.2)
+      (pin p0e29 36e19 576.5 568.6)
+      (pin p37e52 37e52 661.22 545.6)
+      (pin p37e52 37e53 658.66 545.6)
+      (pin p37e52 37e54 656.1 545.6)
+      (pin p37e52 37e55 653.54 545.6)
+      (pin p37e52 37e56 650.99 545.6)
+      (pin p37e52 37e57 648.43 545.6)
+      (pin p37e52 37e58 663.78 545.6)
+      (pin p37e52 37e59 676.57 545.6)
+      (pin p37e52 37e60 674.02 545.6)
+      (pin p37e52 37e61 671.46 545.6)
+      (pin p37e52 37e62 668.9 545.6)
+      (pin p37e52 37e63 666.34 545.6)
+      (pin p37e52 37e64 658.66 569.4)
+      (pin p37e52 37e65 656.1 569.4)
+      (pin p37e52 37e66 653.54 569.4)
+      (pin p37e52 37e67 650.99 569.4)
+      (pin p37e52 37e68 648.43 569.4)
+      (pin p37e52 37e69 661.22 569.4)
+      (pin p37e52 37e70 676.57 569.4)
+      (pin p37e52 37e71 674.02 569.4)
+      (pin p37e52 37e72 671.46 569.4)
+      (pin p37e52 37e73 668.9 569.4)
+      (pin p37e52 37e74 666.34 569.4)
+      (pin p37e52 37e75 663.78 569.4)
+      (pin p38e7 38e7 537.02 569.76)
+      (pin p38e7 38e8 537.02 573.5)
+      (pin p38e7 38e9 537.02 577.24)
+      (pin p38e7 38e10 527.98 577.24)
+      (pin p38e7 38e11 527.98 573.5)
+      (pin p38e7 38e12 527.98 569.76)
+      (pin p39e7 39e7 543.39 584.11)
+      (pin p39e7 39e8 545.36 584.11)
+      (pin p39e7 39e9 547.33 584.11)
+      (pin p39e7 39e10 549.3 584.11)
+      (pin p39e7 39e11 551.27 584.11)
+      (pin p39e7 39e12 551.27 595.23)
+      (pin p39e7 39e13 549.3 595.23)
+      (pin p39e7 39e14 547.33 595.23)
+      (pin p39e7 39e15 545.36 595.23)
+      (pin p39e7 39e16 543.39 595.23)
+      (pin p39e17 39e17 547.33 589.67)
+      (pin p38e7 83e7 752.52 596.26)
+      (pin p38e7 83e8 752.52 600)
+      (pin p38e7 83e9 752.52 603.74)
+      (pin p38e7 83e10 743.48 603.74)
+      (pin p38e7 83e11 743.48 600)
+      (pin p38e7 83e12 743.48 596.26)
+      (pin p84e7 84e7 726.14 491.04)
+      (pin p84e7 84e8 726.14 493.01)
+      (pin p84e7 84e9 726.14 494.97)
+      (pin p84e7 84e10 726.14 496.94)
+      (pin p84e7 84e11 726.14 498.91)
+      (pin p84e7 84e12 715.03 498.91)
+      (pin p84e7 84e13 715.03 496.94)
+      (pin p84e7 84e14 715.03 494.97)
+      (pin p84e7 84e15 715.03 493.01)
+      (pin p84e7 84e16 715.03 491.04)
+      (pin p84e17 84e17 720.58 494.97)
+      (pin p0e29 1e29 332.44 621.66)
+      (pin p0e29 1e30 332.44 631.5)
+      (pin p0e31 1e31 312.56 611.62)
+      (pin p0e31 1e32 312.56 651.38)
+      (pin p681 681 312.56 651.38)
+      (pin p681 703 312.56 611.62)
+      (pin p681 704 312.56 532.88)
+      (pin p681 705 312.56 493.12)
+      (pin p710 710 312.56 611.62)
+      (pin p710 711 312.56 651.38)
+      (pin p710 712 312.56 532.88)
+      (pin p710 713 312.56 493.12)
+    )
+
+    (padstack via0
+      (shape(circle 1 2.4))
+      (shape(circle 2 2.4))
+      (shape(circle 15 2.4))
+      (shape(circle 16 2.4))
+    )
+
+    (padstack p0e29
+      (shape(circle 1 6.3 0 0))
+      (shape(circle 2 6.3 0 0))
+    )
+    (padstack p0e31
+      (shape(circle 1 10.24 0 0))
+      (shape(circle 2 10.24 0 0))
+    )
+    (padstack p2e7
+      (shape(polygon 2 0.01 2.92 3.4 2.92 -3.4 2.92 -3.4 -2.92 -3.4 -2.92 -3.4 -2.92 3.4 -2.92 3.4 2.92 3.4))
+    )
+    (padstack p3e15
+      (shape(polygon 2 0.01 2.78 2.66 2.78 -2.66 2.78 -2.66 -2.78 -2.66 -2.78 -2.66 -2.78 2.66 -2.78 2.66 2.78 2.66))
+    )
+    (padstack p5e15
+      (shape(polygon 1 0.01 -3.15 3.35 3.15 3.35 3.15 3.35 3.15 -3.35 3.15 -3.35 -3.15 -3.35 -3.15 -3.35 -3.15 3.35))
+      (shape(polygon 2 0.01 -3.15 3.35 3.15 3.35 3.15 3.35 3.15 -3.35 3.15 -3.35 -3.15 -3.35 -3.15 -3.35 -3.15 3.35))
+    )
+    (padstack p6e7
+      (shape(polygon 2 0.01 1.59 1.7 1.59 -1.7 1.59 -1.7 -1.59 -1.7 -1.59 -1.7 -1.59 1.7 -1.59 1.7 1.59 1.7))
+    )
+    (padstack p9e7
+      (shape(polygon 2 0.01 -1.59 -1.7 -1.59 1.7 -1.59 1.7 1.59 1.7 1.59 1.7 1.59 -1.7 1.59 -1.7 -1.59 -1.7))
+    )
+    (padstack p10e12
+      (shape(polygon 2 0.01 -2.23 -2.71 -2.23 2.71 -2.23 2.71 2.23 2.71 2.23 2.71 2.23 -2.71 2.23 -2.71 -2.23 -2.71))
+    )
+    (padstack p18e16
+      (shape(polygon 1 0.01 -2.95 2.95 -2.92 3.41 -2.81 3.87 -2.63 4.29 -2.39 4.69 -2.09 5.04 -1.74 5.34 -1.34 5.58 -0.91 5.76 -0.46 5.87 0 5.91 0.46 5.87 0.91 5.76 1.34 5.58 1.74 5.34 2.09 5.04 2.39 4.69 2.63 4.29 2.81 3.87 2.92 3.41 2.95 2.95 2.95 2.95 2.95 -2.95 2.95 -2.95 2.92 -3.41 2.81 -3.87 2.63 -4.29 2.39 -4.69 2.09 -5.04 1.74 -5.34 1.34 -5.58 0.91 -5.76 0.46 -5.87 0 -5.91 -0.46 -5.87 -0.91 -5.76 -1.34 -5.58 -1.74 -5.34 -2.09 -5.04 -2.39 -4.69 -2.63 -4.29 -2.81 -3.87 -2.92 -3.41 -2.95 -2.95 -2.95 -2.95 -2.95 2.95))
+      (shape(polygon 2 0.01 -2.95 2.95 -2.92 3.41 -2.81 3.87 -2.63 4.29 -2.39 4.69 -2.09 5.04 -1.74 5.34 -1.34 5.58 -0.91 5.76 -0.46 5.87 0 5.91 0.46 5.87 0.91 5.76 1.34 5.58 1.74 5.34 2.09 5.04 2.39 4.69 2.63 4.29 2.81 3.87 2.92 3.41 2.95 2.95 2.95 2.95 2.95 -2.95 2.95 -2.95 2.92 -3.41 2.81 -3.87 2.63 -4.29 2.39 -4.69 2.09 -5.04 1.74 -5.34 1.34 -5.58 0.91 -5.76 0.46 -5.87 0 -5.91 -0.46 -5.87 -0.91 -5.76 -1.34 -5.58 -1.74 -5.34 -2.09 -5.04 -2.39 -4.69 -2.63 -4.29 -2.81 -3.87 -2.92 -3.41 -2.95 -2.95 -2.95 -2.95 -2.95 2.95))
+    )
+    (padstack p19e16
+      (shape(circle 1 7.09 0 0))
+      (shape(circle 2 7.09 0 0))
+    )
+    (padstack p19e21
+      (shape(polygon 1 0.01 -3.54 3.54 3.54 3.54 3.54 3.54 3.54 -3.54 3.54 -3.54 -3.54 -3.54 -3.54 -3.54 -3.54 3.54))
+      (shape(polygon 2 0.01 -3.54 3.54 3.54 3.54 3.54 3.54 3.54 -3.54 3.54 -3.54 -3.54 -3.54 -3.54 -3.54 -3.54 3.54))
+    )
+    (padstack p21e7
+      (shape(polygon 1 0.01 5.31 -3.22 -5.31 -3.22 -5.31 -3.22 -5.31 3.22 -5.31 3.22 5.31 3.22 5.31 3.22 5.31 -3.22))
+    )
+    (padstack p22e7
+      (shape(polygon 2 0.01 5.31 -3.22 -5.31 -3.22 -5.31 -3.22 -5.31 3.22 -5.31 3.22 5.31 3.22 5.31 3.22 5.31 -3.22))
+    )
+    (padstack p24e7
+      (shape(polygon 1 0.01 3.22 5.31 3.22 -5.31 3.22 -5.31 -3.22 -5.31 -3.22 -5.31 -3.22 5.31 -3.22 5.31 3.22 5.31))
+    )
+    (padstack p25e7
+      (shape(polygon 1 0.01 -5.31 3.22 5.31 3.22 5.31 3.22 5.31 -3.22 5.31 -3.22 -5.31 -3.22 -5.31 -3.22 -5.31 3.22))
+    )
+    (padstack p26e7
+      (shape(polygon 2 0.01 -7.48 -9.45 -7.48 9.45 -7.48 9.45 7.48 9.45 7.48 9.45 7.48 -9.45 7.48 -9.45 -7.48 -9.45))
+    )
+    (padstack p26e8
+      (shape(polygon 2 0.01 2.8 -2.54 -2.8 -2.54 -2.8 -2.54 -2.8 2.54 -2.8 2.54 2.8 2.54 2.8 2.54 2.8 -2.54))
+    )
+    (padstack p27e7
+      (shape(polygon 2 0.01 1.57 1.7 1.57 -1.7 1.57 -1.7 -1.57 -1.7 -1.57 -1.7 -1.57 1.7 -1.57 1.7 1.57 1.7))
+    )
+    (padstack p28e12
+      (shape(polygon 2 0.01 2.71 -2.23 -2.71 -2.23 -2.71 -2.23 -2.71 2.23 -2.71 2.23 2.71 2.23 2.71 2.23 2.71 -2.23))
+    )
+    (padstack p30e12
+      (shape(polygon 2 0.01 -2.71 2.23 2.71 2.23 2.71 2.23 2.71 -2.23 2.71 -2.23 -2.71 -2.23 -2.71 -2.23 -2.71 2.23))
+    )
+    (padstack p31e7
+      (shape(polygon 1 0.01 1.7 -1.59 -1.7 -1.59 -1.7 -1.59 -1.7 1.59 -1.7 1.59 1.7 1.59 1.7 1.59 1.7 -1.59))
+    )
+    (padstack p32e7
+      (shape(polygon 1 0.01 -1.59 -1.7 -1.59 1.7 -1.59 1.7 1.59 1.7 1.59 1.7 1.59 -1.7 1.59 -1.7 -1.59 -1.7))
+    )
+    (padstack p33e12
+      (shape(polygon 2 0.01 2.23 2.71 2.23 -2.71 2.23 -2.71 -2.23 -2.71 -2.23 -2.71 -2.23 2.71 -2.23 2.71 2.23 2.71))
+    )
+    (padstack p37e52
+      (shape(polygon 1 0.01 -0.79 -3.25 -0.79 3.25 -0.79 3.25 0.79 3.25 0.79 3.25 0.79 -3.25 0.79 -3.25 -0.79 -3.25))
+    )
+    (padstack p38e7
+      (shape(polygon 2 0.01 2.11 -1.05 -2.11 -1.05 -2.11 -1.05 -2.11 1.05 -2.11 1.05 2.11 1.05 2.11 1.05 2.11 -1.05))
+    )
+    (padstack p39e7
+      (shape(polygon 1 0.01 -0.49 -1.28 -0.49 1.28 -0.49 1.28 0.49 1.28 0.49 1.28 0.49 -1.28 0.49 -1.28 -0.49 -1.28))
+    )
+    (padstack p39e17
+      (shape(polygon 1 0.01 -3.94 -2.36 -3.94 2.36 -3.94 2.36 3.94 2.36 3.94 2.36 3.94 -2.36 3.94 -2.36 -3.94 -2.36))
+    )
+    (padstack p84e7
+      (shape(polygon 1 0.01 1.28 -0.49 -1.28 -0.49 -1.28 -0.49 -1.28 0.49 -1.28 0.49 1.28 0.49 1.28 0.49 1.28 -0.49))
+    )
+    (padstack p84e17
+      (shape(polygon 1 0.01 2.36 -3.94 -2.36 -3.94 -2.36 -3.94 -2.36 3.94 -2.36 3.94 2.36 3.94 2.36 3.94 2.36 -3.94))
+    )
+    (padstack p681
+      (shape(circle 1 27.56 0 0))
+    )
+    (padstack p710
+      (shape(circle 2 27.56 0 0))
+    )
+  )
+  (network
+    (net $1N4807
+      (pins u1-0e29 u1-18e17 u1-1e29)
+    )
+    (net $1N2152
+      (pins u1-6e8 u1-7e7)
+    )
+    (net $1N2191
+      (pins u1-7e8 u1-8e7)
+    )
+    (net $1N4392
+      (pins u1-18e23 u1-1e30)
+    )
+    (net $1N4396
+      (pins u1-0e30 u1-18e20)
+    )
+    (net $1N2567
+      (pins u1-13e13 u1-14e7)
+    )
+    (net $1N2606
+      (pins u1-9e7 u1-15e13)
+    )
+    (net $1N2614
+      (pins u1-10e13 u1-11e13 u1-12e12)
+    )
+    (net $1N2796
+      (pins u1-8e8 u1-16e16)
+    )
+    (net $1N3330
+      (pins u1-4e15 u1-17e18)
+    )
+    (net $1N3355
+      (pins u1-2e7 u1-3e15 u1-17e17)
+    )
+    (net 42750_OHM_1
+      (pins u1-13e12 u1-16e17)
+    )
+    (net 47500_OHM_1
+      (pins u1-10e12 u1-11e12 u1-16e18)
+    )
+    (net 52250_OHM_1
+      (pins u1-15e12 u1-16e19)
+    )
+    (net SIGNAL_1_IN
+      (pins u1-6e7 u1-17e16 u1-18e21)
+    )
+    (net $1N7594
+      (pins u1-35e13 u1-36e19)
+    )
+    (net $1N7662
+      (pins u1-30e12 u1-33e13 u1-34e13 u1-35e12)
+    )
+    (net $1N7367
+      (pins u1-31e7 u1-32e8)
+    )
+    (net $1N7529
+      (pins u1-32e7 u1-36e16)
+    )
+    (net $1N7115
+      (pins u1-25e8 u1-31e8 u1-39e13)
+    )
+    (net GND1
+      (pins u1-2e8 u1-3e16 u1-4e16 u1-9e8 u1-12e13 u1-14e8 u1-18e16)
+    )
+    (net +4V_1
+      (pins u1-23e7 u1-26e7 u1-27e8 u1-38e8 u1-38e9)
+    )
+    (net $1N6879
+      (pins u1-26e8 u1-26e9 u1-27e7 u1-38e12)
+    )
+    (net $1N6667
+      (pins u1-28e12 u1-29e8 u1-38e10)
+    )
+    (net BOOST_OUT1
+      (pins u1-22e7 u1-24e7 u1-29e7 u1-38e7 u1-39e7 u1-39e8 u1-39e9)
+    )
+    (net VCC1
+      (pins u1-21e7 u1-39e15 u1-39e16)
+    )
+    (net $1N4819
+      (pins u1-0e32 u1-704 u1-712)
+    )
+    (net $1N4584
+      (pins u1-5e15 u1-5e16 u1-18e22 u1-19e20 u1-19e21)
+    )
+    (net $1N4589
+      (pins u1-5e17 u1-5e18 u1-18e19 u1-19e18 u1-19e19)
+    )
+    (net $1N4406
+      (pins u1-5e19 u1-5e20 u1-18e18 u1-19e16 u1-19e17)
+    )
+    (net GND1_SMOOTHING
+      (pins u1-21e8 u1-24e8 u1-25e7 u1-33e12 u1-34e12 u1-36e18 u1-39e11 u1-39e14 u1-39e17)
+    )
+    (net GND1_BOOST
+      (pins u1-22e8 u1-23e8 u1-28e13 u1-38e11)
+    )
+    (net NET1
+      (pins u1-84e7)
+    )
+    (net NET2
+      (pins u1-84e8)
+    )
+    (net NET3
+      (pins u1-84e9)
+    )
+    (net NET4
+      (pins u1-84e10)
+    )
+    (net NET5
+      (pins u1-84e11)
+    )
+    (net NET6
+      (pins u1-84e12)
+    )
+    (net NET7
+      (pins u1-84e13)
+    )
+    (net NET8
+      (pins u1-84e14)
+    )
+    (net NET9
+      (pins u1-84e15)
+    )
+    (net NET10
+      (pins u1-84e16)
+    )
+    (net NET11
+      (pins u1-84e17)
+    )
+    (net U9_OC
+      (pins u1-83e7)
+    )
+    (net U9_VIN
+      (pins u1-83e8)
+    )
+    (net U9_EN
+      (pins u1-83e9)
+    )
+    (net U9_FB
+      (pins u1-83e10)
+    )
+    (net U9_GND
+      (pins u1-83e11)
+    )
+    (net U9_SW
+      (pins u1-83e12)
+    )
+    (net $1N13851
+      (pins u1-30e13 u1-36e17)
+    )
+    (net $1N4794
+      (pins u1-1e31 u1-703 u1-710)
+    )
+    (net $1N4780
+      (pins u1-1e32 u1-681 u1-711)
+    )
+    (class  ''
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N4396 '$1N4396'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N4392 '$1N4392'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N3355 '$1N3355'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N3330 '$1N3330'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class SIGNAL_1_IN 'SIGNAL_1_IN'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N2152 '$1N2152'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N2191 '$1N2191'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N2796 '$1N2796'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N2606 '$1N2606'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N2614 '$1N2614'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N2567 '$1N2567'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N4406 '$1N4406'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N4589 '$1N4589'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N4584 '$1N4584'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N4807 '$1N4807'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N4819 '$1N4819'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class VCC1 'VCC1'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class BOOST_OUT1 'BOOST_OUT1'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N7115 '$1N7115'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N6879 '$1N6879'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N6667 '$1N6667'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N7367 '$1N7367'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N7529 '$1N7529'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N7662 '$1N7662'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N7594 '$1N7594'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class GND1 'GND1'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class 47500_OHM_1 '47500_OHM_1'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class 42750_OHM_1 '42750_OHM_1'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class 52250_OHM_1 '52250_OHM_1'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class +4V_1 '+4V_1'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class GND1_SMOOTHING 'GND1_SMOOTHING'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class GND1_BOOST 'GND1_BOOST'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class NET1 'NET1'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class NET2 'NET2'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class NET3 'NET3'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class NET4 'NET4'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class NET5 'NET5'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class NET6 'NET6'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class NET7 'NET7'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class NET8 'NET8'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class NET9 'NET9'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class NET10 'NET10'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class NET11 'NET11'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class U9_OC 'U9_OC'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class U9_VIN 'U9_VIN'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class U9_EN 'U9_EN'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class U9_FB 'U9_FB'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class U9_GND 'U9_GND'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class U9_SW 'U9_SW'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N13851 '$1N13851'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N4794 '$1N4794'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+    (class $1N4780 '$1N4780'
+      (circuit 
+        (use_via via0)
+      )
+      (rule 
+        (width 15.75)
+        (clearance 0.8)
+      )
+    )
+  )
+
+  (wiring
+  )
+)

--- a/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
+++ b/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
@@ -434,7 +434,12 @@ public class BatchAutorouter extends NamedAlgorithm {
 
           if (this.settings.maxItems != null && this.totalItemsRouted >= this.settings.maxItems) {
             job.logInfo("Max items limit reached (" + this.settings.maxItems + "). Stopping auto-router.");
-            this.thread.request_stop_auto_router();
+            // Call requestStop() (sets ALL) instead of request_stop_auto_router() (sets
+            // AUTO_ROUTER_ONLY) so the optimizer phase is also skipped.  maxItems is a
+            // debugging/test ceiling meant to bound the entire routing job; running the
+            // optimizer on a deliberately-incomplete board is not useful and prevents the
+            // process from terminating promptly.
+            this.thread.requestStop();
             break;
           }
           this.totalItemsRouted++;

--- a/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
+++ b/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
@@ -705,6 +705,7 @@ public class BatchAutorouter extends NamedAlgorithm {
     float lastBestScore = Float.NEGATIVE_INFINITY;   // score at last board-restore or improvement
     float globalBestScore = Float.NEGATIVE_INFINITY; // best score seen across all passes
     int passOfBestScore = 0;                         // pass where globalBestScore was achieved
+    int incompleteCountAtBestScore = 0;              // incomplete count when globalBestScore was recorded
     // Track board hashes that have already been routed. If the board does not change between
     // two consecutive passes (same hash at pass start), the router is making no progress and
     // would produce identical decisions with identical ripup budgets — stop immediately rather
@@ -879,14 +880,15 @@ public class BatchAutorouter extends NamedAlgorithm {
         if (boardScoreAfter > globalBestScore + STAGNATION_SCORE_THRESHOLD) {
           globalBestScore = boardScoreAfter;
           passOfBestScore = currentPass;
+          incompleteCountAtBestScore = boardStatisticsAfter.connections.incompleteCount;
         } else if ((currentPass - passOfBestScore) >= STAGNATION_PASS_LIMIT) {
           String report = buildUnroutedConnectionsReport();
           job.logInfo("The router's best score (" + FRLogger.defaultFloatFormat.format(globalBestScore)
               + ") has not improved by more than " + STAGNATION_SCORE_THRESHOLD
               + " points since pass #" + passOfBestScore
               + ". Stopping the auto-router after " + currentPass + " passes ("
-              + boardStatisticsAfter.connections.incompleteCount + " item"
-              + (boardStatisticsAfter.connections.incompleteCount == 1 ? "" : "s")
+              + incompleteCountAtBestScore + " item"
+              + (incompleteCountAtBestScore == 1 ? "" : "s")
               + " still unconnected).\n"
               + "The following connections could not be routed -- please review your design "
               + "(e.g. check pad clearances, trace width rules, and available routing space):\n"

--- a/src/main/java/app/freerouting/board/BasicBoard.java
+++ b/src/main/java/app/freerouting/board/BasicBoard.java
@@ -806,13 +806,36 @@ public class BasicBoard implements Serializable {
   }
 
   /**
+   * The maximum number of outer-loop iterations in {@link #normalize_traces}.
+   * Each legitimate split/combine operation converges the board toward a stable state, so a
+   * well-formed net needs at most a small multiple of its trace count.  If we exceed this bound
+   * we are almost certainly oscillating (split → combine → split …) and must break out.
+   */
+  private static final int MAX_NORMALIZE_ITERATIONS = 2000;
+
+  /**
    * Normalizes the traces of this net
    */
   public boolean normalize_traces(int p_net_no) {
     boolean result = false;
     boolean something_changed = true;
     Item curr_item;
+    int iterationCount = 0;
     while (something_changed) {
+      if (++iterationCount > MAX_NORMALIZE_ITERATIONS) {
+        // Safety valve: after this many passes the outer loop has not converged.
+        // This can happen when a pair of traces keeps oscillating between a split state
+        // and a re-combined state (e.g. a self-intersecting or zero-length segment that
+        // the geometry engine cannot cleanly normalise).  Stop here rather than hanging
+        // the board-load thread for minutes.
+        String netName = (rules != null && rules.nets != null && rules.nets.get(p_net_no) != null)
+            ? rules.nets.get(p_net_no).name : String.valueOf(p_net_no);
+        FRLogger.warn("BasicBoard.normalize_traces: reached " + MAX_NORMALIZE_ITERATIONS
+            + " iterations for net '" + netName + "' — stopping to prevent hang."
+            + " The board geometry for this net may be oscillating (split/combine cycle);"
+            + " traces are kept as-is.");
+        break;
+      }
       something_changed = false;
       Iterator<UndoableObjects.UndoableObjectNode> it = item_list.start_read_object();
       for (;;) {

--- a/src/main/java/app/freerouting/board/PolylineTrace.java
+++ b/src/main/java/app/freerouting/board/PolylineTrace.java
@@ -272,10 +272,16 @@ public class PolylineTrace extends Trace implements Serializable {
     }
     System.arraycopy(this_lines, 1, new_lines, join_pos, this_lines.length - 1);
     Polyline joined_polyline = new Polyline(new_lines);
-    if (joined_polyline.arr.length != new_line_count) {
-      // consecutive parallel lines where skipped at the join location
-      // combine without performance optimization
+    // Determine whether both traces have entries in the default search tree.
+    // If either is missing, the optimised merge_entries_in_front path will NPE,
+    // so we fall back to the safe full-remove + re-insert path in that case.
+    boolean hasTreeEntries = (this.get_search_tree_entries(board.search_tree_manager.get_default_tree()) != null)
+        && (other_trace.get_search_tree_entries(board.search_tree_manager.get_default_tree()) != null);
+    if (joined_polyline.arr.length != new_line_count || !hasTreeEntries) {
+      // consecutive parallel lines were skipped at the join location OR a trace
+      // lacks search-tree entries — combine without performance optimization
       board.search_tree_manager.remove(this);
+      this.clear_search_tree_entries();
       this.lines = joined_polyline;
       this.clear_derived_data();
       board.search_tree_manager.insert(this);

--- a/src/main/java/app/freerouting/logger/LogEntry.java
+++ b/src/main/java/app/freerouting/logger/LogEntry.java
@@ -52,6 +52,10 @@ public class LogEntry {
     return this.topic;
   }
 
+  public Throwable getException() {
+    return this.exception;
+  }
+
   @Override
   public String toString() {
     return "%-7s".formatted(this.type.toString().toUpperCase()) + " " + this.message;

--- a/src/test/java/app/freerouting/fixtures/RoutingFixtureTest.java
+++ b/src/test/java/app/freerouting/fixtures/RoutingFixtureTest.java
@@ -4,14 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import app.freerouting.Freerouting;
-import app.freerouting.board.ItemIdentificationNumberGenerator;
-import app.freerouting.board.RoutingBoard;
 import app.freerouting.core.RoutingJob;
 import app.freerouting.core.RoutingJobState;
 import app.freerouting.core.Session;
 import app.freerouting.core.scoring.BoardStatistics;
-import app.freerouting.gui.FileFormat;
-import app.freerouting.interactive.HeadlessBoardManager;
 import app.freerouting.logger.FRLogger;
 import app.freerouting.management.RoutingJobScheduler;
 import app.freerouting.management.SessionManager;
@@ -34,6 +30,9 @@ public class RoutingFixtureTest {
 
   @BeforeEach
   protected void setUp() {
+    // Reset static logging flags so that a previous test (e.g. Dac2020Bm01RoutingTest) that sets
+    // FRLogger.granularTraceEnabled = true does not contaminate subsequent tests.
+    FRLogger.granularTraceEnabled = false;
     Freerouting.globalSettings = new GlobalSettings();
     scheduler = RoutingJobScheduler.getInstance();
     // Clear any leftover jobs from previous tests to avoid singleton state leaking between test runs.
@@ -120,7 +119,7 @@ public class RoutingFixtureTest {
     long timeoutInMillis = TextManager.parseTimespanString(job.routerSettings.jobTimeoutString) * 1000;
 
     while ((job.state != RoutingJobState.COMPLETED) && (job.state != RoutingJobState.CANCELLED)
-        && (job.state != RoutingJobState.TERMINATED)) {
+        && (job.state != RoutingJobState.TERMINATED) && (job.state != RoutingJobState.TIMED_OUT)) {
       try {
         Thread.sleep(100);
       } catch (InterruptedException e) {
@@ -129,6 +128,14 @@ public class RoutingFixtureTest {
 
       // Check for timeout every iteration
       if (System.currentTimeMillis() - startTime > timeoutInMillis) {
+        // Request that the router stops cleanly before propagating the timeout.
+        // Without this, the routing thread keeps running and starves subsequent tests.
+        if (job.thread != null) {
+          job.thread.requestStop();
+        }
+        if (job.state == RoutingJobState.RUNNING) {
+          job.state = RoutingJobState.TIMED_OUT;
+        }
         float timeoutInMinutes = timeoutInMillis / 60000.0f;
         throw new RuntimeException("Routing job timed out after " + timeoutInMinutes + " minutes.");
       }

--- a/src/test/java/app/freerouting/logger/AllowErrorLogs.java
+++ b/src/test/java/app/freerouting/logger/AllowErrorLogs.java
@@ -1,0 +1,44 @@
+package app.freerouting.logger;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Opts a test method or test class out of the {@link ErrorLogFailExtension} check.
+ *
+ * <p>Apply this annotation when a test intentionally exercises code paths that produce
+ * {@link LogEntryType#Error}-level log entries and the test is specifically verifying
+ * that error-handling behaviour. In all other cases the extension will automatically
+ * fail the test if any error-level entries appear in {@link FRLogger}'s log during the
+ * test lifecycle.
+ *
+ * <p>Example — opting a single method out:
+ * <pre>{@code
+ * @Test
+ * @AllowErrorLogs("intentionally triggers a parse error to verify recovery behaviour")
+ * void myTest() { ... }
+ * }</pre>
+ *
+ * <p>Example — opting an entire class out (all methods inherit the exemption):
+ * <pre>{@code
+ * @AllowErrorLogs("all methods in this class exercise error-handling paths")
+ * class MyErrorHandlingTest { ... }
+ * }</pre>
+ */
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface AllowErrorLogs {
+
+  /**
+   * A mandatory human-readable justification explaining why error-level log output is
+   * acceptable for this test or class. This is surfaced in CI output so reviewers can
+   * quickly understand the exemption without reading the full test.
+   */
+  String value();
+}

--- a/src/test/java/app/freerouting/logger/ErrorLogFailExtension.java
+++ b/src/test/java/app/freerouting/logger/ErrorLogFailExtension.java
@@ -1,0 +1,129 @@
+package app.freerouting.logger;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+
+/**
+ * JUnit 5 extension that fails any test which produces one or more {@link LogEntryType#Error}
+ * -level entries in {@link FRLogger} during its execution.
+ *
+ * <h2>Rationale</h2>
+ * The application uses {@link FRLogger#error} for conditions that should never occur under
+ * correct operation (e.g. failed trace normalisation, unexpected null board state, internal
+ * algorithm invariant violations). Silently passing a test that triggers such conditions masks
+ * regressions and hides latent bugs. This extension makes the contract explicit: a test that
+ * produces an error log is a failing test.
+ *
+ * <h2>Scope</h2>
+ * The check covers the full JUnit lifecycle of each test method:
+ * <ol>
+ *   <li>Extension {@code beforeEach} starts — start-time anchor is recorded</li>
+ *   <li>Test class {@code @BeforeEach} methods run</li>
+ *   <li>Test method body executes</li>
+ *   <li>Test class {@code @AfterEach} methods run</li>
+ *   <li>Extension {@code afterEach} fires — any error entries since step 1 cause failure</li>
+ * </ol>
+ *
+ * <h2>Opt-out</h2>
+ * Tests that intentionally exercise error-producing code paths should be annotated with
+ * {@link AllowErrorLogs}.  The annotation can be placed on a method or on the whole class
+ * (inherited by all methods in that class).
+ *
+ * <h2>Auto-registration</h2>
+ * This extension is globally registered via the JUnit 5 service-loader mechanism
+ * ({@code META-INF/services/org.junit.jupiter.api.extension.Extension}) together with
+ * {@code junit.jupiter.extensions.autodetection.enabled=true} in
+ * {@code junit-platform.properties}. No {@code @ExtendWith} annotation is required on
+ * individual test classes.
+ */
+public class ErrorLogFailExtension implements BeforeEachCallback, AfterEachCallback {
+
+  private static final Namespace NAMESPACE = Namespace.create(ErrorLogFailExtension.class);
+  private static final String START_INSTANT_KEY = "startInstant";
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    getStore(context).put(START_INSTANT_KEY, Instant.now());
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    // Honour explicit opt-outs at the method or class level.
+    if (isExempt(context)) {
+      return;
+    }
+
+    Instant startInstant = getStore(context).get(START_INSTANT_KEY, Instant.class);
+    if (startInstant == null) {
+      return; // beforeEach did not run — nothing to check
+    }
+
+    LogEntry[] errorEntries = Arrays
+        .stream(FRLogger.getLogEntries().getEntries(startInstant, null))
+        .filter(e -> e.getType() == LogEntryType.Error)
+        .toArray(LogEntry[]::new);
+
+    if (errorEntries.length == 0) {
+      return;
+    }
+
+    String errorDetails = Arrays
+        .stream(errorEntries)
+        .map(ErrorLogFailExtension::formatEntry)
+        .collect(Collectors.joining("\n\n"));
+
+    org.junit.jupiter.api.Assertions.fail(
+        errorEntries.length + " error-level log entry(ies) were produced during this test — "
+            + "tests must not produce ERROR logs. "
+            + "If this error is intentional, annotate the test with @AllowErrorLogs.\n\n"
+            + errorDetails);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static Store getStore(ExtensionContext context) {
+    return context.getStore(NAMESPACE);
+  }
+
+  /**
+   * Returns {@code true} when the test method or its enclosing class carries
+   * {@link AllowErrorLogs}.
+   */
+  private static boolean isExempt(ExtensionContext context) {
+    // Check method-level annotation first, then class-level.
+    return context.getTestMethod()
+               .map(m -> m.isAnnotationPresent(AllowErrorLogs.class))
+               .orElse(false)
+        || context.getTestClass()
+               .map(c -> c.isAnnotationPresent(AllowErrorLogs.class))
+               .orElse(false);
+  }
+
+  /**
+   * Formats a single error entry for inclusion in the JUnit failure message.
+   * Includes the stack trace of the attached exception when present.
+   */
+  private static String formatEntry(LogEntry entry) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("  [ERROR] ").append(entry.getMessage());
+
+    Throwable ex = entry.getException();
+    if (ex != null) {
+      StringWriter sw = new StringWriter();
+      ex.printStackTrace(new PrintWriter(sw));
+      sb.append("\n  Caused by: ").append(sw.toString().stripTrailing());
+    }
+
+    return sb.toString();
+  }
+}

--- a/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+app.freerouting.logger.ErrorLogFailExtension

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+# Enable JUnit 5 service-loader auto-detection of extensions registered in
+# META-INF/services/org.junit.jupiter.api.extension.Extension.
+# This is how ErrorLogFailExtension is globally applied to every test without
+# requiring @ExtendWith on individual test classes.
+junit.jupiter.extensions.autodetection.enabled=true


### PR DESCRIPTION
This pull request introduces several improvements focused on test reliability, error visibility, and robustness in both the autorouter and board normalization logic. The most notable changes are the global enforcement of error log checks in tests, new safety mechanisms to prevent infinite loops in board normalization, enhancements to test isolation, and improved error reporting.

**Test reliability and error visibility:**

* Introduced a new JUnit 5 extension (`ErrorLogFailExtension`) that automatically fails any test which produces error-level log entries in `FRLogger`, unless the test or class is explicitly annotated with the new `@AllowErrorLogs` annotation and a justification. This extension is globally applied to all tests via the service loader mechanism and `junit-platform.properties`, ensuring that error conditions are not silently ignored in CI. [[1]](diffhunk://#diff-3c484f3d74cccbabc7e2e29fd911bdf27cd357085a98d519f920720fbb171e46R1-R129) [[2]](diffhunk://#diff-9fcc90b74bec76fb2718c2c7d0da81843a68c6048275042fe6cc3db13764d5f3R1-R44) [[3]](diffhunk://#diff-382a05c2515f9ae2627ba1acc605e53288bfe8246cd54e076e390d725ae0d89eR1) [[4]](diffhunk://#diff-221cee5785a2cae438d3555419974cdcf208058dc2a48e3cb6399ea18b1a7f8aR1-R5)

**Board normalization and autorouter robustness:**

* Added a maximum iteration limit (`MAX_NORMALIZE_ITERATIONS`) to the `normalize_traces` method in `BasicBoard` to prevent infinite split/combine oscillations that could otherwise hang the board-load thread. If this limit is exceeded, a warning is logged and normalization stops for that net.
* Improved the `combine_at_start` method in `PolylineTrace` to check for the presence of search tree entries before using the optimized merge path, preventing possible `NullPointerException`s.
* Modified autorouter logic so that hitting the `maxItems` limit now stops the entire routing process (including the optimizer phase) immediately, ensuring test/debug runs terminate promptly as intended.
* Enhanced stagnation reporting in the batch autorouter to accurately report the number of incomplete connections at the time the best score was achieved, rather than at the end of routing. [[1]](diffhunk://#diff-3a6425ca35e8c140d2e54efa24e274b065cde12c9f4445a91b46f139700c3e3dR708) [[2]](diffhunk://#diff-3a6425ca35e8c140d2e54efa24e274b065cde12c9f4445a91b46f139700c3e3dR883-R891)

**Test isolation and stability:**

* Ensured that static logging flags (e.g., `FRLogger.granularTraceEnabled`) are reset before each test in `RoutingFixtureTest` to avoid cross-test contamination. Also, made sure that routing jobs are cleanly stopped and their state is set to `TIMED_OUT` when a timeout occurs, preventing lingering threads from affecting subsequent tests. [[1]](diffhunk://#diff-ef5f9e8a6378a9baad9e72358ae41e8a1b12e4787342fddc981fbdd2493387f2L7-L14) [[2]](diffhunk://#diff-ef5f9e8a6378a9baad9e72358ae41e8a1b12e4787342fddc981fbdd2493387f2R33-R35) [[3]](diffhunk://#diff-ef5f9e8a6378a9baad9e72358ae41e8a1b12e4787342fddc981fbdd2493387f2L123-R122) [[4]](diffhunk://#diff-ef5f9e8a6378a9baad9e72358ae41e8a1b12e4787342fddc981fbdd2493387f2R131-R138)

**Minor improvements:**

* Added a getter for the exception attached to a `LogEntry`, enabling better error reporting in test failures.