### PR TITLE
ses: snap wire endpoints to contacted pad/via centers on export

### DIFF
--- a/src/main/java/app/freerouting/io/specctra/SesWriter.java
+++ b/src/main/java/app/freerouting/io/specctra/SesWriter.java
@@ -325,8 +325,14 @@ public final class SesWriter {
     int cornerIndex = 0;
     int[] prevCoors = null;
     for (int i = 0; i < cornerArr.length; i++) {
-      double[] currFloatCoors =
-          coordinateTransform.board_to_dsn(cornerArr[i].to_float());
+      FloatPoint cornerPoint = cornerArr[i].to_float();
+      if (i == 0 || i == cornerArr.length - 1) {
+        FloatPoint snapped = snappedEndpoint(wire, i == 0);
+        if (snapped != null) {
+          cornerPoint = snapped;
+        }
+      }
+      double[] currFloatCoors = coordinateTransform.board_to_dsn(cornerPoint);
       int[] currCoors = new int[2];
       currCoors[0] = (int) Math.round(currFloatCoors[0]);
       currCoors[1] = (int) Math.round(currFloatCoors[1]);
@@ -344,6 +350,44 @@ public final class SesWriter {
     writePath(boardLayer.name, wireWidth, coors, identifierType, file);
     writeFixedState(file, wire.get_fixed_state());
     file.end_scope();
+  }
+
+  /**
+   * Returns the exact pad/via center to use for a wire endpoint, or null to keep the corner
+   * as-is. Trace endpoints can sit on the border of freerouting's octagon approximation of a
+   * pad — a point that is inside the approximation but outside the importing tool's real pad
+   * polygon, which then reports the net as unconnected. Snapping the endpoint to the contacted
+   * drill item's center (the same coordinate {@code writeVia} emits) removes those sub-pad
+   * gaps. Only snaps when the endpoint already lies within the pad inradius of the center, so
+   * the last segment cannot leave the pad or fold across a neighbor.
+   */
+  static FloatPoint snappedEndpoint(PolylineTrace wire, boolean startSide) {
+    Point corner = startSide ? wire.first_corner() : wire.last_corner();
+    FloatPoint cornerFloat = corner.to_float();
+    java.util.Set<Item> contacts = startSide ? wire.get_start_contacts() : wire.get_end_contacts();
+    int layer = wire.get_layer();
+    for (Item contact : contacts) {
+      if (!(contact instanceof app.freerouting.board.DrillItem drill)) {
+        continue;
+      }
+      if (layer < drill.first_layer() || layer > drill.last_layer()) {
+        continue;
+      }
+      app.freerouting.geometry.planar.Shape padShape = drill.get_shape(layer - drill.first_layer());
+      if (padShape == null) {
+        continue;
+      }
+      FloatPoint center = drill.get_center().to_float();
+      double centerDistance = cornerFloat.distance(center);
+      if (centerDistance <= 0.5) {
+        // Already at the center (within rounding) — nothing to fix.
+        return null;
+      }
+      if (centerDistance <= padShape.border_distance(center)) {
+        return center;
+      }
+    }
+    return null;
   }
 
   private static void writeVia(Via via, BasicBoard board, IdentifierType identifierType,

--- a/src/test/java/app/freerouting/io/specctra/SesRoundTripTest.java
+++ b/src/test/java/app/freerouting/io/specctra/SesRoundTripTest.java
@@ -156,5 +156,55 @@ class SesRoundTripTest {
     SesWriter.write(board, out, "test.dsn");
     assertTrue(out.size() > 0, "SesWriter must write data to the stream");
   }
-}
 
+  /**
+   * Endpoint snapping: wire endpoints already at a contacted drill item's center must not be
+   * moved, endpoints inside the pad inradius snap to the exact center, and rewriting a board
+   * with snapping enabled keeps the session importable with the same wire count.
+   */
+  @Test
+  void endpointSnappingIsStableAndRoundTrips() throws Exception {
+    RoutingBoard board = DsnTestFixtures.loadBoard("Issue593-BBD_Mars-64.dsn");
+    java.io.InputStream sesIn = DsnTestFixtures.openResource("Issue593-BBD_Mars-64.ses");
+    SesImportSummary imported = SesReader.read(sesIn, board);
+    assertTrue(imported.wiresImported() > 0);
+
+    int tracesWithDrillContacts = 0;
+    for (app.freerouting.board.Item item : board.get_items()) {
+      if (!(item instanceof app.freerouting.board.PolylineTrace trace)) {
+        continue;
+      }
+      for (boolean startSide : new boolean[]{true, false}) {
+        var contacts = startSide ? trace.get_start_contacts() : trace.get_end_contacts();
+        boolean hasDrillContact = contacts.stream()
+            .anyMatch(c -> c instanceof app.freerouting.board.DrillItem);
+        if (!hasDrillContact) {
+          continue;
+        }
+        tracesWithDrillContacts++;
+        var corner = (startSide ? trace.first_corner() : trace.last_corner()).to_float();
+        var snapped = SesWriter.snappedEndpoint(trace, startSide);
+        if (snapped != null) {
+          // A snap may only move the endpoint to the center of a contacted drill item,
+          // and never further than that item's pad inradius.
+          boolean isDrillCenter = contacts.stream()
+              .filter(c -> c instanceof app.freerouting.board.DrillItem)
+              .map(c -> ((app.freerouting.board.DrillItem) c).get_center().to_float())
+              .anyMatch(center -> center.distance(snapped) < 0.5);
+          assertTrue(isDrillCenter, "snap target must be a contacted drill item center");
+          assertTrue(corner.distance(snapped) > 0.5, "null is expected for already-centered endpoints");
+        }
+      }
+    }
+    assertTrue(tracesWithDrillContacts > 0, "fixture must exercise drill-contacted endpoints");
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    SesWriter.write(board, out, "Issue593-BBD_Mars-64.dsn");
+    RoutingBoard fresh = DsnTestFixtures.loadBoard("Issue593-BBD_Mars-64.dsn");
+    SesImportSummary reimported = SesReader.read(
+        new ByteArrayInputStream(out.toByteArray()), fresh);
+    assertEquals(imported.wiresImported(), reimported.wiresImported(),
+        "snapping must not change the wire count on re-import");
+    assertEquals(0, reimported.errorsEncountered());
+  }
+}


### PR DESCRIPTION
Routed trace endpoints can sit on the border of freerouting's octagon approximation of a pad — inside the approximation but outside the importing tool's real pad polygon, so KiCad reports sub-millimeter unconnected gaps at pad landings (observed: 2 phantom unconnected on a board freerouting considered routed). Snap a wire's first/last corner to the contacted drill item's exact center — the identical coordinate writeVia emits — when the endpoint already lies within the pad inradius of the center, so the last segment can never leave the pad.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary