### PR TITLE
fanout: stop oscillating no-progress cycles the hash check misses

### DIFF
--- a/src/main/java/app/freerouting/autoroute/BatchFanout.java
+++ b/src/main/java/app/freerouting/autoroute/BatchFanout.java
@@ -92,7 +92,10 @@ public class BatchFanout {
     }
     int maxPasses = (p_settings.fanout != null && p_settings.fanout.maxPasses != null)
         ? p_settings.fanout.maxPasses : 20;
+    final int STAGNATION_PASS_LIMIT = 3;
     int completedPasses = 0;
+    long previousBoardState = Long.MIN_VALUE;
+    int identicalPasses = 0;
     String lastBoardHash = p_board.get_hash();
     for (int i = 0; i < maxPasses; ++i) {
       if (fanout_instance.deadlineMs != null && System.currentTimeMillis() >= fanout_instance.deadlineMs) {
@@ -107,6 +110,23 @@ public class BatchFanout {
       completedPasses++;
       if (routed_count == 0) {
         break;
+      }
+      // Oscillation detector, complementing the single-pass board-hash check below: a
+      // fanout cycle where pins keep ripping each other's escapes alternates between two
+      // board states, so consecutive hashes always differ — but the per-pass outcome
+      // (routed count + via count) repeats exactly while ripup costs escalate uselessly
+      // (observed: 14 identical passes on a dense SMD carrier).
+      long boardState = ((long) routed_count << 32) ^ p_board.get_vias().size();
+      if (boardState == previousBoardState) {
+        identicalPasses++;
+        if (identicalPasses >= STAGNATION_PASS_LIMIT) {
+          FRLogger.info("Fanout stopped after " + completedPasses + " passes: no progress for "
+              + STAGNATION_PASS_LIMIT + " consecutive passes.");
+          break;
+        }
+      } else {
+        identicalPasses = 0;
+        previousBoardState = boardState;
       }
       if (fanout_instance.isTimedOut) {
         break;


### PR DESCRIPTION
The single-pass board-hash comparison ends fanout when a pass changes nothing — but a stuck cycle where two pins keep ripping each other's escapes alternates between two board states, so consecutive hashes always differ and the loop burns every remaining pass with identical outcomes while ripup costs escalate (observed: 14 identical passes of '2 SMD pins fanouted, 9 not routed' on a dense SMD carrier).

Track the per-pass outcome tuple (routed count, board via count) and stop after three consecutive identical passes.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary