### PR TITLE
Layers active/routable toggle fix in GUI mode

### DIFF
--- a/docs/command_line_arguments.md
+++ b/docs/command_line_arguments.md
@@ -217,6 +217,26 @@ FREEROUTING__API_SERVER__ENDPOINTS=http://0.0.0.0:37864,http://127.0.0.1:37864
 
 > **Note:** Commas are the chosen delimiter because URL characters that would normally include a comma are percent-encoded by browsers/tools, so plain commas in the string unambiguously mark element boundaries.
 
+### Layer-specific settings (Arrays)
+
+Settings for individual board layers can be specified as a comma-separated list of values, where each value corresponds to a layer in order (from the top-most layer to the bottom-most):
+
+- **`--router.layers.routable=false,true`**: Sets which layers are active/routable (e.g. `false,true` disables layer 1 and enables layer 2).
+- **`--router.layers.preferred_direction_horizontal=true,false`**: Sets if the preferred direction on each layer is horizontal (`true`) or vertical (`false`).
+
+For example, to route a board using only the second (bottom) layer:
+
+```bash
+java -jar freerouting-2.2.2.jar -de MyBoard.dsn -do MyBoard.ses --router.layers.routable=false,true
+```
+
+The equivalent environment-variable syntax is:
+
+```bash
+FREEROUTING__ROUTER__LAYERS__ROUTABLE=false,true
+FREEROUTING__ROUTER__LAYERS__PREFERRED_DIRECTION_HORIZONTAL=true,false
+```
+
 ### API Server Settings
 
 | Setting | Type | Description |

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -130,6 +130,9 @@ The primary way to configure Freerouting is through a JSON settings file. This f
 - **`plane_via_costs`**: Cost factor for using vias on plane layers.
 - **`start_ripup_costs`**: Cost factor for ripping up existing traces.
 - **`automatic_neckdown`**: Enables or disables automatic neckdown of traces.
+- **`layers`**: An array of layer-specific settings (transient, typically set via CLI or loaded from board files). Each element contains:
+    - **`routable`**: Boolean indicating if the layer is active/routable by the autorouter.
+    - **`preferred_direction_horizontal`**: Boolean indicating if the preferred direction on this layer is horizontal.
 
 #### **`usage_and_diagnostic_data` Section**
 

--- a/fixtures/Issue689-BBD_Mars-64.dsn
+++ b/fixtures/Issue689-BBD_Mars-64.dsn
@@ -1,0 +1,1078 @@
+(pcb Issue593-BBD_Mars-64.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0.1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer B.Cu
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (path pcb 0  101600 -144780  55880 -144780  55880 -43180  101600 -43180
+            101600 -144780)
+    )
+    (via "Via[0-1]_800:400_um")
+    (rule
+      (width 250)
+      (clearance 200)
+      (clearance 50 (type smd_smd))
+    )
+  )
+  (placement
+    (component "Mars-64:BBD_Logo_33x33mm"
+      (place G*** 78740.000000 -60960.000000 front 0.000000 (PN LOGO))
+    )
+    (component "Mars-64:PinHeader_2x06_P2.54mm_Vertical_SMD_TopBottom_Mirrored"
+      (place PmodM 93980.000000 -53340.000000 back 180.000000 (PN Conn_02x06_Top_Bottom))
+    )
+    (component "Mars-64:PinHeader_2x06_P2.54mm_Vertical_SMD_TopBottom"
+      (place PmodF 68580.000000 -53340.000000 back 180.000000 (PN Conn_02x06_Top_Bottom))
+    )
+    (component TestPoint:TestPoint_Pad_4.0x4.0mm
+      (place TP101 60960.000000 -83820.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP103 71120.000000 -83820.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP105 81280.000000 -83820.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP106 86360.000000 -83820.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP107 91440.000000 -83820.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP109 60960.000000 -88900.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP111 71120.000000 -88900.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP113 81280.000000 -88900.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP117 60960.000000 -93980.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP119 71120.000000 -93980.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP121 81280.000000 -93980.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP123 91440.000000 -93980.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP125 60960.000000 -99060.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP127 71120.000000 -99060.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP129 81280.000000 -99060.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP131 91440.000000 -99060.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP201 60960.000000 -104140.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP203 71120.000000 -104140.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP205 81280.000000 -104140.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP209 60960.000000 -109220.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP211 71120.000000 -109220.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP213 81280.000000 -109220.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP215 91440.000000 -109220.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP216 96520.000000 -109220.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP218 66040.000000 -114300.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP220 76200.000000 -114300.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP222 86360.000000 -114300.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP224 96520.000000 -114300.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP226 66040.000000 -119380.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP228 76200.000000 -119380.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP230 86360.000000 -119380.000000 front 0.000000 (PN TestPoint_Small))
+    )
+    (component TestPoint:TestPoint_Pad_4.0x4.0mm::1
+      (place TP102 66040.000000 -83820.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP104 76200.000000 -83820.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP108 96520.000000 -83820.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP110 66040.000000 -88900.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP112 76200.000000 -88900.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP114 86360.000000 -88900.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP115 91440.000000 -88900.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP116 96520.000000 -88900.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP118 66040.000000 -93980.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP120 76200.000000 -93980.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP122 86360.000000 -93980.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP124 96520.000000 -93980.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP126 66040.000000 -99060.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP128 76200.000000 -99060.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP130 86360.000000 -99060.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP132 96520.000000 -99060.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP202 66040.000000 -104140.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP204 76200.000000 -104140.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP206 86360.000000 -104140.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP207 91440.000000 -104140.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP208 96520.000000 -104140.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP210 66040.000000 -109220.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP212 76200.000000 -109220.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP214 86360.000000 -109220.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP217 60960.000000 -114300.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP219 71120.000000 -114300.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP221 81280.000000 -114300.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP223 91440.000000 -114300.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP225 60960.000000 -119380.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP227 71120.000000 -119380.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP229 81280.000000 -119380.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP231 91440.000000 -119380.000000 front 0.000000 (PN TestPoint_Small))
+      (place TP232 96520.000000 -119380.000000 front 0.000000 (PN TestPoint_Small))
+    )
+    (component "Connector_Coaxial:SMA_Amphenol_132134-10_Vertical"
+      (place JA 93980.000000 -76200.000000 back 180.000000 (PN Conn_Coaxial))
+    )
+    (component "Connector_Coaxial:SMA_Amphenol_132134-10_Vertical::1"
+      (place JB 93980.000000 -137160.000000 back 180.000000 (PN Conn_Coaxial))
+    )
+    (component TestPoint:TestPoint_Pad_1.0x1.0mm
+      (place TPAGND1 64770.000000 -76200.000000 back 180.000000 (PN TestPoint_Small))
+    )
+    (component "Jumper:SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm_NumberLabels"
+      (place JP4 63500.000000 -73660.000000 back 0.000000 (PN Jumper_NC_Dual))
+    )
+    (component "Package_QFP:TQFP-48_7x7mm_P0.5mm"
+      (place U101 78740.000000 -68580.000000 back 0.000000 (PN ADG731))
+    )
+    (component "Package_QFP:TQFP-48_7x7mm_P0.5mm::1"
+      (place U102 76200.000000 -137160.000000 back 0.000000 (PN ADG731))
+    )
+    (component "Jumper:SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm"
+      (place JP5 60960.000000 -134620.000000 back 180.000000 (PN SolderJumper_2_Bridged))
+    )
+    (component Capacitor_SMD:C_1206_3216Metric_Pad1.42x1.75mm_HandSolder
+      (place C1 64770.000000 -64770.000000 back 180.000000 (PN "100 nF"))
+    )
+    (component Capacitor_SMD:C_1206_3216Metric_Pad1.42x1.75mm_HandSolder::1
+      (place C2 60960.000000 -139700.000000 back 180.000000 (PN "100 nF"))
+    )
+    (component MountingHole:MountingHole_2.7mm_M2.5
+      (place H1 59690.000000 -68580.000000 front 0.000000 (PN MountingHole))
+      (place H4 97790.000000 -127000.000000 front 0.000000 (PN MountingHole))
+    )
+    (component MountingHole:MountingHole_2.7mm_M2.5::1
+      (place H2 97790.000000 -68580.000000 front 0.000000 (PN MountingHole))
+      (place H3 59690.000000 -127000.000000 front 0.000000 (PN MountingHole))
+    )
+  )
+  (library
+    (image "Mars-64:BBD_Logo_33x33mm"
+    )
+    (image "Mars-64:PinHeader_2x06_P2.54mm_Vertical_SMD_TopBottom_Mirrored"
+      (outline (path signal 50  -5900 8150  5900 8150))
+      (outline (path signal 50  -5900 -8150  -5900 8150))
+      (outline (path signal 50  5900 -8150  -5900 -8150))
+      (outline (path signal 50  5900 8150  5900 -8150))
+      (outline (path signal 120  -2600 -4570  -2600 -5590))
+      (outline (path signal 120  2600 -4570  2600 -5590))
+      (outline (path signal 120  -2600 -2030  -2600 -3050))
+      (outline (path signal 120  2600 -2030  2600 -3050))
+      (outline (path signal 120  -2600 510  -2600 -510))
+      (outline (path signal 120  2600 510  2600 -510))
+      (outline (path signal 120  -2600 3050  -2600 2030))
+      (outline (path signal 120  2600 3050  2600 2030))
+      (outline (path signal 120  -2600 5590  -2600 4570))
+      (outline (path signal 120  2600 5590  2600 4570))
+      (outline (path signal 120  -2600 -7110  -2600 -7680))
+      (outline (path signal 120  2600 -7110  2600 -7680))
+      (outline (path signal 120  -2600 7680  -2600 7110))
+      (outline (path signal 120  2600 7680  2600 7110))
+      (outline (path signal 120  4040 7110  2600 7110))
+      (outline (path signal 120  2600 -7680  -2600 -7680))
+      (outline (path signal 120  2600 7680  -2600 7680))
+      (outline (path signal 100  -3600 -6670  -2540 -6670))
+      (outline (path signal 100  -3600 -6030  -3600 -6670))
+      (outline (path signal 100  -2540 -6030  -3600 -6030))
+      (outline (path signal 100  3600 -6670  2540 -6670))
+      (outline (path signal 100  3600 -6030  3600 -6670))
+      (outline (path signal 100  2540 -6030  3600 -6030))
+      (outline (path signal 100  -3600 -4130  -2540 -4130))
+      (outline (path signal 100  -3600 -3490  -3600 -4130))
+      (outline (path signal 100  -2540 -3490  -3600 -3490))
+      (outline (path signal 100  3600 -4130  2540 -4130))
+      (outline (path signal 100  3600 -3490  3600 -4130))
+      (outline (path signal 100  2540 -3490  3600 -3490))
+      (outline (path signal 100  -3600 -1590  -2540 -1590))
+      (outline (path signal 100  -3600 -950  -3600 -1590))
+      (outline (path signal 100  -2540 -950  -3600 -950))
+      (outline (path signal 100  3600 -1590  2540 -1590))
+      (outline (path signal 100  3600 -950  3600 -1590))
+      (outline (path signal 100  2540 -950  3600 -950))
+      (outline (path signal 100  -3600 950  -2540 950))
+      (outline (path signal 100  -3600 1590  -3600 950))
+      (outline (path signal 100  -2540 1590  -3600 1590))
+      (outline (path signal 100  3600 950  2540 950))
+      (outline (path signal 100  3600 1590  3600 950))
+      (outline (path signal 100  2540 1590  3600 1590))
+      (outline (path signal 100  -3600 3490  -2540 3490))
+      (outline (path signal 100  -3600 4130  -3600 3490))
+      (outline (path signal 100  -2540 4130  -3600 4130))
+      (outline (path signal 100  3600 3490  2540 3490))
+      (outline (path signal 100  3600 4130  3600 3490))
+      (outline (path signal 100  2540 4130  3600 4130))
+      (outline (path signal 100  -3600 6030  -2540 6030))
+      (outline (path signal 100  -3600 6670  -3600 6030))
+      (outline (path signal 100  -2540 6670  -3600 6670))
+      (outline (path signal 100  3600 6030  2540 6030))
+      (outline (path signal 100  3600 6670  3600 6030))
+      (outline (path signal 100  2540 6670  3600 6670))
+      (outline (path signal 100  -2540 7620  -2540 -7620))
+      (outline (path signal 100  2540 6670  1590 7620))
+      (outline (path signal 100  2540 -7620  2540 6670))
+      (outline (path signal 100  1590 7620  -2540 7620))
+      (outline (path signal 100  -2540 -7620  2540 -7620))
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 12 -2525 -6350)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 6 2525 -6350)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 11 -2525 -3810)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 5 2525 -3810)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 10 -2525 -1270)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 4 2525 -1270)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 9 -2525 1270)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 3 2525 1270)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 8 -2525 3810)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 2 2525 3810)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 7 -2525 6350)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 1 2525 6350)
+    )
+    (image "Mars-64:PinHeader_2x06_P2.54mm_Vertical_SMD_TopBottom"
+      (outline (path signal 50  5900 8150  -5900 8150))
+      (outline (path signal 50  5900 -8150  5900 8150))
+      (outline (path signal 50  -5900 -8150  5900 -8150))
+      (outline (path signal 50  -5900 8150  -5900 -8150))
+      (outline (path signal 120  2600 -4570  2600 -5590))
+      (outline (path signal 120  -2600 -4570  -2600 -5590))
+      (outline (path signal 120  2600 -2030  2600 -3050))
+      (outline (path signal 120  -2600 -2030  -2600 -3050))
+      (outline (path signal 120  2600 510  2600 -510))
+      (outline (path signal 120  -2600 510  -2600 -510))
+      (outline (path signal 120  2600 3050  2600 2030))
+      (outline (path signal 120  -2600 3050  -2600 2030))
+      (outline (path signal 120  2600 5590  2600 4570))
+      (outline (path signal 120  -2600 5590  -2600 4570))
+      (outline (path signal 120  2600 -7110  2600 -7680))
+      (outline (path signal 120  -2600 -7110  -2600 -7680))
+      (outline (path signal 120  2600 7680  2600 7110))
+      (outline (path signal 120  -2600 7680  -2600 7110))
+      (outline (path signal 120  -4040 7110  -2600 7110))
+      (outline (path signal 120  -2600 -7680  2600 -7680))
+      (outline (path signal 120  -2600 7680  2600 7680))
+      (outline (path signal 100  3600 -6670  2540 -6670))
+      (outline (path signal 100  3600 -6030  3600 -6670))
+      (outline (path signal 100  2540 -6030  3600 -6030))
+      (outline (path signal 100  -3600 -6670  -2540 -6670))
+      (outline (path signal 100  -3600 -6030  -3600 -6670))
+      (outline (path signal 100  -2540 -6030  -3600 -6030))
+      (outline (path signal 100  3600 -4130  2540 -4130))
+      (outline (path signal 100  3600 -3490  3600 -4130))
+      (outline (path signal 100  2540 -3490  3600 -3490))
+      (outline (path signal 100  -3600 -4130  -2540 -4130))
+      (outline (path signal 100  -3600 -3490  -3600 -4130))
+      (outline (path signal 100  -2540 -3490  -3600 -3490))
+      (outline (path signal 100  3600 -1590  2540 -1590))
+      (outline (path signal 100  3600 -950  3600 -1590))
+      (outline (path signal 100  2540 -950  3600 -950))
+      (outline (path signal 100  -3600 -1590  -2540 -1590))
+      (outline (path signal 100  -3600 -950  -3600 -1590))
+      (outline (path signal 100  -2540 -950  -3600 -950))
+      (outline (path signal 100  3600 950  2540 950))
+      (outline (path signal 100  3600 1590  3600 950))
+      (outline (path signal 100  2540 1590  3600 1590))
+      (outline (path signal 100  -3600 950  -2540 950))
+      (outline (path signal 100  -3600 1590  -3600 950))
+      (outline (path signal 100  -2540 1590  -3600 1590))
+      (outline (path signal 100  3600 3490  2540 3490))
+      (outline (path signal 100  3600 4130  3600 3490))
+      (outline (path signal 100  2540 4130  3600 4130))
+      (outline (path signal 100  -3600 3490  -2540 3490))
+      (outline (path signal 100  -3600 4130  -3600 3490))
+      (outline (path signal 100  -2540 4130  -3600 4130))
+      (outline (path signal 100  3600 6030  2540 6030))
+      (outline (path signal 100  3600 6670  3600 6030))
+      (outline (path signal 100  2540 6670  3600 6670))
+      (outline (path signal 100  -3600 6030  -2540 6030))
+      (outline (path signal 100  -3600 6670  -3600 6030))
+      (outline (path signal 100  -2540 6670  -3600 6670))
+      (outline (path signal 100  2540 7620  2540 -7620))
+      (outline (path signal 100  -2540 6670  -1590 7620))
+      (outline (path signal 100  -2540 -7620  -2540 6670))
+      (outline (path signal 100  -1590 7620  2540 7620))
+      (outline (path signal 100  2540 -7620  -2540 -7620))
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 12 2525 -6350)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 6 -2525 -6350)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 11 2525 -3810)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 5 -2525 -3810)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 10 2525 -1270)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 4 -2525 -1270)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 9 2525 1270)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 3 -2525 1270)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 8 2525 3810)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 2 -2525 3810)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 7 2525 6350)
+      (pin Rect[T]Pad_3150.000000x1000.000000_um 1 -2525 6350)
+    )
+    (image TestPoint:TestPoint_Pad_4.0x4.0mm
+      (outline (path signal 50  2500 -2500  -2500 -2500))
+      (outline (path signal 50  2500 -2500  2500 2500))
+      (outline (path signal 50  -2500 2500  -2500 -2500))
+      (outline (path signal 50  -2500 2500  2500 2500))
+      (outline (path signal 120  -2200 -2200  -2200 2200))
+      (outline (path signal 120  2200 -2200  -2200 -2200))
+      (outline (path signal 120  2200 2200  2200 -2200))
+      (outline (path signal 120  -2200 2200  2200 2200))
+      (pin Rect[T]Pad_4000.000000x4000.000000_um 1 0 0)
+    )
+    (image TestPoint:TestPoint_Pad_4.0x4.0mm::1
+      (outline (path signal 120  -2200 2200  2200 2200))
+      (outline (path signal 120  2200 2200  2200 -2200))
+      (outline (path signal 120  2200 -2200  -2200 -2200))
+      (outline (path signal 120  -2200 -2200  -2200 2200))
+      (outline (path signal 50  -2500 2500  2500 2500))
+      (outline (path signal 50  -2500 2500  -2500 -2500))
+      (outline (path signal 50  2500 -2500  2500 2500))
+      (outline (path signal 50  2500 -2500  -2500 -2500))
+      (pin Rect[T]Pad_4000.000000x4000.000000_um 1 0 0)
+    )
+    (image "Connector_Coaxial:SMA_Amphenol_132134-10_Vertical"
+      (outline (path signal 50  4060 -4060  -4060 -4060))
+      (outline (path signal 50  4060 -4060  4060 4060))
+      (outline (path signal 50  -4060 4060  -4060 -4060))
+      (outline (path signal 50  -4060 4060  4060 4060))
+      (outline (path signal 100  -3175 3175  3175 3175))
+      (outline (path signal 100  -3175 3175  -3175 -3175))
+      (outline (path signal 100  -3175 -3175  3175 -3175))
+      (outline (path signal 100  3175 3175  3175 -3175))
+      (outline (path signal 120  -3355 940  -3355 -940))
+      (outline (path signal 120  3355 940  3355 -940))
+      (outline (path signal 100  2040 0  2021 -277.78  1964.35 -550.385  1871.11 -812.738
+            1743.02 -1059.95  1582.45 -1287.42  1392.41 -1490.9  1176.43 -1666.62
+            938.533 -1811.29  683.154 -1922.21  415.05 -1997.33  139.215 -2035.24
+            -139.215 -2035.24  -415.05 -1997.33  -683.154 -1922.21  -938.533 -1811.29
+            -1176.43 -1666.62  -1392.41 -1490.9  -1582.45 -1287.42  -1743.02 -1059.95
+            -1871.11 -812.738  -1964.35 -550.385  -2021 -277.78  -2040 0
+            -2021 277.78  -1964.35 550.385  -1871.11 812.738  -1743.02 1059.95
+            -1582.45 1287.42  -1392.41 1490.9  -1176.43 1666.62  -938.533 1811.29
+            -683.154 1922.21  -415.05 1997.33  -139.215 2035.24  139.215 2035.24
+            415.05 1997.33  683.154 1922.21  938.533 1811.29  1176.43 1666.62
+            1392.41 1490.9  1582.45 1287.42  1743.02 1059.95  1871.11 812.738
+            1964.35 550.385  2021 277.78  2040 0))
+      (outline (path signal 100  3175 0  3155.73 -349.276  3098.15 -694.312  3002.97 -1030.92
+            2871.33 -1355.02  2704.84 -1662.66  2505.52 -1950.12  2275.78 -2213.92
+            2018.42 -2450.84  1736.56 -2658  1433.62 -2832.91  1113.27 -2973.42
+            779.416 -3077.85  436.098 -3144.91  87.485 -3173.79  -262.189 -3164.16
+            -608.681 -3116.11  -947.785 -3030.24  -1275.38 -2907.58  -1587.5 -2749.63
+            -1880.35 -2558.3  -2150.37 -2335.92  -2394.29 -2085.19  -2609.14 -1809.14
+            -2792.33 -1511.13  -2941.62 -1194.78  -3055.2 -863.929  -3131.7 -522.588
+            -3170.18 -174.904  -3170.18 174.904  -3131.7 522.588  -3055.2 863.929
+            -2941.62 1194.78  -2792.33 1511.13  -2609.14 1809.14  -2394.29 2085.19
+            -2150.37 2335.92  -1880.35 2558.3  -1587.5 2749.63  -1275.38 2907.58
+            -947.785 3030.24  -608.681 3116.11  -262.189 3164.16  87.485 3173.79
+            436.098 3144.91  779.416 3077.85  1113.27 2973.42  1433.62 2832.91
+            1736.56 2658  2018.42 2450.84  2275.78 2213.92  2505.52 1950.12
+            2704.84 1662.66  2871.33 1355.02  3002.97 1030.92  3098.15 694.312
+            3155.73 349.276  3175 0))
+      (pin Round[T]Pad_1730.000000_um (rotate 90) 1 0 0)
+      (pin Cust[T]Pad_7110.000000x1510.000000_7110.000000x2350.000000_5_um_1C9E99E145CF7AC3E371EC2D0369E43E 2 0 -2800)
+      (pin Cust[T]Pad_7110.000000x1510.000000_7110.000000x2350.000000_5_um_1C9E99E145CF7AC3E371EC2D0369E43E (rotate 180) 2@1 0 2800)
+    )
+    (image "Connector_Coaxial:SMA_Amphenol_132134-10_Vertical::1"
+      (outline (path signal 100  3175 0  3155.73 -349.276  3098.15 -694.312  3002.97 -1030.92
+            2871.33 -1355.02  2704.84 -1662.66  2505.52 -1950.12  2275.78 -2213.92
+            2018.42 -2450.84  1736.56 -2658  1433.62 -2832.91  1113.27 -2973.42
+            779.416 -3077.85  436.098 -3144.91  87.485 -3173.79  -262.189 -3164.16
+            -608.681 -3116.11  -947.785 -3030.24  -1275.38 -2907.58  -1587.5 -2749.63
+            -1880.35 -2558.3  -2150.37 -2335.92  -2394.29 -2085.19  -2609.14 -1809.14
+            -2792.33 -1511.13  -2941.62 -1194.78  -3055.2 -863.929  -3131.7 -522.588
+            -3170.18 -174.904  -3170.18 174.904  -3131.7 522.588  -3055.2 863.929
+            -2941.62 1194.78  -2792.33 1511.13  -2609.14 1809.14  -2394.29 2085.19
+            -2150.37 2335.92  -1880.35 2558.3  -1587.5 2749.63  -1275.38 2907.58
+            -947.785 3030.24  -608.681 3116.11  -262.189 3164.16  87.485 3173.79
+            436.098 3144.91  779.416 3077.85  1113.27 2973.42  1433.62 2832.91
+            1736.56 2658  2018.42 2450.84  2275.78 2213.92  2505.52 1950.12
+            2704.84 1662.66  2871.33 1355.02  3002.97 1030.92  3098.15 694.312
+            3155.73 349.276  3175 0))
+      (outline (path signal 100  2040 0  2021 -277.78  1964.35 -550.385  1871.11 -812.738
+            1743.02 -1059.95  1582.45 -1287.42  1392.41 -1490.9  1176.43 -1666.62
+            938.533 -1811.29  683.154 -1922.21  415.05 -1997.33  139.215 -2035.24
+            -139.215 -2035.24  -415.05 -1997.33  -683.154 -1922.21  -938.533 -1811.29
+            -1176.43 -1666.62  -1392.41 -1490.9  -1582.45 -1287.42  -1743.02 -1059.95
+            -1871.11 -812.738  -1964.35 -550.385  -2021 -277.78  -2040 0
+            -2021 277.78  -1964.35 550.385  -1871.11 812.738  -1743.02 1059.95
+            -1582.45 1287.42  -1392.41 1490.9  -1176.43 1666.62  -938.533 1811.29
+            -683.154 1922.21  -415.05 1997.33  -139.215 2035.24  139.215 2035.24
+            415.05 1997.33  683.154 1922.21  938.533 1811.29  1176.43 1666.62
+            1392.41 1490.9  1582.45 1287.42  1743.02 1059.95  1871.11 812.738
+            1964.35 550.385  2021 277.78  2040 0))
+      (outline (path signal 120  3355 940  3355 -940))
+      (outline (path signal 120  -3355 940  -3355 -940))
+      (outline (path signal 100  3175 3175  3175 -3175))
+      (outline (path signal 100  -3175 -3175  3175 -3175))
+      (outline (path signal 100  -3175 3175  -3175 -3175))
+      (outline (path signal 100  -3175 3175  3175 3175))
+      (outline (path signal 50  -4060 4060  4060 4060))
+      (outline (path signal 50  -4060 4060  -4060 -4060))
+      (outline (path signal 50  4060 -4060  4060 4060))
+      (outline (path signal 50  4060 -4060  -4060 -4060))
+      (pin Cust[T]Pad_7110.000000x1510.000000_7110.000000x2350.000000_5_um_1C9E99E145CF7AC3E371EC2D0369E43E (rotate 180) 2 0 2800)
+      (pin Cust[T]Pad_7110.000000x1510.000000_7110.000000x2350.000000_5_um_1C9E99E145CF7AC3E371EC2D0369E43E 2@1 0 -2800)
+      (pin Round[T]Pad_1730.000000_um (rotate 90) 1 0 0)
+    )
+    (image TestPoint:TestPoint_Pad_1.0x1.0mm
+      (outline (path signal 120  -700 700  700 700))
+      (outline (path signal 120  700 700  700 -700))
+      (outline (path signal 120  700 -700  -700 -700))
+      (outline (path signal 120  -700 -700  -700 700))
+      (outline (path signal 50  -1000 1000  1000 1000))
+      (outline (path signal 50  -1000 1000  -1000 -1000))
+      (outline (path signal 50  1000 -1000  1000 1000))
+      (outline (path signal 50  1000 -1000  -1000 -1000))
+      (pin Rect[T]Pad_1000.000000x1000.000000_um 1 0 0)
+    )
+    (image "Jumper:SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm_NumberLabels"
+      (outline (path signal 120  -2050 -1000  -2050 1000))
+      (outline (path signal 120  2050 -1000  -2050 -1000))
+      (outline (path signal 120  2050 1000  2050 -1000))
+      (outline (path signal 120  -2050 1000  2050 1000))
+      (outline (path signal 50  -2300 1250  2300 1250))
+      (outline (path signal 50  -2300 1250  -2300 -1250))
+      (outline (path signal 50  2300 -1250  2300 1250))
+      (outline (path signal 50  2300 -1250  -2300 -1250))
+      (pin Rect[T]Pad_1000.000000x1500.000000_um 1 -1300 0)
+      (pin Rect[T]Pad_1000.000000x1500.000000_um 3 1300 0)
+      (pin Rect[T]Pad_1000.000000x1500.000000_um 2 0 0)
+    )
+    (image "Package_QFP:TQFP-48_7x7mm_P0.5mm"
+      (outline (path signal 150  -2500 3500  3500 3500))
+      (outline (path signal 150  3500 3500  3500 -3500))
+      (outline (path signal 150  3500 -3500  -3500 -3500))
+      (outline (path signal 150  -3500 -3500  -3500 2500))
+      (outline (path signal 150  -3500 2500  -2500 3500))
+      (outline (path signal 50  -5250 5250  -5250 -5250))
+      (outline (path signal 50  5250 5250  5250 -5250))
+      (outline (path signal 50  -5250 5250  5250 5250))
+      (outline (path signal 50  -5250 -5250  5250 -5250))
+      (outline (path signal 150  -3625 3625  -3625 3200))
+      (outline (path signal 150  3625 3625  3625 3100))
+      (outline (path signal 150  3625 -3625  3625 -3100))
+      (outline (path signal 150  -3625 -3625  -3625 -3100))
+      (outline (path signal 150  -3625 3625  -3100 3625))
+      (outline (path signal 150  -3625 -3625  -3100 -3625))
+      (outline (path signal 150  3625 -3625  3100 -3625))
+      (outline (path signal 150  3625 3625  3100 3625))
+      (outline (path signal 150  -3625 3200  -5000 3200))
+      (pin Rect[T]Pad_1300.000000x250.000000_um 1 -4350 2750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 2 -4350 2250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 3 -4350 1750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 4 -4350 1250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 5 -4350 750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 6 -4350 250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 7 -4350 -250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 8 -4350 -750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 9 -4350 -1250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 10 -4350 -1750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 11 -4350 -2250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 12 -4350 -2750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 13 -2750 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 14 -2250 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 15 -1750 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 16 -1250 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 17 -750 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 18 -250 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 19 250 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 20 750 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 21 1250 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 22 1750 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 23 2250 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 24 2750 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 25 4350 -2750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 26 4350 -2250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 27 4350 -1750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 28 4350 -1250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 29 4350 -750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 30 4350 -250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 31 4350 250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 32 4350 750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 33 4350 1250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 34 4350 1750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 35 4350 2250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 36 4350 2750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 37 2750 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 38 2250 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 39 1750 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 40 1250 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 41 750 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 42 250 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 43 -250 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 44 -750 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 45 -1250 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 46 -1750 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 47 -2250 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 48 -2750 4350)
+    )
+    (image "Package_QFP:TQFP-48_7x7mm_P0.5mm::1"
+      (outline (path signal 150  -3625 3200  -5000 3200))
+      (outline (path signal 150  3625 3625  3100 3625))
+      (outline (path signal 150  3625 -3625  3100 -3625))
+      (outline (path signal 150  -3625 -3625  -3100 -3625))
+      (outline (path signal 150  -3625 3625  -3100 3625))
+      (outline (path signal 150  -3625 -3625  -3625 -3100))
+      (outline (path signal 150  3625 -3625  3625 -3100))
+      (outline (path signal 150  3625 3625  3625 3100))
+      (outline (path signal 150  -3625 3625  -3625 3200))
+      (outline (path signal 50  -5250 -5250  5250 -5250))
+      (outline (path signal 50  -5250 5250  5250 5250))
+      (outline (path signal 50  5250 5250  5250 -5250))
+      (outline (path signal 50  -5250 5250  -5250 -5250))
+      (outline (path signal 150  -3500 2500  -2500 3500))
+      (outline (path signal 150  -3500 -3500  -3500 2500))
+      (outline (path signal 150  3500 -3500  -3500 -3500))
+      (outline (path signal 150  3500 3500  3500 -3500))
+      (outline (path signal 150  -2500 3500  3500 3500))
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 48 -2750 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 47 -2250 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 46 -1750 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 45 -1250 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 44 -750 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 43 -250 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 42 250 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 41 750 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 40 1250 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 39 1750 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 38 2250 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 37 2750 4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 36 4350 2750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 35 4350 2250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 34 4350 1750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 33 4350 1250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 32 4350 750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 31 4350 250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 30 4350 -250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 29 4350 -750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 28 4350 -1250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 27 4350 -1750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 26 4350 -2250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 25 4350 -2750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 24 2750 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 23 2250 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 22 1750 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 21 1250 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 20 750 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 19 250 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 18 -250 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 17 -750 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 16 -1250 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 15 -1750 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 14 -2250 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um (rotate 90) 13 -2750 -4350)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 12 -4350 -2750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 11 -4350 -2250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 10 -4350 -1750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 9 -4350 -1250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 8 -4350 -750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 7 -4350 -250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 6 -4350 250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 5 -4350 750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 4 -4350 1250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 3 -4350 1750)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 2 -4350 2250)
+      (pin Rect[T]Pad_1300.000000x250.000000_um 1 -4350 2750)
+    )
+    (image "Jumper:SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm"
+      (outline (path signal 0  848.269 1045.4  990.839 1002.15  1122.23 931.917  1237.4 837.401
+            1331.92 722.233  1402.15 590.839  1445.4 448.269  1460 300  1455.43 300
+            1455.43 277.039  1422.96 244.567  1377.04 244.567  1344.57 277.039
+            1344.57 300  1340 300  1323.95 442.413  1276.62 577.686  1200.37 699.033
+            1099.03 800.372  977.686 876.62  842.413 923.954  700 940  700 944.567
+            677.039 944.567  644.567 977.039  644.567 1022.96  677.039 1055.43
+            700 1055.43  700 1060))
+      (outline (path signal 0  1455.43 -277.039  1455.43 -300  1460 -300  1445.4 -448.269
+            1402.15 -590.839  1331.92 -722.233  1237.4 -837.401  1122.23 -931.917
+            990.839 -1002.15  848.269 -1045.4  700 -1060  700 -1055.43  677.039 -1055.43
+            644.567 -1022.96  644.567 -977.039  677.039 -944.567  700 -944.567
+            700 -940  842.413 -923.954  977.686 -876.62  1099.03 -800.372
+            1200.37 -699.033  1276.62 -577.686  1323.95 -442.413  1340 -300
+            1344.57 -300  1344.57 -277.039  1377.04 -244.567  1422.96 -244.567))
+      (outline (path signal 0  -1344.57 -277.039  -1344.57 -300  -1340 -300  -1323.95 -442.413
+            -1276.62 -577.686  -1200.37 -699.033  -1099.03 -800.372  -977.686 -876.62
+            -842.413 -923.954  -700 -940  -700 -944.567  -677.039 -944.567
+            -644.567 -977.039  -644.567 -1022.96  -677.039 -1055.43  -700 -1055.43
+            -700 -1060  -848.269 -1045.4  -990.839 -1002.15  -1122.23 -931.917
+            -1237.4 -837.401  -1331.92 -722.233  -1402.15 -590.839  -1445.4 -448.269
+            -1460 -300  -1455.43 -300  -1455.43 -277.039  -1422.96 -244.567
+            -1377.04 -244.567))
+      (outline (path signal 0  -700 1055.43  -677.039 1055.43  -644.567 1022.96  -644.567 977.039
+            -677.039 944.567  -700 944.567  -700 940  -842.413 923.954  -977.686 876.62
+            -1099.03 800.372  -1200.37 699.033  -1276.62 577.686  -1323.95 442.413
+            -1340 300  -1344.57 300  -1344.57 277.039  -1377.04 244.567
+            -1422.96 244.567  -1455.43 277.039  -1455.43 300  -1460 300
+            -1445.4 448.269  -1402.15 590.839  -1331.92 722.233  -1237.4 837.401
+            -1122.23 931.917  -990.839 1002.15  -848.269 1045.4  -700 1060))
+      (outline (path signal 120  -1400 -300  -1400 300))
+      (outline (path signal 120  700 -1000  -700 -1000))
+      (outline (path signal 120  1400 300  1400 -300))
+      (outline (path signal 120  -700 1000  700 1000))
+      (outline (path signal 50  -1650 1250  1650 1250))
+      (outline (path signal 50  -1650 1250  -1650 -1250))
+      (outline (path signal 50  1650 -1250  1650 1250))
+      (outline (path signal 50  1650 -1250  -1650 -1250))
+      (pin Cust[T]Pad_1000.000000x500.000000_1000.000000x1500.000000_19_um_86772D42E08000F807F2952CF30D331A 2 650 0)
+      (pin Cust[T]Pad_1000.000000x500.000000_1000.000000x1500.000000_19_um_BD66147BA5415864FF86D5BB75C674D5 1 -650 0)
+    )
+    (image Capacitor_SMD:C_1206_3216Metric_Pad1.42x1.75mm_HandSolder
+      (outline (path signal 100  -1600 -800  -1600 800))
+      (outline (path signal 100  -1600 800  1600 800))
+      (outline (path signal 100  1600 800  1600 -800))
+      (outline (path signal 100  1600 -800  -1600 -800))
+      (outline (path signal 120  -602.064 910  602.064 910))
+      (outline (path signal 120  -602.064 -910  602.064 -910))
+      (outline (path signal 50  -2450 -1120  -2450 1120))
+      (outline (path signal 50  -2450 1120  2450 1120))
+      (outline (path signal 50  2450 1120  2450 -1120))
+      (outline (path signal 50  2450 -1120  -2450 -1120))
+      (pin RoundRect[T]Pad_1425.000000x1750.000000_250.952000_um_0.000000_0 1 -1487.5 0)
+      (pin RoundRect[T]Pad_1425.000000x1750.000000_250.952000_um_0.000000_0 2 1487.5 0)
+    )
+    (image Capacitor_SMD:C_1206_3216Metric_Pad1.42x1.75mm_HandSolder::1
+      (outline (path signal 50  2450 -1120  -2450 -1120))
+      (outline (path signal 50  2450 1120  2450 -1120))
+      (outline (path signal 50  -2450 1120  2450 1120))
+      (outline (path signal 50  -2450 -1120  -2450 1120))
+      (outline (path signal 120  -602.064 -910  602.064 -910))
+      (outline (path signal 120  -602.064 910  602.064 910))
+      (outline (path signal 100  1600 -800  -1600 -800))
+      (outline (path signal 100  1600 800  1600 -800))
+      (outline (path signal 100  -1600 800  1600 800))
+      (outline (path signal 100  -1600 -800  -1600 800))
+      (pin RoundRect[T]Pad_1425.000000x1750.000000_250.952000_um_0.000000_0 2 1487.5 0)
+      (pin RoundRect[T]Pad_1425.000000x1750.000000_250.952000_um_0.000000_0 1 -1487.5 0)
+    )
+    (image MountingHole:MountingHole_2.7mm_M2.5
+      (outline (path signal 150  2700 0  2681.05 -319.338  2624.46 -634.192  2531.03 -940.144
+            2402.07 -1232.9  2239.39 -1508.35  2045.28 -1762.62  1822.45 -1992.15
+            1574.05 -2193.72  1303.54 -2364.48  1014.73 -2502.06  711.685 -2604.52
+            398.646 -2670.41  80.01 -2698.81  -239.749 -2689.34  -556.142 -2642.1
+            -864.729 -2557.78  -1161.18 -2437.55  -1441.32 -2283.11  -1701.24 -2096.61
+            -1937.27 -1880.69  -2146.11 -1638.36  -2324.82 -1373.03  -2470.89 -1088.43
+            -2582.28 -788.553  -2657.42 -477.604  -2695.26 -159.95  -2695.26 159.95
+            -2657.42 477.604  -2582.28 788.553  -2470.89 1088.43  -2324.82 1373.03
+            -2146.11 1638.36  -1937.27 1880.69  -1701.24 2096.61  -1441.32 2283.11
+            -1161.18 2437.55  -864.729 2557.78  -556.142 2642.1  -239.749 2689.34
+            80.01 2698.81  398.646 2670.41  711.685 2604.52  1014.73 2502.06
+            1303.54 2364.48  1574.05 2193.72  1822.45 1992.15  2045.28 1762.62
+            2239.39 1508.35  2402.07 1232.9  2531.03 940.144  2624.46 634.192
+            2681.05 319.338  2700 0))
+      (outline (path signal 50  2950 0  2930.77 -336.275  2873.34 -668.165  2778.44 -991.346
+            2647.32 -1301.6  2481.7 -1594.89  2283.72 -1867.39  2055.97 -2115.54
+            1801.41 -2336.11  1523.37 -2526.23  1225.47 -2683.41  911.6 -2805.62
+            585.842 -2891.24  252.446 -2939.18  -84.24 -2948.8  -419.829 -2919.97
+            -749.944 -2853.08  -1070.28 -2749  -1376.67 -2609.08  -1665.11 -2435.14
+            -1931.84 -2229.46  -2173.39 -1994.72  -2386.6 -1733.97  -2568.7 -1450.61
+            -2717.32 -1148.35  -2830.5 -831.111  -2906.79 -503.04  -2945.19 -168.412
+            -2945.19 168.412  -2906.79 503.04  -2830.5 831.111  -2717.32 1148.35
+            -2568.7 1450.61  -2386.6 1733.97  -2173.39 1994.72  -1931.84 2229.46
+            -1665.11 2435.14  -1376.67 2609.08  -1070.28 2749  -749.944 2853.08
+            -419.829 2919.97  -84.24 2948.8  252.446 2939.18  585.842 2891.24
+            911.6 2805.62  1225.47 2683.41  1523.37 2526.23  1801.41 2336.11
+            2055.97 2115.54  2283.72 1867.39  2481.7 1594.89  2647.32 1301.6
+            2778.44 991.346  2873.34 668.165  2930.77 336.275  2950 0))
+      (keepout "" (circle F.Cu 3200))
+      (keepout "" (circle B.Cu 3200))
+    )
+    (image MountingHole:MountingHole_2.7mm_M2.5::1
+      (outline (path signal 50  2950 0  2930.77 -336.275  2873.34 -668.165  2778.44 -991.346
+            2647.32 -1301.6  2481.7 -1594.89  2283.72 -1867.39  2055.97 -2115.54
+            1801.41 -2336.11  1523.37 -2526.23  1225.47 -2683.41  911.6 -2805.62
+            585.842 -2891.24  252.446 -2939.18  -84.24 -2948.8  -419.829 -2919.97
+            -749.944 -2853.08  -1070.28 -2749  -1376.67 -2609.08  -1665.11 -2435.14
+            -1931.84 -2229.46  -2173.39 -1994.72  -2386.6 -1733.97  -2568.7 -1450.61
+            -2717.32 -1148.35  -2830.5 -831.111  -2906.79 -503.04  -2945.19 -168.412
+            -2945.19 168.412  -2906.79 503.04  -2830.5 831.111  -2717.32 1148.35
+            -2568.7 1450.61  -2386.6 1733.97  -2173.39 1994.72  -1931.84 2229.46
+            -1665.11 2435.14  -1376.67 2609.08  -1070.28 2749  -749.944 2853.08
+            -419.829 2919.97  -84.24 2948.8  252.446 2939.18  585.842 2891.24
+            911.6 2805.62  1225.47 2683.41  1523.37 2526.23  1801.41 2336.11
+            2055.97 2115.54  2283.72 1867.39  2481.7 1594.89  2647.32 1301.6
+            2778.44 991.346  2873.34 668.165  2930.77 336.275  2950 0))
+      (outline (path signal 150  2700 0  2681.05 -319.338  2624.46 -634.192  2531.03 -940.144
+            2402.07 -1232.9  2239.39 -1508.35  2045.28 -1762.62  1822.45 -1992.15
+            1574.05 -2193.72  1303.54 -2364.48  1014.73 -2502.06  711.685 -2604.52
+            398.646 -2670.41  80.01 -2698.81  -239.749 -2689.34  -556.142 -2642.1
+            -864.729 -2557.78  -1161.18 -2437.55  -1441.32 -2283.11  -1701.24 -2096.61
+            -1937.27 -1880.69  -2146.11 -1638.36  -2324.82 -1373.03  -2470.89 -1088.43
+            -2582.28 -788.553  -2657.42 -477.604  -2695.26 -159.95  -2695.26 159.95
+            -2657.42 477.604  -2582.28 788.553  -2470.89 1088.43  -2324.82 1373.03
+            -2146.11 1638.36  -1937.27 1880.69  -1701.24 2096.61  -1441.32 2283.11
+            -1161.18 2437.55  -864.729 2557.78  -556.142 2642.1  -239.749 2689.34
+            80.01 2698.81  398.646 2670.41  711.685 2604.52  1014.73 2502.06
+            1303.54 2364.48  1574.05 2193.72  1822.45 1992.15  2045.28 1762.62
+            2239.39 1508.35  2402.07 1232.9  2531.03 940.144  2624.46 634.192
+            2681.05 319.338  2700 0))
+      (keepout "" (circle F.Cu 3200))
+      (keepout "" (circle B.Cu 3200))
+    )
+    (padstack Round[T]Pad_1730.000000_um
+      (shape (circle F.Cu 1730))
+      (attach off)
+    )
+    (padstack Cust[T]Pad_7110.000000x1510.000000_7110.000000x2350.000000_5_um_1C9E99E145CF7AC3E371EC2D0369E43E
+      (shape (polygon F.Cu 0  -3555 1595  3555 1595  3555 -755  -3555 -755  -3555 1595))
+      (attach off)
+    )
+    (padstack Cust[T]Pad_1000.000000x500.000000_1000.000000x1500.000000_19_um_BD66147BA5415864FF86D5BB75C674D5
+      (shape (polygon F.Cu 0  -500 250  -495.722 315.263  -461.94 441.342  -396.677 554.381
+            -304.381 646.677  -191.342 711.94  -65.263 745.722  0 750  500 750
+            500 -750  0 -750  -65.263 -745.722  -191.342 -711.94  -304.381 -646.677
+            -396.677 -554.381  -461.94 -441.342  -495.722 -315.263  -500 -250
+            -500 250))
+      (attach off)
+    )
+    (padstack Cust[T]Pad_1000.000000x500.000000_1000.000000x1500.000000_19_um_86772D42E08000F807F2952CF30D331A
+      (shape (polygon F.Cu 0  -500 750  0 750  65.263 745.722  191.342 711.94  304.381 646.677
+            396.677 554.381  461.94 441.342  495.722 315.263  500 250  500 -250
+            495.722 -315.263  461.94 -441.342  396.677 -554.381  304.381 -646.677
+            191.342 -711.94  65.263 -745.722  0 -750  -500 -750  -500 750))
+      (attach off)
+    )
+    (padstack RoundRect[T]Pad_1425.000000x1750.000000_250.952000_um_0.000000_0
+      (shape (polygon F.Cu 0  -713.451 624.999  -694.348 721.034  -639.949 802.449  -558.534 856.848
+            -462.499 875.951  462.499 875.951  558.534 856.848  639.949 802.449
+            694.348 721.034  713.451 624.999  713.451 -624.999  694.348 -721.034
+            639.949 -802.449  558.534 -856.848  462.499 -875.951  -462.499 -875.951
+            -558.534 -856.848  -639.949 -802.449  -694.348 -721.034  -713.451 -624.999
+            -713.451 624.999))
+      (attach off)
+    )
+    (padstack Rect[T]Pad_3150.000000x1000.000000_um
+      (shape (rect F.Cu -1575 -500 1575 500))
+      (attach off)
+    )
+    (padstack Rect[T]Pad_4000.000000x4000.000000_um
+      (shape (rect F.Cu -2000 -2000 2000 2000))
+      (attach off)
+    )
+    (padstack Rect[T]Pad_1000.000000x1000.000000_um
+      (shape (rect F.Cu -500 -500 500 500))
+      (attach off)
+    )
+    (padstack Rect[T]Pad_1000.000000x1500.000000_um
+      (shape (rect F.Cu -500 -750 500 750))
+      (attach off)
+    )
+    (padstack Rect[T]Pad_1300.000000x250.000000_um
+      (shape (rect F.Cu -650 -125 650 125))
+      (attach off)
+    )
+    (padstack "Via[0-1]_800:400_um"
+      (shape (circle F.Cu 800))
+      (shape (circle B.Cu 800))
+      (attach off)
+    )
+  )
+  (network
+    (net "/~{SPI_CE}"
+      (pins PmodM-1 PmodF-1 U101-17 U102-17)
+    )
+    (net /SPI_MOSI
+      (pins PmodM-2 PmodF-2 U101-18 U102-18)
+    )
+    (net /SPI_CLK
+      (pins PmodM-4 PmodF-4 U101-19 U102-19)
+    )
+    (net GND
+      (pins PmodM-11 PmodM-5 PmodF-11 PmodF-5 JP4-3 U101-23 U102-23 JP5-1 C1-1 C2-1)
+    )
+    (net /VCC3V3
+      (pins PmodM-12 PmodM-6 PmodF-12 PmodF-6 U101-13 U101-14 U102-14 U102-13 C1-2
+        C2-2)
+    )
+    (net /AGND
+      (pins PmodM-8 PmodF-8 TPAGND1-1 JP4-1)
+    )
+    (net /DA
+      (pins PmodM-9 JA-1 U101-43)
+    )
+    (net /DB
+      (pins PmodM-10 JB-1 U102-43)
+    )
+    (net "Net-(TP101-Pad1)"
+      (pins TP101-1 U101-12)
+    )
+    (net "Net-(TP102-Pad1)"
+      (pins TP102-1 U101-11)
+    )
+    (net "Net-(TP103-Pad1)"
+      (pins TP103-1 U101-10)
+    )
+    (net "Net-(TP104-Pad1)"
+      (pins TP104-1 U101-9)
+    )
+    (net "Net-(TP105-Pad1)"
+      (pins TP105-1 U101-8)
+    )
+    (net "Net-(TP106-Pad1)"
+      (pins TP106-1 U101-7)
+    )
+    (net "Net-(TP107-Pad1)"
+      (pins TP107-1 U101-6)
+    )
+    (net "Net-(TP108-Pad1)"
+      (pins TP108-1 U101-5)
+    )
+    (net "Net-(TP109-Pad1)"
+      (pins TP109-1 U101-4)
+    )
+    (net "Net-(TP110-Pad1)"
+      (pins TP110-1 U101-3)
+    )
+    (net "Net-(TP111-Pad1)"
+      (pins TP111-1 U101-2)
+    )
+    (net "Net-(TP112-Pad1)"
+      (pins TP112-1 U101-1)
+    )
+    (net "Net-(TP113-Pad1)"
+      (pins TP113-1 U101-48)
+    )
+    (net "Net-(TP114-Pad1)"
+      (pins TP114-1 U101-47)
+    )
+    (net "Net-(TP115-Pad1)"
+      (pins TP115-1 U101-46)
+    )
+    (net "Net-(TP116-Pad1)"
+      (pins TP116-1 U101-45)
+    )
+    (net "Net-(TP117-Pad1)"
+      (pins TP117-1 U101-25)
+    )
+    (net "Net-(TP118-Pad1)"
+      (pins TP118-1 U101-26)
+    )
+    (net "Net-(TP119-Pad1)"
+      (pins TP119-1 U101-27)
+    )
+    (net "Net-(TP120-Pad1)"
+      (pins TP120-1 U101-28)
+    )
+    (net "Net-(TP121-Pad1)"
+      (pins TP121-1 U101-29)
+    )
+    (net "Net-(TP122-Pad1)"
+      (pins TP122-1 U101-30)
+    )
+    (net "Net-(TP123-Pad1)"
+      (pins TP123-1 U101-31)
+    )
+    (net "Net-(TP124-Pad1)"
+      (pins TP124-1 U101-32)
+    )
+    (net "Net-(TP125-Pad1)"
+      (pins TP125-1 U101-33)
+    )
+    (net "Net-(TP126-Pad1)"
+      (pins TP126-1 U101-34)
+    )
+    (net "Net-(TP127-Pad1)"
+      (pins TP127-1 U101-35)
+    )
+    (net "Net-(TP128-Pad1)"
+      (pins TP128-1 U101-36)
+    )
+    (net "Net-(TP129-Pad1)"
+      (pins TP129-1 U101-37)
+    )
+    (net "Net-(TP130-Pad1)"
+      (pins TP130-1 U101-38)
+    )
+    (net "Net-(TP131-Pad1)"
+      (pins TP131-1 U101-39)
+    )
+    (net "Net-(TP132-Pad1)"
+      (pins TP132-1 U101-40)
+    )
+    (net "Net-(TP201-Pad1)"
+      (pins TP201-1 U102-12)
+    )
+    (net "Net-(TP202-Pad1)"
+      (pins TP202-1 U102-11)
+    )
+    (net "Net-(TP203-Pad1)"
+      (pins TP203-1 U102-10)
+    )
+    (net "Net-(TP204-Pad1)"
+      (pins TP204-1 U102-9)
+    )
+    (net "Net-(TP205-Pad1)"
+      (pins TP205-1 U102-8)
+    )
+    (net "Net-(TP206-Pad1)"
+      (pins TP206-1 U102-7)
+    )
+    (net "Net-(TP207-Pad1)"
+      (pins TP207-1 U102-6)
+    )
+    (net "Net-(TP208-Pad1)"
+      (pins TP208-1 U102-5)
+    )
+    (net "Net-(TP209-Pad1)"
+      (pins TP209-1 U102-4)
+    )
+    (net "Net-(TP210-Pad1)"
+      (pins TP210-1 U102-3)
+    )
+    (net "Net-(TP211-Pad1)"
+      (pins TP211-1 U102-2)
+    )
+    (net "Net-(TP212-Pad1)"
+      (pins TP212-1 U102-1)
+    )
+    (net "Net-(TP213-Pad1)"
+      (pins TP213-1 U102-48)
+    )
+    (net "Net-(TP214-Pad1)"
+      (pins TP214-1 U102-47)
+    )
+    (net "Net-(TP215-Pad1)"
+      (pins TP215-1 U102-46)
+    )
+    (net "Net-(TP216-Pad1)"
+      (pins TP216-1 U102-45)
+    )
+    (net "Net-(TP217-Pad1)"
+      (pins TP217-1 U102-25)
+    )
+    (net "Net-(TP218-Pad1)"
+      (pins TP218-1 U102-26)
+    )
+    (net "Net-(TP219-Pad1)"
+      (pins TP219-1 U102-27)
+    )
+    (net "Net-(TP220-Pad1)"
+      (pins TP220-1 U102-28)
+    )
+    (net "Net-(TP221-Pad1)"
+      (pins TP221-1 U102-29)
+    )
+    (net "Net-(TP222-Pad1)"
+      (pins TP222-1 U102-30)
+    )
+    (net "Net-(TP223-Pad1)"
+      (pins TP223-1 U102-31)
+    )
+    (net "Net-(TP224-Pad1)"
+      (pins TP224-1 U102-32)
+    )
+    (net "Net-(TP225-Pad1)"
+      (pins TP225-1 U102-33)
+    )
+    (net "Net-(TP226-Pad1)"
+      (pins TP226-1 U102-34)
+    )
+    (net "Net-(TP227-Pad1)"
+      (pins TP227-1 U102-35)
+    )
+    (net "Net-(TP228-Pad1)"
+      (pins TP228-1 U102-36)
+    )
+    (net "Net-(TP229-Pad1)"
+      (pins TP229-1 U102-37)
+    )
+    (net "Net-(TP230-Pad1)"
+      (pins TP230-1 U102-38)
+    )
+    (net "Net-(TP231-Pad1)"
+      (pins TP231-1 U102-39)
+    )
+    (net "Net-(TP232-Pad1)"
+      (pins TP232-1 U102-40)
+    )
+    (net "Net-(J101-Pad2)"
+      (pins JA-2 JA-2@1 JB-2 JB-2@1 JP4-2)
+    )
+    (net /VSS
+      (pins PmodM-7 PmodF-7 U101-24 U102-24 JP5-2)
+    )
+    (net "Net-(PmodF2-Pad10)"
+      (pins PmodF-10)
+    )
+    (net "Net-(PmodF2-Pad9)"
+      (pins PmodF-9)
+    )
+    (net "Net-(PmodF2-Pad3)"
+      (pins PmodF-3)
+    )
+    (net "Net-(PmodM1-Pad3)"
+      (pins PmodM-3)
+    )
+    (net "Net-(U101-Pad15)"
+      (pins U101-15)
+    )
+    (net "Net-(U101-Pad16)"
+      (pins U101-16)
+    )
+    (net "Net-(U101-Pad20)"
+      (pins U101-20)
+    )
+    (net "Net-(U101-Pad21)"
+      (pins U101-21)
+    )
+    (net "Net-(U101-Pad22)"
+      (pins U101-22)
+    )
+    (net "Net-(U101-Pad41)"
+      (pins U101-41)
+    )
+    (net "Net-(U101-Pad42)"
+      (pins U101-42)
+    )
+    (net "Net-(U101-Pad44)"
+      (pins U101-44)
+    )
+    (net "Net-(U102-Pad44)"
+      (pins U102-44)
+    )
+    (net "Net-(U102-Pad42)"
+      (pins U102-42)
+    )
+    (net "Net-(U102-Pad41)"
+      (pins U102-41)
+    )
+    (net "Net-(U102-Pad22)"
+      (pins U102-22)
+    )
+    (net "Net-(U102-Pad21)"
+      (pins U102-21)
+    )
+    (net "Net-(U102-Pad20)"
+      (pins U102-20)
+    )
+    (net "Net-(U102-Pad16)"
+      (pins U102-16)
+    )
+    (net "Net-(U102-Pad15)"
+      (pins U102-15)
+    )
+    (class kicad_default /AGND /DA /DB /SPI_CLK /SPI_MOSI /VCC3V3 /VSS "/~{SPI_CE}"
+      GND "Net-(J101-Pad2)" "Net-(PmodF2-Pad10)" "Net-(PmodF2-Pad3)" "Net-(PmodF2-Pad9)"
+      "Net-(PmodM1-Pad3)" "Net-(TP101-Pad1)" "Net-(TP102-Pad1)" "Net-(TP103-Pad1)"
+      "Net-(TP104-Pad1)" "Net-(TP105-Pad1)" "Net-(TP106-Pad1)" "Net-(TP107-Pad1)"
+      "Net-(TP108-Pad1)" "Net-(TP109-Pad1)" "Net-(TP110-Pad1)" "Net-(TP111-Pad1)"
+      "Net-(TP112-Pad1)" "Net-(TP113-Pad1)" "Net-(TP114-Pad1)" "Net-(TP115-Pad1)"
+      "Net-(TP116-Pad1)" "Net-(TP117-Pad1)" "Net-(TP118-Pad1)" "Net-(TP119-Pad1)"
+      "Net-(TP120-Pad1)" "Net-(TP121-Pad1)" "Net-(TP122-Pad1)" "Net-(TP123-Pad1)"
+      "Net-(TP124-Pad1)" "Net-(TP125-Pad1)" "Net-(TP126-Pad1)" "Net-(TP127-Pad1)"
+      "Net-(TP128-Pad1)" "Net-(TP129-Pad1)" "Net-(TP130-Pad1)" "Net-(TP131-Pad1)"
+      "Net-(TP132-Pad1)" "Net-(TP201-Pad1)" "Net-(TP202-Pad1)" "Net-(TP203-Pad1)"
+      "Net-(TP204-Pad1)" "Net-(TP205-Pad1)" "Net-(TP206-Pad1)" "Net-(TP207-Pad1)"
+      "Net-(TP208-Pad1)" "Net-(TP209-Pad1)" "Net-(TP210-Pad1)" "Net-(TP211-Pad1)"
+      "Net-(TP212-Pad1)" "Net-(TP213-Pad1)" "Net-(TP214-Pad1)" "Net-(TP215-Pad1)"
+      "Net-(TP216-Pad1)" "Net-(TP217-Pad1)" "Net-(TP218-Pad1)" "Net-(TP219-Pad1)"
+      "Net-(TP220-Pad1)" "Net-(TP221-Pad1)" "Net-(TP222-Pad1)" "Net-(TP223-Pad1)"
+      "Net-(TP224-Pad1)" "Net-(TP225-Pad1)" "Net-(TP226-Pad1)" "Net-(TP227-Pad1)"
+      "Net-(TP228-Pad1)" "Net-(TP229-Pad1)" "Net-(TP230-Pad1)" "Net-(TP231-Pad1)"
+      "Net-(TP232-Pad1)" "Net-(U101-Pad15)" "Net-(U101-Pad16)" "Net-(U101-Pad20)"
+      "Net-(U101-Pad21)" "Net-(U101-Pad22)" "Net-(U101-Pad41)" "Net-(U101-Pad42)"
+      "Net-(U101-Pad44)" "Net-(U102-Pad15)" "Net-(U102-Pad16)" "Net-(U102-Pad20)"
+      "Net-(U102-Pad21)" "Net-(U102-Pad22)" "Net-(U102-Pad41)" "Net-(U102-Pad42)"
+      "Net-(U102-Pad44)"
+      (circuit
+        (use_via "Via[0-1]_800:400_um")
+      )
+      (rule
+        (width 250)
+        (clearance 200)
+      )
+    )
+  )
+  (wiring
+  )
+)

--- a/fixtures/Issue689-BBD_Mars-64.dsn
+++ b/fixtures/Issue689-BBD_Mars-64.dsn
@@ -1,4 +1,4 @@
-(pcb Issue593-BBD_Mars-64.dsn
+(pcb Issue689-BBD_Mars-64.dsn
   (parser
     (string_quote ")
     (space_in_quoted_tokens on)

--- a/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
+++ b/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
@@ -748,6 +748,19 @@ public class BatchAutorouter extends NamedAlgorithm {
    * stopped by the user. Returns true if the board is completed.
    */
   public boolean runBatchLoop() {
+    boolean anyRoutable = false;
+    for (int i = 0; i < this.settings.getLayerCount(); i++) {
+      if (this.settings.get_layer_active(i)) {
+        anyRoutable = true;
+        break;
+      }
+    }
+    if (!anyRoutable) {
+      FRLogger.warn("Cannot start autorouter: all layers are disabled.");
+      this.fireTaskStateChangedEvent(new TaskStateChangedEvent(this, TaskState.CANCELLED, 0, this.board.get_hash()));
+      throw new IllegalArgumentException("Cannot start autorouter: all layers are disabled.");
+    }
+
     this.fireTaskStateChangedEvent(new TaskStateChangedEvent(this, TaskState.STARTED, 0, this.board.get_hash()));
 
     // Capture initial state for session summary
@@ -759,8 +772,8 @@ public class BatchAutorouter extends NamedAlgorithm {
     BoardHistory bh = new BoardHistory(job.routerSettings.scoring);
 
     // Record configuration for profiler
-    if (this.settings.isLayerActive != null) {
-      int layerCount = this.settings.isLayerActive.length;
+    if (this.settings.getLayerCount() > 0) {
+      int layerCount = this.settings.getLayerCount();
       double[] prefCosts = new double[layerCount];
       double[] againstCosts = new double[layerCount];
       for (int i = 0; i < layerCount; i++) {

--- a/src/main/java/app/freerouting/autoroute/BatchAutorouterV19.java
+++ b/src/main/java/app/freerouting/autoroute/BatchAutorouterV19.java
@@ -151,6 +151,19 @@ public class BatchAutorouterV19 extends NamedAlgorithm {
      * This is the main entry point, matching the current router's interface.
      */
     public boolean runBatchLoop() {
+        boolean anyRoutable = false;
+        for (int i = 0; i < this.settings.getLayerCount(); i++) {
+            if (this.settings.get_layer_active(i)) {
+                anyRoutable = true;
+                break;
+            }
+        }
+        if (!anyRoutable) {
+            FRLogger.warn("Cannot start autorouter: all layers are disabled.");
+            this.fireTaskStateChangedEvent(new TaskStateChangedEvent(this, TaskState.CANCELLED, 0, this.board.get_hash()));
+            throw new IllegalArgumentException("Cannot start autorouter: all layers are disabled.");
+        }
+
         this.fireTaskStateChangedEvent(new TaskStateChangedEvent(this, TaskState.STARTED, 0, this.board.get_hash()));
 
         // Capture initial state for session summary

--- a/src/main/java/app/freerouting/gui/BoardFrame.java
+++ b/src/main/java/app/freerouting/gui/BoardFrame.java
@@ -408,7 +408,7 @@ public class BoardFrame extends WindowBase {
       this.routingJob.setSettings(mergedSettings);
       var interactiveSettings = board_panel.board_handling.getInteractiveSettings();
       if (interactiveSettings != null) {
-        interactiveSettings.setSettings(mergedSettings);
+        interactiveSettings.setSettings(this.routingJob.routerSettings);
       }
     }
 
@@ -477,7 +477,7 @@ public class BoardFrame extends WindowBase {
           this.routingJob.setSettings(mergedSettings);
           var interactiveSettings = board_panel.board_handling.getInteractiveSettings();
           if (interactiveSettings != null) {
-            interactiveSettings.setSettings(mergedSettings);
+            interactiveSettings.setSettings(this.routingJob.routerSettings);
           }
         }
 

--- a/src/main/java/app/freerouting/gui/BoardFrame.java
+++ b/src/main/java/app/freerouting/gui/BoardFrame.java
@@ -456,8 +456,8 @@ public class BoardFrame extends WindowBase {
         RoutingBoard board = board_panel.board_handling.get_routing_board();
         int boardLayerCount = board.get_layer_count();
 
-        if (this.routingJob.routerSettings.isLayerActive == null ||
-            this.routingJob.routerSettings.isLayerActive.length != boardLayerCount) {
+        if (this.routingJob.routerSettings.getLayerCount() == 0 ||
+            this.routingJob.routerSettings.getLayerCount() != boardLayerCount) {
           // Initialize layer arrays and apply board-specific optimizations
           this.routingJob.routerSettings.setLayerCount(boardLayerCount);
           this.routingJob.routerSettings.applyBoardSpecificOptimizations(board);

--- a/src/main/java/app/freerouting/gui/BoardFrame.java
+++ b/src/main/java/app/freerouting/gui/BoardFrame.java
@@ -404,7 +404,12 @@ public class BoardFrame extends WindowBase {
     this.routingJob.routerSettings.applyBoardSpecificOptimizations(board);
 
     if (this.settingsMerger != null) {
-      this.routingJob.setSettings(this.settingsMerger.merge());
+      var mergedSettings = this.settingsMerger.merge();
+      this.routingJob.setSettings(mergedSettings);
+      var interactiveSettings = board_panel.board_handling.getInteractiveSettings();
+      if (interactiveSettings != null) {
+        interactiveSettings.setSettings(mergedSettings);
+      }
     }
 
     initialize_windows();
@@ -468,7 +473,12 @@ public class BoardFrame extends WindowBase {
         // tries to read fields like scoring.via_costs.  Without this step the windows would
         // NPE on the first access to any nullable RouterSettings field.
         if (this.settingsMerger != null) {
-          this.routingJob.setSettings(this.settingsMerger.merge());
+          var mergedSettings = this.settingsMerger.merge();
+          this.routingJob.setSettings(mergedSettings);
+          var interactiveSettings = board_panel.board_handling.getInteractiveSettings();
+          if (interactiveSettings != null) {
+            interactiveSettings.setSettings(mergedSettings);
+          }
         }
 
         initialize_windows();

--- a/src/main/java/app/freerouting/gui/BoardToolbar.java
+++ b/src/main/java/app/freerouting/gui/BoardToolbar.java
@@ -179,7 +179,7 @@ class BoardToolbar extends JPanel {
       }
       guiRoutingJob.routerSettings = board_frame.board_panel.board_handling.settingsMerger.merge();
       // The GUI-path settingsMerger does not include DsnFileSettings, so the merged
-      // RouterSettings has isLayerActive == null (layer count 0).  Re-apply board-
+      // RouterSettings has layers == null (layer count 0).  Re-apply board-
       // specific optimisations so the layer arrays are populated from the actual board
       // before the autorouter reads them (fixes Issue #676 / "get_layer_active out of
       // range [0..-1]" warnings and MazeSearchAlgo exceptions on LibrePCB DSN files).

--- a/src/main/java/app/freerouting/gui/BoardToolbar.java
+++ b/src/main/java/app/freerouting/gui/BoardToolbar.java
@@ -178,10 +178,10 @@ class BoardToolbar extends JPanel {
         return;
       }
       var mergedSettings = board_frame.board_panel.board_handling.settingsMerger.merge();
-      guiRoutingJob.routerSettings = mergedSettings;
+      guiRoutingJob.setSettings(mergedSettings);
       var interactiveSettings = board_frame.board_panel.board_handling.getInteractiveSettings();
       if (interactiveSettings != null) {
-        interactiveSettings.setSettings(mergedSettings);
+        interactiveSettings.setSettings(guiRoutingJob.routerSettings);
       }
       // The GUI-path settingsMerger does not include DsnFileSettings, so the merged
       // RouterSettings has layers == null (layer count 0).  Re-apply board-

--- a/src/main/java/app/freerouting/gui/BoardToolbar.java
+++ b/src/main/java/app/freerouting/gui/BoardToolbar.java
@@ -177,7 +177,12 @@ class BoardToolbar extends JPanel {
         FRLogger.warn(tm.getText("warn_no_input_file"));
         return;
       }
-      guiRoutingJob.routerSettings = board_frame.board_panel.board_handling.settingsMerger.merge();
+      var mergedSettings = board_frame.board_panel.board_handling.settingsMerger.merge();
+      guiRoutingJob.routerSettings = mergedSettings;
+      var interactiveSettings = board_frame.board_panel.board_handling.getInteractiveSettings();
+      if (interactiveSettings != null) {
+        interactiveSettings.setSettings(mergedSettings);
+      }
       // The GUI-path settingsMerger does not include DsnFileSettings, so the merged
       // RouterSettings has layers == null (layer count 0).  Re-apply board-
       // specific optimisations so the layer arrays are populated from the actual board

--- a/src/main/java/app/freerouting/gui/BoardToolbar.java
+++ b/src/main/java/app/freerouting/gui/BoardToolbar.java
@@ -177,11 +177,14 @@ class BoardToolbar extends JPanel {
         FRLogger.warn(tm.getText("warn_no_input_file"));
         return;
       }
-      var mergedSettings = board_frame.board_panel.board_handling.settingsMerger.merge();
-      guiRoutingJob.setSettings(mergedSettings);
-      var interactiveSettings = board_frame.board_panel.board_handling.getInteractiveSettings();
-      if (interactiveSettings != null) {
-        interactiveSettings.setSettings(guiRoutingJob.routerSettings);
+      var merger = board_frame.board_panel.board_handling.settingsMerger;
+      if (merger != null) {
+        var mergedSettings = merger.merge();
+        guiRoutingJob.setSettings(mergedSettings);
+        var interactiveSettings = board_frame.board_panel.board_handling.getInteractiveSettings();
+        if (interactiveSettings != null) {
+          interactiveSettings.setSettings(guiRoutingJob.routerSettings);
+        }
       }
       // The GUI-path settingsMerger does not include DsnFileSettings, so the merged
       // RouterSettings has layers == null (layer count 0).  Re-apply board-

--- a/src/main/java/app/freerouting/gui/WindowAutorouteParameter.java
+++ b/src/main/java/app/freerouting/gui/WindowAutorouteParameter.java
@@ -140,7 +140,6 @@ public class WindowAutorouteParameter extends BoardSavableSubWindow {
       settings_autorouter_layer_active_arr[i].addActionListener(new LayerActiveListener(i));
       settings_autorouter_layer_active_arr[i]
           .addActionListener(_ -> FRAnalytics.buttonClicked("settings_autorouter_layer_active_arr", null));
-      board_handling.getCurrentRoutingJob().routerSettings.set_layer_active(i, curr_layer.is_signal);
       settings_autorouter_layer_active_arr[i].setEnabled(curr_layer.is_signal);
       gridbag.setConstraints(settings_autorouter_layer_active_arr[i], gridbag_constraints);
       main_panel.add(settings_autorouter_layer_active_arr[i]);

--- a/src/main/java/app/freerouting/gui/WindowAutorouteParameter.java
+++ b/src/main/java/app/freerouting/gui/WindowAutorouteParameter.java
@@ -46,6 +46,7 @@ public class WindowAutorouteParameter extends BoardSavableSubWindow {
   private final List<JComboBox<String>> settings_autorouter_combo_box_arr;
   private final JCheckBox settings_autorouter_vias_allowed;
 
+  private final JCheckBox settings_autorouter_fanout_button;
   private final JCheckBox settings_autorouter_autoroute_pass_button;
   private final JCheckBox settings_autorouter_postroute_pass_button;
   private final String horizontal;
@@ -187,15 +188,21 @@ public class WindowAutorouteParameter extends BoardSavableSubWindow {
     JLabel passes_label = new JLabel(tm.getText("passes"));
 
     gridbag_constraints.gridwidth = 2;
-    gridbag_constraints.gridheight = 2;
+    gridbag_constraints.gridheight = 3;
     gridbag.setConstraints(passes_label, gridbag_constraints);
     main_panel.add(passes_label);
 
+    this.settings_autorouter_fanout_button = new JCheckBox(tm.getText("fanout"));
+    this.settings_autorouter_fanout_button.setToolTipText(tm.getText("fanout_tooltip"));
     this.settings_autorouter_autoroute_pass_button = new JCheckBox(tm.getText("autoroute"));
     this.settings_autorouter_autoroute_pass_button.setToolTipText(tm.getText("autoroute_tooltip"));
     this.settings_autorouter_postroute_pass_button = new JCheckBox(tm.getText("postroute"));
     this.settings_autorouter_postroute_pass_button.setToolTipText(tm.getText("postroute_tooltip"));
 
+    settings_autorouter_fanout_button.addActionListener(new FanoutListener());
+    settings_autorouter_fanout_button
+        .addActionListener(_ -> FRAnalytics.buttonClicked("settings_autorouter_fanout_button",
+            settings_autorouter_fanout_button.getText()));
     settings_autorouter_autoroute_pass_button.addActionListener(new AutorouteListener());
     settings_autorouter_autoroute_pass_button
         .addActionListener(_ -> FRAnalytics.buttonClicked("settings_autorouter_autoroute_pass_button",
@@ -205,12 +212,15 @@ public class WindowAutorouteParameter extends BoardSavableSubWindow {
         .addActionListener(_ -> FRAnalytics.buttonClicked("settings_autorouter_postroute_pass_button",
             settings_autorouter_postroute_pass_button.getText()));
 
+    settings_autorouter_fanout_button.setSelected(true);
     settings_autorouter_autoroute_pass_button.setSelected(true);
     settings_autorouter_postroute_pass_button.setSelected(false);
 
     gridbag_constraints.gridwidth = GridBagConstraints.REMAINDER;
     gridbag_constraints.gridheight = 1;
 
+    gridbag.setConstraints(settings_autorouter_fanout_button, gridbag_constraints);
+    main_panel.add(settings_autorouter_fanout_button, gridbag_constraints);
     gridbag.setConstraints(settings_autorouter_autoroute_pass_button, gridbag_constraints);
     main_panel.add(settings_autorouter_autoroute_pass_button, gridbag_constraints);
     gridbag.setConstraints(settings_autorouter_postroute_pass_button, gridbag_constraints);
@@ -495,6 +505,11 @@ public class WindowAutorouteParameter extends BoardSavableSubWindow {
             }
           }
           break;
+        case "fanout.enabled":
+          if (newValue instanceof Boolean) {
+            settings_autorouter_fanout_button.setSelected((Boolean) newValue);
+          }
+          break;
         case "optimizer.enabled":
           if (newValue instanceof Boolean) {
             settings_autorouter_postroute_pass_button.setSelected((Boolean) newValue);
@@ -515,6 +530,7 @@ public class WindowAutorouteParameter extends BoardSavableSubWindow {
     LayerStructure layer_structure = this.board_handling.get_routing_board().layer_structure;
 
     this.settings_autorouter_vias_allowed.setSelected(settings.get_vias_allowed());
+    this.settings_autorouter_fanout_button.setSelected(settings.getRunFanout());
     this.settings_autorouter_autoroute_pass_button.setSelected(settings.getRunRouter());
     this.settings_autorouter_postroute_pass_button.setSelected(settings.getRunOptimizer());
 
@@ -605,6 +621,10 @@ public class WindowAutorouteParameter extends BoardSavableSubWindow {
     settings.setViasAllowed(selected);
   }
 
+  static void applyFanoutEnabledSelection(RouterSettings settings, boolean selected) {
+    settings.setFanoutEnabled(selected);
+  }
+
   static void applyAutorouteEnabledSelection(RouterSettings settings, boolean selected) {
     settings.setEnabled(selected);
   }
@@ -659,6 +679,20 @@ public class WindowAutorouteParameter extends BoardSavableSubWindow {
       try {
         applyViasAllowedSelection(board_handling.getCurrentRoutingJob().routerSettings,
             settings_autorouter_vias_allowed.isSelected());
+      } finally {
+        isUpdatingFromSettings = false;
+      }
+    }
+  }
+
+  private class FanoutListener implements ActionListener {
+
+    @Override
+    public void actionPerformed(ActionEvent p_evt) {
+      RouterSettings autoroute_settings = board_handling.getCurrentRoutingJob().routerSettings;
+      isUpdatingFromSettings = true;
+      try {
+        applyFanoutEnabledSelection(autoroute_settings, settings_autorouter_fanout_button.isSelected());
       } finally {
         isUpdatingFromSettings = false;
       }

--- a/src/main/java/app/freerouting/interactive/GuiBoardManager.java
+++ b/src/main/java/app/freerouting/interactive/GuiBoardManager.java
@@ -1375,7 +1375,7 @@ public class GuiBoardManager extends HeadlessBoardManager {
         p_board_communication);
 
     // Reset and rebind the GUI-session singleton for the newly created board.
-    this.interactiveSettings = InteractiveSettings.reset(this.board);
+    this.interactiveSettings = InteractiveSettings.reset(this.board, this.routingJob.routerSettings);
     this.initialize_manual_trace_half_widths();
 
     // create the interactive/GUI settings with default values
@@ -2245,7 +2245,7 @@ public class GuiBoardManager extends HeadlessBoardManager {
     if (this.board != null) {
       // Always reset: a new DSN load may introduce a different layer count or design rules,
       // making any previously-constructed InteractiveSettings invalid for this board.
-      this.interactiveSettings = InteractiveSettings.reset(this.board);
+      this.interactiveSettings = InteractiveSettings.reset(this.board, this.routingJob.routerSettings);
       this.initialize_manual_trace_half_widths();
 
       // Register the singleton as the live GuiSettings source (priority 50) in the merger so
@@ -2281,7 +2281,7 @@ public class GuiBoardManager extends HeadlessBoardManager {
     if (this.board != null) {
       // Always reset: a new DSN load may introduce a different layer count or design rules,
       // making any previously-constructed InteractiveSettings invalid for this board.
-      this.interactiveSettings = InteractiveSettings.reset(this.board);
+      this.interactiveSettings = InteractiveSettings.reset(this.board, this.routingJob.routerSettings);
       this.initialize_manual_trace_half_widths();
 
       // Register the singleton as the live GuiSettings source (priority 50) in the merger so

--- a/src/main/java/app/freerouting/interactive/InteractiveSettings.java
+++ b/src/main/java/app/freerouting/interactive/InteractiveSettings.java
@@ -97,7 +97,7 @@ public class InteractiveSettings extends GuiSettings implements Serializable {
           instance = new InteractiveSettings(board, routerSettings);
         }
       }
-    } else {
+    } else if (routerSettings != null) {
       instance.setSettings(routerSettings);
     }
     return instance;
@@ -714,4 +714,3 @@ public class InteractiveSettings extends GuiSettings implements Serializable {
     this.read_only = false;
   }
 }
-

--- a/src/main/java/app/freerouting/interactive/InteractiveSettings.java
+++ b/src/main/java/app/freerouting/interactive/InteractiveSettings.java
@@ -341,9 +341,10 @@ public class InteractiveSettings extends GuiSettings implements Serializable {
   public RouterSettings getSettings() {
     RouterSettings baseSettings = super.getSettings();
     if (baseSettings != null) {
-      baseSettings.trace_pull_tight_accuracy = this.get_trace_pull_tight_accuracy();
-      baseSettings.automatic_neckdown = this.get_automatic_neckdown();
-      return baseSettings;
+      RouterSettings clone = baseSettings.clone();
+      clone.trace_pull_tight_accuracy = this.get_trace_pull_tight_accuracy();
+      clone.automatic_neckdown = this.get_automatic_neckdown();
+      return clone;
     }
     RouterSettings snapshot = new RouterSettings();
     snapshot.trace_pull_tight_accuracy = this.trace_pull_tight_accuracy;

--- a/src/main/java/app/freerouting/interactive/InteractiveSettings.java
+++ b/src/main/java/app/freerouting/interactive/InteractiveSettings.java
@@ -79,36 +79,62 @@ public class InteractiveSettings extends GuiSettings implements Serializable {
    * @param board the routing board to bind the settings to on first creation
    * @return the singleton {@link InteractiveSettings} instance
    */
-  public static InteractiveSettings getOrCreate(RoutingBoard board) {
+  /**
+   * Returns the singleton, creating it (bound to {@code board}) if not yet initialised.
+   *
+   * <p>In headless mode this method is never called; use
+   * {@link BoardManager#getInteractiveSettings()} to safely obtain the instance (returns
+   * {@code null} when headless).
+   *
+   * @param board the routing board to bind the settings to on first creation
+   * @param routerSettings the active job settings to bind to the GUI
+   * @return the singleton {@link InteractiveSettings} instance
+   */
+  public static InteractiveSettings getOrCreate(RoutingBoard board, RouterSettings routerSettings) {
     if (instance == null) {
       synchronized (InteractiveSettings.class) {
         if (instance == null) {
-          instance = new InteractiveSettings(board);
+          instance = new InteractiveSettings(board, routerSettings);
         }
       }
+    } else {
+      instance.setSettings(routerSettings);
     }
     return instance;
   }
 
   /**
+   * Returns the singleton, creating it (bound to {@code board}) if not yet initialised.
+   *
+   * @param board the routing board to bind the settings to on first creation
+   * @return the singleton {@link InteractiveSettings} instance
+   */
+  public static InteractiveSettings getOrCreate(RoutingBoard board) {
+    return getOrCreate(board, null);
+  }
+
+  /**
    * Discards the current singleton and creates a fresh one bound to {@code board}.
    *
-   * <p>Must be called whenever a new design is loaded into the GUI session (DSN or binary load),
-   * because the new board may have a different layer count, net list, or design rules than the
-   * previous one. An {@code InteractiveSettings} constructed for the old board is invalid for the
-   * new one.
-   *
-   * <p>After this call all {@code PropertyChangeListener} panels must be re-registered on the new
-   * instance. {@link GuiBoardManager#refreshGuiFromSettings()} is the canonical place to do this.
+   * @param board the newly loaded {@link RoutingBoard}; must not be {@code null}
+   * @param routerSettings the active job settings to bind to the GUI
+   * @return the new singleton instance
+   */
+  public static InteractiveSettings reset(RoutingBoard board, RouterSettings routerSettings) {
+    synchronized (InteractiveSettings.class) {
+      instance = new InteractiveSettings(board, routerSettings);
+      return instance;
+    }
+  }
+
+  /**
+   * Discards the current singleton and creates a fresh one bound to {@code board}.
    *
    * @param board the newly loaded {@link RoutingBoard}; must not be {@code null}
    * @return the new singleton instance
    */
   public static InteractiveSettings reset(RoutingBoard board) {
-    synchronized (InteractiveSettings.class) {
-      instance = new InteractiveSettings(board);
-      return instance;
-    }
+    return reset(board, null);
   }
 
   /**
@@ -261,6 +287,14 @@ public class InteractiveSettings extends GuiSettings implements Serializable {
   }
 
   /**
+   * Creates a new interactive settings variable bound to the active job settings.
+   */
+  public InteractiveSettings(RoutingBoard p_board, RouterSettings p_settings) {
+    this(p_board);
+    setSettings(p_settings);
+  }
+
+  /**
    * Copy constructor
    */
   public InteractiveSettings(InteractiveSettings p_settings) {
@@ -297,24 +331,20 @@ public class InteractiveSettings extends GuiSettings implements Serializable {
    * instance.
    *
    * <p>This override ensures that the {@link app.freerouting.settings.SettingsMerger} always reads
-   * up-to-date GUI state at priority 50 rather than a stale static snapshot. It is called on every
+   * up-to-date GUI state at priority 65 rather than a stale static snapshot. It is called on every
    * {@code merge()} invocation (e.g. when the user starts the autorouter, saves settings, or the
    * toolbar rebuilds settings).
-   *
-   * <p>Only fields that {@code InteractiveSettings} actually owns are populated; fields that belong
-   * exclusively to other settings sources (e.g. {@code maxPasses}, {@code maxThreads}) are left
-   * {@code null} so the merger correctly resolves them from their authoritative sources.
-   *
-   * <p>Currently mapped fields:
-   * <ul>
-   *   <li>{@link RouterSettings#trace_pull_tight_accuracy} ← {@link #trace_pull_tight_accuracy}</li>
-   *   <li>{@link RouterSettings#automatic_neckdown} ← {@link #automatic_neckdown}</li>
-   * </ul>
    *
    * @return a new {@link RouterSettings} containing the current GUI-controlled values
    */
   @Override
   public RouterSettings getSettings() {
+    RouterSettings baseSettings = super.getSettings();
+    if (baseSettings != null) {
+      baseSettings.trace_pull_tight_accuracy = this.get_trace_pull_tight_accuracy();
+      baseSettings.automatic_neckdown = this.get_automatic_neckdown();
+      return baseSettings;
+    }
     RouterSettings snapshot = new RouterSettings();
     snapshot.trace_pull_tight_accuracy = this.trace_pull_tight_accuracy;
     snapshot.automatic_neckdown = this.automatic_neckdown;

--- a/src/main/java/app/freerouting/management/ReflectionUtil.java
+++ b/src/main/java/app/freerouting/management/ReflectionUtil.java
@@ -79,7 +79,7 @@ public class ReflectionUtil {
       }
       if (field.getName().equals(name)) {
         // Enforce that new layer fields must only be identified by their SerializedName
-        if (annotation != null && (field.getName().equals("preferredDirectionHorizontal") || field.getName().equals("routable"))) {
+        if (annotation != null && field.getDeclaringClass() == app.freerouting.settings.LayerSettings.class && (field.getName().equals("preferredDirectionHorizontal") || field.getName().equals("routable"))) {
           continue;
         }
         return field;

--- a/src/main/java/app/freerouting/management/ReflectionUtil.java
+++ b/src/main/java/app/freerouting/management/ReflectionUtil.java
@@ -78,8 +78,8 @@ public class ReflectionUtil {
         return field;
       }
       if (field.getName().equals(name)) {
-        // Enforce that new layer fields must only be identified by their SerializedName
-        if (annotation != null && field.getDeclaringClass() == app.freerouting.settings.LayerSettings.class && (field.getName().equals("preferredDirectionHorizontal") || field.getName().equals("routable"))) {
+        // Enforce that fields with a SerializedName must not be queried by their camelCase Java name
+        if (annotation != null && !name.equals(name.toLowerCase())) {
           continue;
         }
         return field;

--- a/src/main/java/app/freerouting/management/ReflectionUtil.java
+++ b/src/main/java/app/freerouting/management/ReflectionUtil.java
@@ -11,36 +11,77 @@ public class ReflectionUtil {
   }
 
   public static void setFieldValue(Object obj, String propertyName, Object newValue)
-      throws NoSuchFieldException, IllegalAccessException {
+      throws Exception {
     String[] propertyPath = propertyName.split("[.:\\-]");
-    Object currentObject = obj;
-    Field field = null;
+    setPropertyRecursive(obj, propertyPath, 0, newValue);
+  }
 
-    // Navigate to the nested object
-    for (int i = 0; i < propertyPath.length - 1; i++) {
-      field = getFieldByNameOrSerializedName(currentObject.getClass(), propertyPath[i]);
-      field.setAccessible(true);
-      currentObject = field.get(currentObject);
+  private static void setPropertyRecursive(Object currentObject, String[] propertyPath, int pathIndex, Object newValue)
+      throws Exception {
+    if (currentObject == null) {
+      return;
     }
 
-    // Set the final field value
-    field = getFieldByNameOrSerializedName(currentObject.getClass(), propertyPath[propertyPath.length - 1]);
+    String currentName = propertyPath[pathIndex];
+    Field field = getFieldByNameOrSerializedName(currentObject.getClass(), currentName);
     field.setAccessible(true);
-    Object convertedValue = convertValue(field.getType(), newValue);
-    field.set(currentObject, convertedValue);
+
+    if (pathIndex == propertyPath.length - 1) {
+      // Leaf field - set the value
+      Object convertedValue = convertValue(field.getType(), newValue);
+      field.set(currentObject, convertedValue);
+      return;
+    }
+
+    // Intermediate field - check if it is an array
+    if (field.getType().isArray()) {
+      Class<?> componentType = field.getType().getComponentType();
+      // We are navigating through an array. The next part of the path is a property of the array element.
+      // E.g., layers.routable
+      // The newValue is expected to be a comma-separated list of values for each array element.
+      String[] valTokens = newValue.toString().split(",");
+      int size = valTokens.length;
+
+      Object array = field.get(currentObject);
+      if (array == null) {
+        array = java.lang.reflect.Array.newInstance(componentType, size);
+        field.set(currentObject, array);
+      }
+
+      int arrayLength = java.lang.reflect.Array.getLength(array);
+      int limit = Math.min(arrayLength, size);
+
+      for (int i = 0; i < limit; i++) {
+        Object element = java.lang.reflect.Array.get(array, i);
+        if (element == null) {
+          element = componentType.getDeclaredConstructor().newInstance();
+          java.lang.reflect.Array.set(array, i, element);
+        }
+        // Recursively set the property on the array element
+        setPropertyRecursive(element, propertyPath, pathIndex + 1, valTokens[i].trim());
+      }
+    } else {
+      // Normal object navigation
+      Object nestedObject = field.get(currentObject);
+      if (nestedObject == null) {
+        nestedObject = field.getType().getDeclaredConstructor().newInstance();
+        field.set(currentObject, nestedObject);
+      }
+      setPropertyRecursive(nestedObject, propertyPath, pathIndex + 1, newValue);
+    }
   }
 
   private static Field getFieldByNameOrSerializedName(Class<?> clazz, String name) throws NoSuchFieldException {
     for (Field field : clazz.getDeclaredFields()) {
-      if (field
-          .getName()
-          .equals(name)) {
+      SerializedName annotation = field.getAnnotation(SerializedName.class);
+      if (annotation != null && annotation.value().equals(name)) {
         return field;
       }
-      SerializedName annotation = field.getAnnotation(SerializedName.class);
-      if (annotation != null && annotation
-          .value()
-          .equals(name)) {
+      if (field.getName().equals(name)) {
+        // Enforce that new layer fields must only be identified by their SerializedName
+        if (annotation != null && (field.getName().equals("preferredDirectionHorizontal") || field.getName().equals("routable"))) {
+          continue;
+        }
         return field;
       }
     }
@@ -198,14 +239,21 @@ public class ReflectionUtil {
                 numberOfFieldsChanged++;
               }
             } else {
-              // The field is an array, so we need to copy its elements
+              // The field is an array of objects (like LayerSettings[])
               Object[] sourceArray = (Object[]) sourceValue;
-              Object[] targetArray = (Object[]) field.get(target);
-              if (targetArray == null) {
-                targetArray = new Object[sourceArray.length];
-                field.set(target, targetArray);
+              Class<?> componentType = field.getType().getComponentType();
+
+              // Create target array of the specific component type
+              Object[] targetArray = (Object[]) java.lang.reflect.Array.newInstance(componentType, sourceArray.length);
+
+              for (int i = 0; i < sourceArray.length; i++) {
+                if (sourceArray[i] != null) {
+                  Object targetElement = componentType.getDeclaredConstructor().newInstance();
+                  copyFields(sourceArray[i], targetElement);
+                  targetArray[i] = targetElement;
+                }
               }
-              System.arraycopy(sourceArray, 0, targetArray, 0, sourceArray.length);
+              field.set(target, targetArray);
               numberOfFieldsChanged += sourceArray.length;
             }
           } else {

--- a/src/main/java/app/freerouting/management/ReflectionUtil.java
+++ b/src/main/java/app/freerouting/management/ReflectionUtil.java
@@ -243,18 +243,34 @@ public class ReflectionUtil {
               Object[] sourceArray = (Object[]) sourceValue;
               Class<?> componentType = field.getType().getComponentType();
 
-              // Create target array of the specific component type
-              Object[] targetArray = (Object[]) java.lang.reflect.Array.newInstance(componentType, sourceArray.length);
+              Object targetArrayObj = field.get(target);
+              int targetLength = targetArrayObj != null ? java.lang.reflect.Array.getLength(targetArrayObj) : 0;
 
-              for (int i = 0; i < sourceArray.length; i++) {
-                if (sourceArray[i] != null) {
-                  Object targetElement = componentType.getDeclaredConstructor().newInstance();
-                  copyFields(sourceArray[i], targetElement);
-                  targetArray[i] = targetElement;
+              if (targetLength >= sourceArray.length) {
+                // Merge source elements into existing target elements
+                Object[] targetObjArray = (Object[]) targetArrayObj;
+                for (int i = 0; i < sourceArray.length; i++) {
+                  if (sourceArray[i] != null) {
+                    if (targetObjArray[i] == null) {
+                      targetObjArray[i] = componentType.getDeclaredConstructor().newInstance();
+                    }
+                    copyFields(sourceArray[i], targetObjArray[i]);
+                  }
                 }
+                numberOfFieldsChanged += sourceArray.length;
+              } else {
+                // Allocate a new target array of the specific component type
+                Object[] targetArray = (Object[]) java.lang.reflect.Array.newInstance(componentType, sourceArray.length);
+                for (int i = 0; i < sourceArray.length; i++) {
+                  if (sourceArray[i] != null) {
+                    Object targetElement = componentType.getDeclaredConstructor().newInstance();
+                    copyFields(sourceArray[i], targetElement);
+                    targetArray[i] = targetElement;
+                  }
+                }
+                field.set(target, targetArray);
+                numberOfFieldsChanged += sourceArray.length;
               }
-              field.set(target, targetArray);
-              numberOfFieldsChanged += sourceArray.length;
             }
           } else {
             // The field is an object, so we need to copy its fields

--- a/src/main/java/app/freerouting/management/gson/GsonProvider.java
+++ b/src/main/java/app/freerouting/management/gson/GsonProvider.java
@@ -14,6 +14,7 @@ public class GsonProvider {
       .registerTypeAdapter(Instant.class, new InstantTypeAdapter())
       .registerTypeAdapter(byte[].class, new ByteArrayToBase64TypeAdapter())
       .registerTypeAdapter(Path.class, new PathTypeAdapter())
+      .registerTypeAdapterFactory(new RouterSettingsTypeAdapterFactory())
       .setStrictness(Strictness.LENIENT)
       .create();
 

--- a/src/main/java/app/freerouting/management/gson/RouterSettingsTypeAdapterFactory.java
+++ b/src/main/java/app/freerouting/management/gson/RouterSettingsTypeAdapterFactory.java
@@ -1,0 +1,68 @@
+package app.freerouting.management.gson;
+
+import app.freerouting.settings.LayerSettings;
+import app.freerouting.settings.RouterSettings;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+/**
+ * Custom GSON TypeAdapter Factory to serialize and deserialize the transient
+ * layers settings array within RouterSettings.
+ */
+public class RouterSettingsTypeAdapterFactory implements TypeAdapterFactory {
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    if (!RouterSettings.class.isAssignableFrom(type.getRawType())) {
+      return null;
+    }
+
+    // Retrieve default delegate TypeAdapter (which ignores transient fields)
+    TypeAdapter<RouterSettings> delegate = (TypeAdapter<RouterSettings>) gson.getDelegateAdapter(this, type);
+    TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+
+    return (TypeAdapter<T>) new TypeAdapter<RouterSettings>() {
+      @Override
+      public void write(JsonWriter out, RouterSettings value) throws IOException {
+        if (value == null) {
+          out.nullValue();
+          return;
+        }
+
+        // Serialize using default delegate adapter
+        JsonElement tree = delegate.toJsonTree(value);
+
+        elementAdapter.write(out, tree);
+      }
+
+      @Override
+      public RouterSettings read(JsonReader in) throws IOException {
+        JsonElement tree = elementAdapter.read(in);
+        if (tree == null || tree.isJsonNull()) {
+          return null;
+        }
+
+        // Deserialize using default delegate adapter
+        RouterSettings settings = delegate.fromJsonTree(tree);
+
+        // Explicitly extract the transient layers array if present
+        if (tree.isJsonObject() && settings != null) {
+          JsonObject jsonObject = tree.getAsJsonObject();
+          if (jsonObject.has("layers")) {
+            settings.layers = gson.fromJson(jsonObject.get("layers"), LayerSettings[].class);
+          }
+        }
+
+        return settings;
+      }
+    };
+  }
+}

--- a/src/main/java/app/freerouting/management/gson/RouterSettingsTypeAdapterFactory.java
+++ b/src/main/java/app/freerouting/management/gson/RouterSettingsTypeAdapterFactory.java
@@ -13,8 +13,9 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 
 /**
- * Custom GSON TypeAdapter Factory to serialize and deserialize the transient
- * layers settings array within RouterSettings.
+ * Custom GSON TypeAdapter Factory that preserves default serialization behavior
+ * and extends deserialization to populate the transient layers settings array
+ * within RouterSettings.
  */
 public class RouterSettingsTypeAdapterFactory implements TypeAdapterFactory {
 

--- a/src/main/java/app/freerouting/settings/LayerSettings.java
+++ b/src/main/java/app/freerouting/settings/LayerSettings.java
@@ -1,0 +1,63 @@
+package app.freerouting.settings;
+
+import com.google.gson.annotations.SerializedName;
+import java.io.Serializable;
+
+/**
+ * Settings configuration for a single board layer.
+ */
+public class LayerSettings implements Serializable, Cloneable {
+
+  @SerializedName("routable")
+  public Boolean routable;
+
+  @SerializedName("preferred_direction_horizontal")
+  public Boolean preferredDirectionHorizontal;
+
+  /**
+   * Default constructor required for reflection and serialization.
+   */
+  public LayerSettings() {
+  }
+
+  /**
+   * Convenience constructor.
+   *
+   * @param routable                     whether the layer is routable by the autorouter
+   * @param preferredDirectionHorizontal whether the preferred direction on this layer is horizontal
+   */
+  public LayerSettings(Boolean routable, Boolean preferredDirectionHorizontal) {
+    this.routable = routable;
+    this.preferredDirectionHorizontal = preferredDirectionHorizontal;
+  }
+
+  @Override
+  public LayerSettings clone() {
+    try {
+      return (LayerSettings) super.clone();
+    } catch (CloneNotSupportedException e) {
+      LayerSettings copy = new LayerSettings();
+      copy.routable = this.routable;
+      copy.preferredDirectionHorizontal = this.preferredDirectionHorizontal;
+      return copy;
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    LayerSettings that = (LayerSettings) o;
+    return java.util.Objects.equals(routable, that.routable) &&
+        java.util.Objects.equals(preferredDirectionHorizontal, that.preferredDirectionHorizontal);
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(routable, preferredDirectionHorizontal);
+  }
+}

--- a/src/main/java/app/freerouting/settings/RouterSettings.java
+++ b/src/main/java/app/freerouting/settings/RouterSettings.java
@@ -154,10 +154,11 @@ public class RouterSettings implements Serializable, Cloneable {
   }
 
   public void setFanoutEnabled(Boolean value) {
-    Boolean oldValue = this.fanout != null ? this.fanout.enabled : null;
-    if (this.fanout != null) {
-      this.fanout.enabled = value;
+    if (this.fanout == null) {
+      this.fanout = new RouterFanoutSettings();
     }
+    Boolean oldValue = this.fanout.enabled;
+    this.fanout.enabled = value;
     if (pcs != null) {
       pcs.firePropertyChange("fanout.enabled", oldValue, value);
     }

--- a/src/main/java/app/freerouting/settings/RouterSettings.java
+++ b/src/main/java/app/freerouting/settings/RouterSettings.java
@@ -202,11 +202,15 @@ public class RouterSettings implements Serializable, Cloneable {
     }
 
     for (int i = 0; i < layer_count; i++) {
-      layers[i].routable = p_board.layer_structure.arr[i].is_signal;
+      if (layers[i].routable == null) {
+        layers[i].routable = p_board.layer_structure.arr[i].is_signal;
+      }
       if (p_board.layer_structure.arr[i].is_signal) {
         curr_preferred_direction_is_horizontal = !curr_preferred_direction_is_horizontal;
       }
-      layers[i].preferredDirectionHorizontal = curr_preferred_direction_is_horizontal;
+      if (layers[i].preferredDirectionHorizontal == null) {
+        layers[i].preferredDirectionHorizontal = curr_preferred_direction_is_horizontal;
+      }
       scoring.preferredDirectionTraceCost[i] = scoring.defaultPreferredDirectionTraceCost;
       scoring.undesiredDirectionTraceCost[i] = scoring.defaultUndesiredDirectionTraceCost;
       if (curr_preferred_direction_is_horizontal) {

--- a/src/main/java/app/freerouting/settings/RouterSettings.java
+++ b/src/main/java/app/freerouting/settings/RouterSettings.java
@@ -153,6 +153,16 @@ public class RouterSettings implements Serializable, Cloneable {
     }
   }
 
+  public void setFanoutEnabled(Boolean value) {
+    Boolean oldValue = this.fanout != null ? this.fanout.enabled : null;
+    if (this.fanout != null) {
+      this.fanout.enabled = value;
+    }
+    if (pcs != null) {
+      pcs.firePropertyChange("fanout.enabled", oldValue, value);
+    }
+  }
+
   /**
    * Apply board-specific optimizations to RouterSettings based on board geometry
    * and layer structure.
@@ -180,9 +190,14 @@ public class RouterSettings implements Serializable, Cloneable {
 
     // initialize the layer specific settings.
     if (layers == null || layers.length != layer_count) {
+      LayerSettings[] oldLayers = layers;
       layers = new LayerSettings[layer_count];
       for (int i = 0; i < layer_count; i++) {
-        layers[i] = new LayerSettings();
+        if (oldLayers != null && i < oldLayers.length && oldLayers[i] != null) {
+          layers[i] = oldLayers[i];
+        } else {
+          layers[i] = new LayerSettings();
+        }
       }
     }
     if (scoring.preferredDirectionTraceCost == null || scoring.preferredDirectionTraceCost.length != layer_count) {
@@ -332,6 +347,10 @@ public class RouterSettings implements Serializable, Cloneable {
 
   public boolean getRunOptimizer() {
     return optimizer != null && optimizer.enabled != null ? optimizer.enabled : false;
+  }
+
+  public boolean getRunFanout() {
+    return fanout != null && fanout.enabled != null ? fanout.enabled : true;
   }
 
   public void setRunOptimizer(boolean p_value) {
@@ -521,6 +540,8 @@ public class RouterSettings implements Serializable, Cloneable {
       pcs.firePropertyChange("maxThreads", null, this.maxThreads);
       pcs.firePropertyChange("jobTimeoutString", null, this.jobTimeoutString);
       pcs.firePropertyChange("enabled", null, this.enabled);
+      pcs.firePropertyChange("optimizer.enabled", null, this.optimizer != null ? this.optimizer.enabled : null);
+      pcs.firePropertyChange("fanout.enabled", null, this.fanout != null ? this.fanout.enabled : null);
     }
 
     return changedCount;

--- a/src/main/java/app/freerouting/settings/RouterSettings.java
+++ b/src/main/java/app/freerouting/settings/RouterSettings.java
@@ -155,7 +155,7 @@ public class RouterSettings implements Serializable, Cloneable {
 
   public void setFanoutEnabled(Boolean value) {
     if (this.fanout == null) {
-      this.fanout = new RouterFanoutSettings();
+      this.fanout = new FanoutSettings();
     }
     Boolean oldValue = this.fanout.enabled;
     this.fanout.enabled = value;
@@ -218,8 +218,10 @@ public class RouterSettings implements Serializable, Cloneable {
     }
 
     for (int i = 0; i < layer_count; i++) {
-      if (layers[i].routable == null) {
-        layers[i].routable = p_board.layer_structure.arr[i].is_signal;
+      if (!p_board.layer_structure.arr[i].is_signal) {
+        layers[i].routable = false;
+      } else if (layers[i].routable == null) {
+        layers[i].routable = true;
       }
       if (p_board.layer_structure.arr[i].is_signal) {
         curr_preferred_direction_is_horizontal = !curr_preferred_direction_is_horizontal;
@@ -398,6 +400,9 @@ public class RouterSettings implements Serializable, Cloneable {
           + (this.getLayerCount() - 1) + "]");
       return;
     }
+    if (layers[p_layer] == null) {
+      layers[p_layer] = new LayerSettings();
+    }
     layers[p_layer].routable = p_value;
   }
 
@@ -406,6 +411,9 @@ public class RouterSettings implements Serializable, Cloneable {
       FRLogger.warn("AutorouteSettings.get_layer_active: p_layer=" + p_layer + " out of range [0.."
           + (this.getLayerCount() - 1) + "]");
       return false;
+    }
+    if (layers[p_layer] == null) {
+      return true;
     }
     return layers[p_layer].routable != null ? layers[p_layer].routable : true;
   }
@@ -416,6 +424,9 @@ public class RouterSettings implements Serializable, Cloneable {
           + (this.getLayerCount() - 1) + "]");
       return;
     }
+    if (layers[p_layer] == null) {
+      layers[p_layer] = new LayerSettings();
+    }
     layers[p_layer].preferredDirectionHorizontal = p_value;
   }
 
@@ -424,6 +435,9 @@ public class RouterSettings implements Serializable, Cloneable {
       FRLogger.warn("AutorouteSettings.get_preferred_direction_is_horizontal: p_layer=" + p_layer + " out of range [0.."
           + (this.getLayerCount() - 1) + "]");
       return false;
+    }
+    if (layers[p_layer] == null) {
+      return (p_layer % 2 == 1);
     }
     return layers[p_layer].preferredDirectionHorizontal != null ? layers[p_layer].preferredDirectionHorizontal : (p_layer % 2 == 1);
   }

--- a/src/main/java/app/freerouting/settings/RouterSettings.java
+++ b/src/main/java/app/freerouting/settings/RouterSettings.java
@@ -30,8 +30,8 @@ public class RouterSettings implements Serializable, Cloneable {
   public Integer maxPasses;
   @SerializedName("max_items")
   public transient Integer maxItems;
-  public transient boolean[] isLayerActive;
-  public transient boolean[] isPreferredDirectionHorizontalOnLayer;
+  @SerializedName("layers")
+  public transient LayerSettings[] layers;
   public transient Boolean save_intermediate_stages = false;
   @SerializedName("ignore_net_classes")
   public transient String[] ignoreNetClasses;
@@ -179,11 +179,11 @@ public class RouterSettings implements Serializable, Cloneable {
     boolean curr_preferred_direction_is_horizontal = horizontal_width < vertical_width;
 
     // initialize the layer specific settings.
-    if (isLayerActive == null || isLayerActive.length != layer_count) {
-      isLayerActive = new boolean[layer_count];
-    }
-    if (isPreferredDirectionHorizontalOnLayer == null || isPreferredDirectionHorizontalOnLayer.length != layer_count) {
-      isPreferredDirectionHorizontalOnLayer = new boolean[layer_count];
+    if (layers == null || layers.length != layer_count) {
+      layers = new LayerSettings[layer_count];
+      for (int i = 0; i < layer_count; i++) {
+        layers[i] = new LayerSettings();
+      }
     }
     if (scoring.preferredDirectionTraceCost == null || scoring.preferredDirectionTraceCost.length != layer_count) {
       scoring.preferredDirectionTraceCost = new double[layer_count];
@@ -202,11 +202,11 @@ public class RouterSettings implements Serializable, Cloneable {
     }
 
     for (int i = 0; i < layer_count; i++) {
-      isLayerActive[i] = p_board.layer_structure.arr[i].is_signal;
+      layers[i].routable = p_board.layer_structure.arr[i].is_signal;
       if (p_board.layer_structure.arr[i].is_signal) {
         curr_preferred_direction_is_horizontal = !curr_preferred_direction_is_horizontal;
       }
-      isPreferredDirectionHorizontalOnLayer[i] = curr_preferred_direction_is_horizontal;
+      layers[i].preferredDirectionHorizontal = curr_preferred_direction_is_horizontal;
       scoring.preferredDirectionTraceCost[i] = scoring.defaultPreferredDirectionTraceCost;
       scoring.undesiredDirectionTraceCost[i] = scoring.defaultUndesiredDirectionTraceCost;
       if (curr_preferred_direction_is_horizontal) {
@@ -232,11 +232,11 @@ public class RouterSettings implements Serializable, Cloneable {
    * @return The layer count
    */
   public int getLayerCount() {
-    if (isLayerActive == null) {
+    if (layers == null) {
       return 0;
     }
 
-    return isLayerActive.length;
+    return layers.length;
   }
 
   /**
@@ -247,8 +247,12 @@ public class RouterSettings implements Serializable, Cloneable {
    * immediately without a prior call to {@link #applyBoardSpecificOptimizations}.
    */
   public void setLayerCount(int layerCount) {
-    isLayerActive = new boolean[layerCount];
-    isPreferredDirectionHorizontalOnLayer = new boolean[layerCount];
+    if (layers == null || layers.length != layerCount) {
+      layers = new LayerSettings[layerCount];
+      for (int i = 0; i < layerCount; i++) {
+        layers[i] = new LayerSettings();
+      }
+    }
     if (scoring == null) {
       scoring = new RouterScoringSettings();
     }
@@ -258,8 +262,8 @@ public class RouterSettings implements Serializable, Cloneable {
     scoring.undesiredDirectionTraceCost = new double[layerCount];
 
     for (int i = 0; i < layerCount; i++) {
-      isLayerActive[i] = true;
-      isPreferredDirectionHorizontalOnLayer[i] = i % 2 == 1;
+      layers[i].routable = true;
+      layers[i].preferredDirectionHorizontal = i % 2 == 1;
       scoring.preferredDirectionTraceCost[i] = 1.0;
       scoring.undesiredDirectionTraceCost[i] = 1.0;
     }
@@ -280,9 +284,14 @@ public class RouterSettings implements Serializable, Cloneable {
     }
     result.algorithm = this.algorithm;
     result.jobTimeoutString = this.jobTimeoutString;
-    result.isLayerActive = (this.isLayerActive != null) ? this.isLayerActive.clone() : null;
-    result.isPreferredDirectionHorizontalOnLayer = (this.isPreferredDirectionHorizontalOnLayer != null)
-        ? this.isPreferredDirectionHorizontalOnLayer.clone() : null;
+    if (this.layers != null) {
+      result.layers = new LayerSettings[this.layers.length];
+      for (int i = 0; i < this.layers.length; i++) {
+        if (this.layers[i] != null) {
+          result.layers[i] = this.layers[i].clone();
+        }
+      }
+    }
     result.maxPasses = this.maxPasses;
     result.maxItems = this.maxItems;
     result.copperToEdgeClearanceUm = this.copperToEdgeClearanceUm;
@@ -365,7 +374,7 @@ public class RouterSettings implements Serializable, Cloneable {
           + (this.getLayerCount() - 1) + "]");
       return;
     }
-    isLayerActive[p_layer] = p_value;
+    layers[p_layer].routable = p_value;
   }
 
   public boolean get_layer_active(int p_layer) {
@@ -374,7 +383,7 @@ public class RouterSettings implements Serializable, Cloneable {
           + (this.getLayerCount() - 1) + "]");
       return false;
     }
-    return isLayerActive[p_layer];
+    return layers[p_layer].routable != null ? layers[p_layer].routable : true;
   }
 
   public void set_preferred_direction_is_horizontal(int p_layer, boolean p_value) {
@@ -383,7 +392,7 @@ public class RouterSettings implements Serializable, Cloneable {
           + (this.getLayerCount() - 1) + "]");
       return;
     }
-    isPreferredDirectionHorizontalOnLayer[p_layer] = p_value;
+    layers[p_layer].preferredDirectionHorizontal = p_value;
   }
 
   public boolean get_preferred_direction_is_horizontal(int p_layer) {
@@ -392,7 +401,7 @@ public class RouterSettings implements Serializable, Cloneable {
           + (this.getLayerCount() - 1) + "]");
       return false;
     }
-    return isPreferredDirectionHorizontalOnLayer[p_layer];
+    return layers[p_layer].preferredDirectionHorizontal != null ? layers[p_layer].preferredDirectionHorizontal : (p_layer % 2 == 1);
   }
 
   public void set_preferred_direction_trace_costs(int p_layer, double p_value) {
@@ -425,7 +434,7 @@ public class RouterSettings implements Serializable, Cloneable {
       return 0;
     }
     double result;
-    if (isPreferredDirectionHorizontalOnLayer[p_layer]) {
+    if (get_preferred_direction_is_horizontal(p_layer)) {
       result = scoring.preferredDirectionTraceCost[p_layer];
     } else {
       result = scoring.undesiredDirectionTraceCost[p_layer];
@@ -447,7 +456,7 @@ public class RouterSettings implements Serializable, Cloneable {
       return 0;
     }
     double result;
-    if (isPreferredDirectionHorizontalOnLayer[p_layer]) {
+    if (get_preferred_direction_is_horizontal(p_layer)) {
       result = scoring.undesiredDirectionTraceCost[p_layer];
     } else {
       result = scoring.preferredDirectionTraceCost[p_layer];

--- a/src/main/java/app/freerouting/settings/RouterSettings.java
+++ b/src/main/java/app/freerouting/settings/RouterSettings.java
@@ -200,6 +200,13 @@ public class RouterSettings implements Serializable, Cloneable {
           layers[i] = new LayerSettings();
         }
       }
+    } else {
+      // Ensure no elements inside the layers array are null
+      for (int i = 0; i < layer_count; i++) {
+        if (layers[i] == null) {
+          layers[i] = new LayerSettings();
+        }
+      }
     }
     if (scoring.preferredDirectionTraceCost == null || scoring.preferredDirectionTraceCost.length != layer_count) {
       scoring.preferredDirectionTraceCost = new double[layer_count];

--- a/src/main/java/app/freerouting/settings/sources/DefaultSettings.java
+++ b/src/main/java/app/freerouting/settings/sources/DefaultSettings.java
@@ -87,7 +87,7 @@ public class DefaultSettings implements SettingsSource {
     @Override
     public RouterSettings getSettings() {
         // Create a RouterSettings object with all default values.
-        // Layer-count-dependent arrays (isLayerActive, isPreferredDirectionHorizontalOnLayer,
+        // Layer-count-dependent arrays (layers,
         // preferredDirectionTraceCost, undesiredDirectionTraceCost) are intentionally left null
         // here. Their actual sizes must come from the board file (via DsnFileSettings) and are
         // finalised by RouterSettings.applyBoardSpecificOptimizations() once the board is loaded.
@@ -108,7 +108,7 @@ public class DefaultSettings implements SettingsSource {
         settings.maxThreads = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
         settings.copperToEdgeClearanceUm = DEFAULT_COPPER_TO_EDGE_CLEARANCE_UM;
 
-        // isLayerActive and isPreferredDirectionHorizontalOnLayer are left null intentionally –
+        // layers is left null intentionally –
         // they will be populated by DsnFileSettings (from the DSN layer count) and then
         // overwritten with board-geometry-aware values by applyBoardSpecificOptimizations().
 

--- a/src/main/java/app/freerouting/settings/sources/GuiSettings.java
+++ b/src/main/java/app/freerouting/settings/sources/GuiSettings.java
@@ -31,8 +31,8 @@ import app.freerouting.settings.SettingsSource;
  */
 public class GuiSettings implements SettingsSource {
 
-    private static final int PRIORITY = 50;
-    private final RouterSettings settings;
+    private static final int PRIORITY = 65;
+    protected RouterSettings settings;
 
     /**
      * Creates a GuiSettings source with the specified settings.
@@ -41,6 +41,15 @@ public class GuiSettings implements SettingsSource {
      *                 fields non-null)
      */
     public GuiSettings(RouterSettings settings) {
+        this.settings = settings != null ? settings : new RouterSettings();
+    }
+
+    /**
+     * Updates the underlying settings object.
+     *
+     * @param settings the new settings
+     */
+    public void setSettings(RouterSettings settings) {
         this.settings = settings != null ? settings : new RouterSettings();
     }
 

--- a/src/test/java/app/freerouting/autoroute/RoutableLayersSafetyCheckTest.java
+++ b/src/test/java/app/freerouting/autoroute/RoutableLayersSafetyCheckTest.java
@@ -1,0 +1,52 @@
+package app.freerouting.autoroute;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import app.freerouting.board.ItemIdentificationNumberGenerator;
+import app.freerouting.core.RoutingJob;
+import app.freerouting.fixtures.RoutingFixtureTest;
+import app.freerouting.interactive.HeadlessBoardManager;
+import org.junit.jupiter.api.Test;
+
+class RoutableLayersSafetyCheckTest extends RoutingFixtureTest {
+
+  @Test
+  void testRoutingFailsWhenAllLayersDisabledCurrent() {
+    RoutingJob job = GetRoutingJob("Issue508-DAC2020_bm01.dsn");
+    HeadlessBoardManager boardManager = new HeadlessBoardManager(job);
+    try {
+      boardManager.loadFromSpecctraDsn(job.input.getData(), null, new ItemIdentificationNumberGenerator());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load DSN board", e);
+    }
+    job.board = boardManager.get_routing_board();
+
+    // Disable all layers
+    for (int i = 0; i < job.routerSettings.getLayerCount(); i++) {
+      job.routerSettings.set_layer_active(i, false);
+    }
+
+    BatchAutorouter router = new BatchAutorouter(job);
+    assertThrows(IllegalArgumentException.class, router::runBatchLoop);
+  }
+
+  @Test
+  void testRoutingFailsWhenAllLayersDisabledV19() {
+    RoutingJob job = GetRoutingJob("Issue508-DAC2020_bm01.dsn");
+    HeadlessBoardManager boardManager = new HeadlessBoardManager(job);
+    try {
+      boardManager.loadFromSpecctraDsn(job.input.getData(), null, new ItemIdentificationNumberGenerator());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load DSN board", e);
+    }
+    job.board = boardManager.get_routing_board();
+
+    // Disable all layers
+    for (int i = 0; i < job.routerSettings.getLayerCount(); i++) {
+      job.routerSettings.set_layer_active(i, false);
+    }
+
+    BatchAutorouterV19 routerV19 = new BatchAutorouterV19(job);
+    assertThrows(IllegalArgumentException.class, routerV19::runBatchLoop);
+  }
+}

--- a/src/test/java/app/freerouting/interactive/SettingsMergerGuiIntegrationTest.java
+++ b/src/test/java/app/freerouting/interactive/SettingsMergerGuiIntegrationTest.java
@@ -210,6 +210,47 @@ class SettingsMergerGuiIntegrationTest {
         // The merged settings should respect the GUI change (routable = true), overriding the CLI setting
         assertTrue(postGuiChangeMerged.layers[0].routable, "GUI change must override the CLI setting");
     }
+
+    /**
+     * Verifies that when InteractiveSettings and the jobSettings share the same reference
+     * (the fixed behavior), user GUI edits correctly override startup CLI settings.
+     */
+    @Test
+    void settingsMerge_guiOverridesCliCorrectlyWithSharedReference() {
+        // 1. Setup job settings (like routingJob.routerSettings at startup, layers is null)
+        RouterSettings jobSettings = new RouterSettings();
+
+        // 2. CLI Source disables the first layer: --router.layers.routable=false,true
+        RouterSettings cliSettings = new RouterSettings();
+        cliSettings.setLayerCount(2);
+        cliSettings.layers[0].routable = false;
+        cliSettings.layers[1].routable = true;
+        app.freerouting.settings.SettingsSource cliSource = new app.freerouting.settings.sources.CliSettings(new String[]{"--router.layers.routable=false,true"});
+
+        // 3. InteractiveSettings initially created with jobSettings (contains null layers)
+        InteractiveSettings interactiveSettings = InteractiveSettings.reset(board, jobSettings);
+
+        // 4. Merger setup
+        SettingsMerger merger = new SettingsMerger(new DefaultSettings(), cliSource, interactiveSettings);
+
+        // 5. BoardFrame startup load logic:
+        RouterSettings startupMerged = merger.merge();
+        assertFalse(startupMerged.layers[0].routable, "At startup, first layer must be disabled (CLI wins)");
+
+        // jobSettings (routingJob.routerSettings) is initialized to match board layer count,
+        // and mutated in-place by copying fields from startupMerged
+        jobSettings.setLayerCount(2);
+        jobSettings.applyNewValuesFrom(startupMerged);
+        // interactiveSettings.settings is set to jobSettings (fixed/shared reference!)
+        interactiveSettings.setSettings(jobSettings);
+
+        // 6. User modifies settings in the GUI: mutates jobSettings (routingJob.routerSettings)
+        jobSettings.layers[0].routable = true;
+
+        // 7. Merger merges again when starting routing run:
+        RouterSettings runMerged = merger.merge();
+
+        // 8. Assert that the merged settings for the run correctly respect the GUI change (routable = true)
+        assertTrue(runMerged.layers[0].routable, "GUI change must be respected on the first run, overriding CLI settings");
+    }
 }
-
-

--- a/src/test/java/app/freerouting/interactive/SettingsMergerGuiIntegrationTest.java
+++ b/src/test/java/app/freerouting/interactive/SettingsMergerGuiIntegrationTest.java
@@ -167,6 +167,49 @@ class SettingsMergerGuiIntegrationTest {
         assertTrue(merged.automatic_neckdown,
                 "InteractiveSettings.automatic_neckdown=true must be reflected by merge()");
     }
+
+    /**
+     * Reproduces the issue where CLI settings override GUI modifications at startup,
+     * but the user should be able to override them on the GUI.
+     */
+    @Test
+    void settingsMerge_cliOverridesGuiAtStartupButGuiShouldOverrideCliLater() {
+        // Prepare base settings where first layer is routable, second layer is routable
+        RouterSettings baseSettings = new RouterSettings();
+        baseSettings.setLayerCount(2);
+        baseSettings.layers[0].routable = true;
+        baseSettings.layers[1].routable = true;
+
+        // CLI Source disables the first layer: --router.layers.routable=false,true
+        RouterSettings cliSettings = new RouterSettings();
+        cliSettings.setLayerCount(2);
+        cliSettings.layers[0].routable = false;
+        cliSettings.layers[1].routable = true;
+        app.freerouting.settings.SettingsSource cliSource = new app.freerouting.settings.sources.CliSettings(new String[]{"--router.layers.routable=false,true"});
+
+        // Gui Settings initially contains the active settings (which got the merged startup settings from CLI)
+        RouterSettings guiActiveSettings = new RouterSettings();
+        guiActiveSettings.setLayerCount(2);
+        guiActiveSettings.layers[0].routable = false;
+        guiActiveSettings.layers[1].routable = true;
+        InteractiveSettings interactiveSettings = InteractiveSettings.reset(board, guiActiveSettings);
+
+        // Merger setup: defaults (0), GuiSettings (65), CliSettings (60)
+        SettingsMerger merger = new SettingsMerger(new DefaultSettings(), cliSource, interactiveSettings);
+
+        // Assert startup state matches CLI: first layer is disabled
+        RouterSettings startupMerged = merger.merge();
+        assertFalse(startupMerged.layers[0].routable, "At startup, first layer must be disabled (CLI wins)");
+
+        // Now, user overrides the first layer checkbox on GUI: changes it to enabled (true)
+        guiActiveSettings.layers[0].routable = true;
+
+        // Perform merge before starting router
+        RouterSettings postGuiChangeMerged = merger.merge();
+
+        // The merged settings should respect the GUI change (routable = true), overriding the CLI setting
+        assertTrue(postGuiChangeMerged.layers[0].routable, "GUI change must override the CLI setting");
+    }
 }
 
 

--- a/src/test/java/app/freerouting/management/ReflectionUtilArrayTest.java
+++ b/src/test/java/app/freerouting/management/ReflectionUtilArrayTest.java
@@ -1,0 +1,79 @@
+package app.freerouting.management;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import app.freerouting.settings.LayerSettings;
+import app.freerouting.settings.RouterSettings;
+import org.junit.jupiter.api.Test;
+
+class ReflectionUtilArrayTest {
+
+  @Test
+  void testSetSimpleProperty() throws Exception {
+    RouterSettings settings = new RouterSettings();
+    ReflectionUtil.setFieldValue(settings, "enabled", "false");
+    assertFalse(settings.enabled);
+
+    ReflectionUtil.setFieldValue(settings, "enabled", "true");
+    assertTrue(settings.enabled);
+  }
+
+  @Test
+  void testSetNestedArrayPropertiesWhenNull() throws Exception {
+    RouterSettings settings = new RouterSettings();
+    // settings.layers is initially null
+    ReflectionUtil.setFieldValue(settings, "layers.routable", "false,true");
+
+    assertNotNull(settings.layers);
+    assertEquals(2, settings.layers.length);
+    assertFalse(settings.layers[0].routable);
+    assertTrue(settings.layers[1].routable);
+  }
+
+  @Test
+  void testSetNestedArrayPropertiesWhenInitialized() throws Exception {
+    RouterSettings settings = new RouterSettings();
+    settings.setLayerCount(2);
+
+    ReflectionUtil.setFieldValue(settings, "layers.routable", "false,true");
+    assertFalse(settings.layers[0].routable);
+    assertTrue(settings.layers[1].routable);
+
+    // Verify setting preferred direction
+    ReflectionUtil.setFieldValue(settings, "layers.preferred_direction_horizontal", "true,false");
+    assertTrue(settings.layers[0].preferredDirectionHorizontal);
+    assertFalse(settings.layers[1].preferredDirectionHorizontal);
+  }
+
+  @Test
+  void testSerializedNameOnlyMatching() {
+    RouterSettings settings = new RouterSettings();
+    settings.setLayerCount(2);
+
+    // Should succeed because preferred_direction_horizontal is the SerializedName value
+    try {
+      ReflectionUtil.setFieldValue(settings, "layers.preferred_direction_horizontal", "true,false");
+      assertTrue(settings.layers[0].preferredDirectionHorizontal);
+    } catch (Exception e) {
+      throw new AssertionError("Should not have thrown exception", e);
+    }
+
+    // Should throw NoSuchFieldException because the Java field name is preferredDirectionHorizontal
+    // but the SerializedName annotation value is preferred_direction_horizontal, so only the annotation value must match.
+    assertThrows(NoSuchFieldException.class, () -> {
+      ReflectionUtil.setFieldValue(settings, "layers.preferredDirectionHorizontal", "true,false");
+    });
+
+    // Similarly for routable - it matches because the SerializedName is "routable"
+    try {
+      ReflectionUtil.setFieldValue(settings, "layers.routable", "true,true");
+      assertTrue(settings.layers[0].routable);
+    } catch (Exception e) {
+      throw new AssertionError("Should not have thrown exception", e);
+    }
+  }
+}

--- a/src/test/java/app/freerouting/management/gson/RouterSettingsSerializationTest.java
+++ b/src/test/java/app/freerouting/management/gson/RouterSettingsSerializationTest.java
@@ -1,0 +1,57 @@
+package app.freerouting.management.gson;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import app.freerouting.settings.LayerSettings;
+import app.freerouting.settings.RouterSettings;
+import java.lang.reflect.Modifier;
+import org.junit.jupiter.api.Test;
+
+class RouterSettingsSerializationTest {
+
+  @Test
+  void testLayersFieldRemainsTransient() throws NoSuchFieldException {
+    var field = RouterSettings.class.getField("layers");
+    assertTrue(Modifier.isTransient(field.getModifiers()), "The layers field MUST remain transient");
+  }
+
+  @Test
+  void testRouterSettingsSerializationAndDeserialization() {
+    // 1. Setup a RouterSettings object with non-null layers
+    RouterSettings original = new RouterSettings();
+    original.setLayerCount(2);
+    original.layers[0] = new LayerSettings(false, true);
+    original.layers[1] = new LayerSettings(true, false);
+    original.maxPasses = 42;
+
+    // 2. Serialize to JSON using GsonProvider.GSON (must NOT contain layers since we never serialize it)
+    String json = GsonProvider.GSON.toJson(original);
+    assertNotNull(json);
+    assertFalse(json.contains("\"layers\""), "Serialized JSON must NOT contain the 'layers' field");
+    assertTrue(json.contains("\"max_passes\""), "Serialized JSON must contain other settings like 'max_passes'");
+
+    // 3. Deserialize from the serialized JSON
+    RouterSettings deserializedFromEmptyLayers = GsonProvider.GSON.fromJson(json, RouterSettings.class);
+    assertNotNull(deserializedFromEmptyLayers);
+    assertEquals(42, deserializedFromEmptyLayers.maxPasses);
+    assertNull(deserializedFromEmptyLayers.layers, "Layers array should be null since it was not serialized");
+
+    // 4. Deserialize from a JSON payload that contains the layers array (simulating API call)
+    String apiJson = "{\n"
+        + "  \"max_passes\": 42,\n"
+        + "  \"layers\": [\n"
+        + "    {\"routable\": false, \"preferred_direction_horizontal\": true},\n"
+        + "    {\"routable\": true, \"preferred_direction_horizontal\": false}\n"
+        + "  ]\n"
+        + "}";
+    RouterSettings deserializedFromApi = GsonProvider.GSON.fromJson(apiJson, RouterSettings.class);
+    assertNotNull(deserializedFromApi);
+    assertEquals(42, deserializedFromApi.maxPasses);
+    assertNotNull(deserializedFromApi.layers, "The transient layers field must be successfully deserialized when present in the JSON");
+    assertEquals(2, deserializedFromApi.layers.length);
+    assertFalse(deserializedFromApi.layers[0].routable);
+    assertTrue(deserializedFromApi.layers[0].preferredDirectionHorizontal);
+    assertTrue(deserializedFromApi.layers[1].routable);
+    assertFalse(deserializedFromApi.layers[1].preferredDirectionHorizontal);
+  }
+}

--- a/src/test/java/app/freerouting/settings/RouterSettingsMergeTest.java
+++ b/src/test/java/app/freerouting/settings/RouterSettingsMergeTest.java
@@ -37,4 +37,39 @@ class RouterSettingsMergeTest {
     assertFalse(source.layers[0].routable);
     assertNotSame(source.layers[0], target.layers[0]);
   }
+
+  @Test
+  void testApplyBoardSpecificOptimizationsPreservesSettings() {
+    RouterSettings settings = new RouterSettings();
+    settings.setLayerCount(2);
+    settings.layers[0].routable = false;
+    settings.layers[1].routable = true;
+    settings.layers[0].preferredDirectionHorizontal = true;
+    settings.layers[1].preferredDirectionHorizontal = false;
+
+    // Create a mock/real board with 2 signal layers
+    app.freerouting.board.Layer layer1 = new app.freerouting.board.Layer("Top", true);
+    app.freerouting.board.Layer layer2 = new app.freerouting.board.Layer("Bottom", true);
+    app.freerouting.board.LayerStructure layerStructure = new app.freerouting.board.LayerStructure(new app.freerouting.board.Layer[] { layer1, layer2 });
+    app.freerouting.rules.ClearanceMatrix clearanceMatrix = app.freerouting.rules.ClearanceMatrix.get_default_instance(layerStructure, 10);
+    app.freerouting.rules.BoardRules boardRules = new app.freerouting.rules.BoardRules(layerStructure, clearanceMatrix);
+    boardRules.create_default_net_class();
+    app.freerouting.board.Communication communication = new app.freerouting.board.Communication();
+    app.freerouting.board.RoutingBoard board = new app.freerouting.board.RoutingBoard(
+        new app.freerouting.geometry.planar.IntBox(0, 0, 2000000, 2000000),
+        layerStructure,
+        new app.freerouting.geometry.planar.PolylineShape[] { app.freerouting.geometry.planar.TileShape.get_instance(0, 0, 2000000, 2000000) },
+        0,
+        boardRules,
+        communication);
+
+    // Run optimizations
+    settings.applyBoardSpecificOptimizations(board);
+
+    // Verify settings were preserved and not reset to is_signal (true, true)
+    assertFalse(settings.layers[0].routable);
+    assertTrue(settings.layers[1].routable);
+    assertTrue(settings.layers[0].preferredDirectionHorizontal);
+    assertFalse(settings.layers[1].preferredDirectionHorizontal);
+  }
 }

--- a/src/test/java/app/freerouting/settings/RouterSettingsMergeTest.java
+++ b/src/test/java/app/freerouting/settings/RouterSettingsMergeTest.java
@@ -1,0 +1,40 @@
+package app.freerouting.settings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import app.freerouting.management.ReflectionUtil;
+import org.junit.jupiter.api.Test;
+
+class RouterSettingsMergeTest {
+
+  @Test
+  void testMergeLayersArray() {
+    RouterSettings source = new RouterSettings();
+    source.setLayerCount(2);
+    source.layers[0].routable = false;
+    source.layers[1].routable = true;
+    source.layers[0].preferredDirectionHorizontal = true;
+    source.layers[1].preferredDirectionHorizontal = false;
+
+    RouterSettings target = new RouterSettings();
+
+    // Perform the merge using ReflectionUtil.copyFields / applyNewValuesFrom
+    target.applyNewValuesFrom(source);
+
+    assertNotNull(target.layers);
+    assertEquals(2, target.layers.length);
+    assertFalse(target.layers[0].routable);
+    assertTrue(target.layers[1].routable);
+    assertTrue(target.layers[0].preferredDirectionHorizontal);
+    assertFalse(target.layers[1].preferredDirectionHorizontal);
+
+    // Verify deep copy: changing target should not affect source
+    target.layers[0].routable = true;
+    assertFalse(source.layers[0].routable);
+    assertNotSame(source.layers[0], target.layers[0]);
+  }
+}

--- a/src/test/java/app/freerouting/settings/SettingsMergerTest.java
+++ b/src/test/java/app/freerouting/settings/SettingsMergerTest.java
@@ -230,4 +230,39 @@ class SettingsMergerTest {
         assertNotNull(merged);
         assertFalse(merged.getRunRouter());
     }
+
+    @Test
+    void testCliRoutableLayersDoesNotDisableRouter() {
+        DefaultSettings defaults = new DefaultSettings();
+        CliSettings cli = new CliSettings(new String[] {
+            "-de", "fixtures/Issue508-DAC2020_bm05.dsn",
+            "--router.layers.routable=false,true"
+        });
+
+        RouterSettings merged = new SettingsMerger(defaults, cli).merge();
+
+        assertNotNull(merged);
+        assertTrue(merged.getRunRouter());
+    }
+
+    @Test
+    void testLayersArrayNotShrunkOnMerge() {
+        RouterSettings target = new RouterSettings();
+        target.setLayerCount(6);
+        target.layers[0].routable = true;
+        target.layers[1].routable = true;
+        target.layers[2].routable = true;
+
+        RouterSettings source = new RouterSettings();
+        source.setLayerCount(2);
+        source.layers[0].routable = false;
+        source.layers[1].routable = true;
+
+        app.freerouting.management.ReflectionUtil.copyFields(source, target);
+
+        assertEquals(6, target.getLayerCount());
+        assertFalse(target.layers[0].routable);
+        assertTrue(target.layers[1].routable);
+        assertTrue(target.layers[2].routable);
+    }
 }


### PR DESCRIPTION
This PR implements several fixes and enhancements related to layer-specific autorouter settings, GUI-to-backend settings synchronization (specifically ensuring GUI changes override CLI/startup-applied settings later in the session), and adding a new fanout option to the GUI.

### **Overview**
The primary focus of this PR is fixing the layers active/routable toggle behavior in GUI mode. It resolves issues where CLI-supplied parameters could permanently shadow/override subsequent user changes in the GUI, prevents unintended mutation of merged `RouterSettings`, adds support for handling array fields and transient properties during serialization/merging, and introduces a dedicated **Fanout** checkbox in the GUI.

---

### **Detailed Commit Summary**

#### 1. **Add fanout option to autoroute UI** (`7ffaaa2d`)
* Introduces a **"fanout"** checkbox in the `WindowAutorouteParameter` panel.
* Adds a tooltip, layout placement, `FanoutListener`, and analytics click-tracking.
* Wires the checkbox to the configuration system via `applyFanoutEnabledSelection` and property-change notifications (`"fanout.enabled"`).
* Preserves existing `LayerSettings` when resizing the layers array during initialization.

#### 2. **Preserve and merge existing array fields** (`997c4c0c`)
* Updates `ReflectionUtil.copyFields` to merge source array elements into an existing target array when the target array length is greater than or equal to the source length, instantiating elements as needed.
* Adds corresponding tests in `SettingsMergerTest` (`testCliRoutableLayersDoesNotDisableRouter` and `testLayersArrayNotShrunkOnMerge`) to verify that merging does not shrink target layer arrays or result in data loss.

#### 3. **Handle transient `RouterSettings.layers` in Gson** (`b7c0ae81`)
* Adds a custom Gson TypeAdapterFactory (`RouterSettingsTypeAdapterFactory`) to ensure that the transient `layers` array on `RouterSettings` can be deserialized when present in incoming JSON payloads.
* Registers this factory in `GsonProvider` and adds test coverage under `RouterSettingsSerializationTest`.

#### 4. **Prevent mutating merged `RouterSettings`** (`6cf52f56`)
* Clones base settings in `InteractiveSettings.getSettings()` before applying GUI-specific tweaks to prevent accidental mutation of the shared `RouterSettings` instance.
* Updates `BoardFrame` and `BoardToolbar` to set `InteractiveSettings` from the job's persistent reference rather than the ephemeral merged result.

#### 5. **Add test ensuring GUI overrides CLI after startup** (`3d09396d`)
* Adds integration test (`settingsMerge_cliOverridesGuiAtStartupButGuiShouldOverrideCliLater`) demonstrating that while CLI settings initially disable a layer at startup, subsequent user interactions in the GUI successfully re-enable the layer.

#### 6. **Apply merged `RouterSettings` to `InteractiveSettings`** (`d0a5c8b2`)
* Passes the merged settings used by the routing job into the board's `InteractiveSettings`.
* Adds constructors and `getOrCreate`/`reset` overloads to `InteractiveSettings` accepting `RouterSettings`, and raises `GuiSettings` priority from 50 to 65.

#### 7. **Preserve explicit layer settings during optimizations** (`2c6c87f9`)
* Prevents `applyBoardSpecificOptimizations` from resetting explicitly configured layer settings to the board defaults by only setting `routable` and `preferredDirectionHorizontal` values if they are currently `null`.
* Adds unit test `testApplyBoardSpecificOptimizationsPreservesSettings`.

#### 8. **Add per-layer settings, docs, fixture and tests** (`b30f0bfe`)
* Lays the foundation for layer-specific settings (`LayerSettings`) wired through `RouterSettings`, `DefaultSettings`, the autorouter, and the GUI.
* Updates documentation outlining CLI array syntax, and adds a KiCad `.dsn` test fixture along with parsing, reflection, and safety check tests.