### PR TITLE
Ensure version starts with 'v' in VersionChecker

### DIFF
--- a/src/main/java/app/freerouting/management/VersionChecker.java
+++ b/src/main/java/app/freerouting/management/VersionChecker.java
@@ -9,46 +9,102 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 /**
- * A class to check for new versions of the application.
+ * VersionChecker retrieves the latest release information from GitHub in the background
+ * and logs a message if a newer version of the application is available.
  */
 public class VersionChecker implements Runnable {
 
   private static final String GITHUB_RELEASES_URL = "https://api.github.com/repos/freerouting/freerouting/releases/latest";
-  private static String CURRENT_VERSION = "v1.0";  // replace with your current version
+  
+  private final String currentVersion;
+  private final HttpClient httpClient;
 
+  /**
+   * Constructs a new VersionChecker with the specified current version and the default HttpClient.
+   *
+   * @param version the current version of the application (e.g. "1.2.3" or "v1.2.3")
+   */
   public VersionChecker(String version) {
-    if (version.startsWith("v")) {
-      CURRENT_VERSION = version;
+    this(version, HttpClient.newHttpClient());
+  }
+
+  /**
+   * Package-private constructor for dependency injection during testing.
+   *
+   * @param version the current version of the application (e.g. "1.2.3" or "v1.2.3")
+   * @param httpClient the HttpClient to use for making requests
+   */
+  VersionChecker(String version, HttpClient httpClient) {
+    if (version == null || version.isBlank()) {
+      this.currentVersion = "v0.0.0";
+    } else if (version.startsWith("v") || version.startsWith("V")) {
+      this.currentVersion = "v" + version.substring(1);
     } else {
-      CURRENT_VERSION = "v" + version;
+      this.currentVersion = "v" + version;
     }
+    this.httpClient = httpClient;
+  }
+
+  /**
+   * Gets the normalized current version (always starts with 'v').
+   *
+   * @return the normalized current version string
+   */
+  public String getCurrentVersion() {
+    return currentVersion;
   }
 
   @Override
   public void run() {
-    // Fix if sometime network broken, then throw original exception message
     try {
-      HttpClient client = HttpClient.newHttpClient();
-      HttpRequest request = HttpRequest.newBuilder().uri(URI.create(GITHUB_RELEASES_URL)).build();
+      HttpRequest request = HttpRequest.newBuilder()
+          .uri(URI.create(GITHUB_RELEASES_URL))
+          .header("User-Agent", "Freerouting-Version-Checker")
+          .build();
 
-      client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply(HttpResponse::body).thenAccept(this::processResponse).exceptionally(e ->
-      {
-        FRLogger.warn("Failed to check for new version");
-        return null;
-      });
-    } catch (Exception e) { 
-      FRLogger.warn("Failed to check for new version");
+      httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+          .thenApply(HttpResponse::body)
+          .thenAccept(this::processResponse)
+          .exceptionally(e -> {
+            FRLogger.warn("Failed to check for new version: " + e.getMessage());
+            return null;
+          });
+    } catch (Exception e) {
+      FRLogger.warn("Failed to initiate version check: " + e.getMessage());
     }
   }
 
-  private void processResponse(String responseBody) {
-    JsonObject json = JsonParser.parseString(responseBody).getAsJsonObject();
-    String latestVersion = json.get("tag_name").getAsString();
+  /**
+   * Processes the JSON response body from the GitHub releases API.
+   *
+   * @param responseBody the raw response body string
+   */
+  void processResponse(String responseBody) {
+    if (responseBody == null || responseBody.isBlank()) {
+      FRLogger.warn("Received empty response body during version check.");
+      return;
+    }
+    try {
+      JsonObject json = JsonParser.parseString(responseBody).getAsJsonObject();
+      if (json.has("tag_name")) {
+        String latestVersion = json.get("tag_name").getAsString();
+        
+        String cleanCurrent = currentVersion.substring(1); // currentVersion always starts with 'v'
+        String cleanLatest = latestVersion.startsWith("v") || latestVersion.startsWith("V")
+            ? latestVersion.substring(1)
+            : latestVersion;
 
-    if (!CURRENT_VERSION.equals(latestVersion)) {
-      FRLogger.info("New version available: " + latestVersion);
-    } else {
-      FRLogger.debug("No new version available.");
+        if (!cleanCurrent.equalsIgnoreCase(cleanLatest)) {
+          FRLogger.info("New version available: " + latestVersion);
+        } else {
+          FRLogger.debug("No new version available. Current version is up to date: " + currentVersion);
+        }
+      } else {
+        FRLogger.warn("GitHub release response does not contain 'tag_name': " + responseBody);
+      }
+    } catch (Exception e) {
+      FRLogger.warn("Failed to parse version check response: " + e.getMessage());
     }
   }
 }
+

--- a/src/main/java/app/freerouting/management/VersionChecker.java
+++ b/src/main/java/app/freerouting/management/VersionChecker.java
@@ -17,7 +17,11 @@ public class VersionChecker implements Runnable {
   private static String CURRENT_VERSION = "v1.0";  // replace with your current version
 
   public VersionChecker(String version) {
-    CURRENT_VERSION = version;
+    if (version.startsWith("v")) {
+      CURRENT_VERSION = version;
+    } else {
+      CURRENT_VERSION = "v" + version;
+    }
   }
 
   @Override

--- a/src/test/java/app/freerouting/management/VersionCheckerTest.java
+++ b/src/test/java/app/freerouting/management/VersionCheckerTest.java
@@ -1,0 +1,69 @@
+package app.freerouting.management;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.net.http.HttpClient;
+import org.junit.jupiter.api.Test;
+
+class VersionCheckerTest {
+
+  @Test
+  void testConstructorVersionNormalization() {
+    // Test case: starts with "v"
+    VersionChecker v1 = new VersionChecker("v1.2.3");
+    assertEquals("v1.2.3", v1.getCurrentVersion());
+
+    // Test case: starts with "V"
+    VersionChecker v2 = new VersionChecker("V1.2.3");
+    assertEquals("v1.2.3", v2.getCurrentVersion());
+
+    // Test case: does not start with "v" or "V"
+    VersionChecker v3 = new VersionChecker("1.2.3");
+    assertEquals("v1.2.3", v3.getCurrentVersion());
+
+    // Test case: null version input
+    VersionChecker v4 = new VersionChecker(null);
+    assertEquals("v0.0.0", v4.getCurrentVersion());
+
+    // Test case: empty/blank version input
+    VersionChecker v5 = new VersionChecker("   ");
+    assertEquals("v0.0.0", v5.getCurrentVersion());
+  }
+
+  @Test
+  void testProcessResponseWithVariousVersionFormats() {
+    HttpClient mockClient = mock(HttpClient.class);
+    
+    // Equal versions (matching tag_name)
+    VersionChecker checker1 = new VersionChecker("1.2.3", mockClient);
+    checker1.processResponse("{\"tag_name\":\"v1.2.3\"}"); // should log "No new version available"
+    
+    // Equal versions (both starting with v)
+    VersionChecker checker2 = new VersionChecker("v1.2.3", mockClient);
+    checker2.processResponse("{\"tag_name\":\"v1.2.3\"}");
+
+    // Equal versions (GitHub tag has no 'v', constructor has 'v')
+    VersionChecker checker3 = new VersionChecker("v1.2.3", mockClient);
+    checker3.processResponse("{\"tag_name\":\"1.2.3\"}");
+
+    // Equal versions (GitHub tag has 'v', constructor has no 'v')
+    VersionChecker checker4 = new VersionChecker("1.2.3", mockClient);
+    checker4.processResponse("{\"tag_name\":\"v1.2.3\"}");
+
+    // Different versions (GitHub tag newer)
+    VersionChecker checker5 = new VersionChecker("1.2.3", mockClient);
+    checker5.processResponse("{\"tag_name\":\"v1.2.4\"}"); // should log "New version available"
+  }
+
+  @Test
+  void testProcessResponseMalformedJson() {
+    HttpClient mockClient = mock(HttpClient.class);
+    VersionChecker checker = new VersionChecker("1.2.3", mockClient);
+    // Should handle malformed JSON and null/empty input without throwing exceptions
+    checker.processResponse(null);
+    checker.processResponse("");
+    checker.processResponse("{invalid-json}");
+    checker.processResponse("{}");
+  }
+}


### PR DESCRIPTION
This fixes a bug with version checker, since currently it fed strings of the form '1.2.3' and compares them against strings of the form 'v1.2.3' which always results in a mismatch.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary