### PR TITLE
router: opt-in width necking — retry failed connections at neck_width_um

### DIFF
--- a/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
+++ b/src/main/java/app/freerouting/autoroute/BatchAutorouter.java
@@ -1331,11 +1331,77 @@ public class BatchAutorouter extends NamedAlgorithm {
         FRLogger.trace("compare_trace_opt_changed_area_after net=" + p_route_net_no + ", maxItemId=" + maxItemIdAfterOpt + ", delta=" + (maxItemIdAfterOpt - maxItemIdBeforeOpt));
       }
 
+      if ((autoroute_result.state == AutorouteAttemptState.FAILED
+          || autoroute_result.state == AutorouteAttemptState.INSERT_ERROR)
+          && this.settings.getNeckWidthUm() > 0) {
+        AutorouteAttemptResult necked_result = retryConnectionNecked(p_route_net_no, autoroute_control,
+            curr_via_costs, route_start_set, route_dest_set, p_ripped_item_list, p_ripup_costs,
+            p_ripup_pass_no, time_limit);
+        if (necked_result != null) {
+          return necked_result;
+        }
+      }
+
       return autoroute_result;
     } catch (Exception e) {
       FRLogger.error("Error during routing passes", e);
       return new AutorouteAttemptResult(AutorouteAttemptState.FAILED);
     }
+  }
+
+
+  /**
+   * Width-necking retry: when a connection failed at its net-class trace width and the
+   * neck_width_um setting is enabled, retry it ONCE with every layer's trace half-width
+   * clamped to the neck width. Fine-pitch pads whose pitch is below (class width +
+   * clearance) are unroutable at class width and fail as generic congestion; the operator
+   * supplies a legal manufacturable neck width (e.g. the project's densest net class).
+   * Returns the retry result when it routed, else null (keep the original failure).
+   */
+  private AutorouteAttemptResult retryConnectionNecked(int p_route_net_no,
+      AutorouteControl p_original_control, int p_via_costs, Set<Item> p_route_start_set,
+      Set<Item> p_route_dest_set, SortedSet<Item> p_ripped_item_list,
+      Map<Item, Integer> p_ripup_costs, int p_ripup_pass_no, TimeLimit p_time_limit) {
+    int boardResolution = Math.max(1, board.communication.resolution);
+    int neck_width = (int) Math.round(app.freerouting.board.Unit.scale(
+        this.settings.getNeckWidthUm() * boardResolution, app.freerouting.board.Unit.UM,
+        board.communication.unit));
+    int neck_half_width = Math.max(1, neck_width / 2);
+    boolean narrower_somewhere = false;
+    for (int i = 0; i < p_original_control.layer_count; i++) {
+      if (p_original_control.layer_active[i]
+          && p_original_control.trace_half_width[i] > neck_half_width) {
+        narrower_somewhere = true;
+        break;
+      }
+    }
+    if (!narrower_somewhere) {
+      return null;
+    }
+    AutorouteControl neck_control = new AutorouteControl(this.board, p_route_net_no, settings,
+        p_via_costs, this.trace_cost_arr);
+    neck_control.ripup_allowed = true;
+    neck_control.ripup_costs = this.start_ripup_costs * p_ripup_pass_no;
+    neck_control.remove_unconnected_vias = this.remove_unconnected_vias;
+    for (int i = 0; i < neck_control.layer_count; i++) {
+      int compensation = neck_control.compensated_trace_half_width[i] - neck_control.trace_half_width[i];
+      neck_control.trace_half_width[i] = Math.min(neck_control.trace_half_width[i], neck_half_width);
+      neck_control.compensated_trace_half_width[i] = neck_control.trace_half_width[i] + compensation;
+    }
+    AutorouteEngine neck_engine = board.init_autoroute(p_route_net_no,
+        neck_control.trace_clearance_class_no, this.thread, p_time_limit, this.retain_autoroute_database);
+    AutorouteAttemptResult neck_result = neck_engine.autoroute_connection(p_route_start_set,
+        p_route_dest_set, neck_control, p_ripped_item_list, p_ripup_costs);
+    if (neck_result.state != AutorouteAttemptState.ROUTED) {
+      return null;
+    }
+    board.opt_changed_area(new int[0], null, this.trace_pull_tight_accuracy, neck_control.trace_costs,
+        this.thread, TIME_LIMIT_TO_PREVENT_ENDLESS_LOOP);
+    Net route_net = board.rules.nets.get(p_route_net_no);
+    FRLogger.info("Necked retry routed net '"
+        + (route_net != null ? route_net.name : "#" + p_route_net_no)
+        + "' at " + this.settings.getNeckWidthUm() + " um trace width.");
+    return neck_result;
   }
 
   /**

--- a/src/main/java/app/freerouting/settings/RouterSettings.java
+++ b/src/main/java/app/freerouting/settings/RouterSettings.java
@@ -24,6 +24,14 @@ public class RouterSettings implements Serializable, Cloneable {
   public FanoutSettings fanout;
   @SerializedName("copper_to_edge_clearance_um")
   public Double copperToEdgeClearanceUm;
+  /**
+   * Opt-in width necking: when a connection fails at its net-class trace width, retry it
+   * once with all trace half-widths clamped to this width (in micrometers). Intended for
+   * fine-pitch regions where the class width physically cannot exit the pads; supply a
+   * legal manufacturable width (e.g. the project's densest net class). 0/absent = off.
+   */
+  @SerializedName("neck_width_um")
+  public Double neckWidthUm;
   @SerializedName("job_timeout")
   public String jobTimeoutString;
   @SerializedName("max_passes")
@@ -390,6 +398,7 @@ public class RouterSettings implements Serializable, Cloneable {
     result.maxPasses = this.maxPasses;
     result.maxItems = this.maxItems;
     result.copperToEdgeClearanceUm = this.copperToEdgeClearanceUm;
+    result.neckWidthUm = this.neckWidthUm;
     result.ignoreNetClasses = (this.ignoreNetClasses != null) ? this.ignoreNetClasses.clone() : null;
     result.trace_pull_tight_accuracy = this.trace_pull_tight_accuracy;
     result.enabled = this.enabled;
@@ -403,6 +412,11 @@ public class RouterSettings implements Serializable, Cloneable {
     result.fanout = this.fanout != null ? this.fanout.clone() : new FanoutSettings();
 
     return result;
+  }
+
+  /** Neck width in micrometers, or 0 when width necking is disabled. */
+  public double getNeckWidthUm() {
+    return (neckWidthUm != null && neckWidthUm > 0) ? neckWidthUm : 0;
   }
 
   public int get_start_ripup_costs() {

--- a/src/main/java/app/freerouting/settings/sources/DefaultSettings.java
+++ b/src/main/java/app/freerouting/settings/sources/DefaultSettings.java
@@ -99,6 +99,7 @@ public class DefaultSettings implements SettingsSource {
         settings.ignoreNetClasses = new String[0];
         settings.maxThreads = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
         settings.copperToEdgeClearanceUm = DEFAULT_COPPER_TO_EDGE_CLEARANCE_UM;
+        settings.neckWidthUm = 0.0;
 
         // layers is left null intentionally –
         // they will be populated by DsnFileSettings (from the DSN layer count) and then

--- a/src/test/java/app/freerouting/settings/NeckWidthSettingsTest.java
+++ b/src/test/java/app/freerouting/settings/NeckWidthSettingsTest.java
@@ -1,0 +1,28 @@
+package app.freerouting.settings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import app.freerouting.settings.sources.CliSettings;
+import org.junit.jupiter.api.Test;
+
+/** CLI plumbing and helper semantics for the neck_width_um setting. */
+class NeckWidthSettingsTest {
+
+  @Test
+  void cliFlagReachesRouterSettings() {
+    CliSettings cli = new CliSettings(new String[]{"--router.neck_width_um=250"});
+    assertEquals(250.0, cli.getSettings().getNeckWidthUm(), 1e-9);
+  }
+
+  @Test
+  void defaultIsOff() {
+    assertEquals(0.0, new RouterSettings().getNeckWidthUm(), 1e-9);
+  }
+
+  @Test
+  void cloneCarriesTheField() {
+    RouterSettings settings = new RouterSettings();
+    settings.neckWidthUm = 130.0;
+    assertEquals(130.0, settings.clone().getNeckWidthUm(), 1e-9);
+  }
+}

--- a/src/test/java/app/freerouting/settings/sources/TestingSettings.java
+++ b/src/test/java/app/freerouting/settings/sources/TestingSettings.java
@@ -71,6 +71,10 @@ public class TestingSettings implements SettingsSource {
         this.settings.copperToEdgeClearanceUm = copperToEdgeClearanceUm;
     }
 
+    public void setNeckWidthUm(double neckWidthUm) {
+        this.settings.neckWidthUm = neckWidthUm;
+    }
+
     @Override
     public RouterSettings getSettings() {
         return settings;


### PR DESCRIPTION
Fine-pitch pads whose pitch is below (net-class width + clearance) are physically unroutable at class width; the failure surfaces as generic congestion and the connection stays open forever (real-world case: a GND net in a 0.5 mm Power class through 0.5 mm-pitch M.2 card-edge fingers — a single manual width override routed 27 connections instantly). With --router.neck_width_um=N set, a FAILED/INSERT_ERROR connection is retried once with every layer's trace half-width clamped to the neck width; the retry honors ripup settings and logs when it succeeds. Off by default; zero behavior change unless enabled.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary