### PR TITLE
router: honor drill-hole-to-copper clearance end to end

### DIFF
--- a/src/main/java/app/freerouting/board/ForcedViaAlgo.java
+++ b/src/main/java/app/freerouting/board/ForcedViaAlgo.java
@@ -93,24 +93,48 @@ public class ForcedViaAlgo {
     int calc_from_side_offset = p_board.get_min_trace_half_width();
     ForcedPadAlgo forced_pad_algo = new ForcedPadAlgo(p_board);
     Padstack via_padstack = p_via_info.get_padstack();
+    Shape hole_shape = hole_check_shape(via_padstack, p_location, p_board);
     for (int i = via_padstack.from_layer(); i <= via_padstack.to_layer(); i++) {
       Shape curr_pad_shape = via_padstack.get_shape(i);
+      int curr_clearance_class = p_via_info.get_clearance_class();
       if (curr_pad_shape == null) {
-        continue;
+        if (hole_shape == null) {
+          continue;
+        }
+        // The drill hole itself must keep hole clearance from copper on this layer.
+        curr_pad_shape = hole_shape;
+        curr_clearance_class = 0;
+      } else {
+        curr_pad_shape = (Shape) curr_pad_shape.translate_by(translate_vector);
       }
-      curr_pad_shape = (Shape) curr_pad_shape.translate_by(translate_vector);
       TileShape tile_shape;
       if (p_board.rules.get_trace_angle_restriction() == AngleRestriction.NINETY_DEGREE) {
         tile_shape = curr_pad_shape.bounding_box();
       } else {
         tile_shape = curr_pad_shape.bounding_octagon();
       }
-      CalcFromSide from_side = forced_pad_algo.calc_from_side(tile_shape, p_location, i, calc_from_side_offset, p_via_info.get_clearance_class());
-      if (forced_pad_algo.check_forced_pad(tile_shape, from_side, i, p_net_no_arr, p_via_info.get_clearance_class(),
+      CalcFromSide from_side = forced_pad_algo.calc_from_side(tile_shape, p_location, i, calc_from_side_offset, curr_clearance_class);
+      if (forced_pad_algo.check_forced_pad(tile_shape, from_side, i, p_net_no_arr, curr_clearance_class,
           p_via_info.attach_smd_allowed(), null, p_max_recursion_depth,
           p_max_via_recursion_depth, false, null) == ForcedPadAlgo.CheckDrillResult.NOT_DRILLABLE) {
         p_board.set_shove_failing_layer(i);
         return false;
+      }
+      if (curr_clearance_class != 0 && hole_shape != null) {
+        // The drill hole must ALSO keep hole clearance from other-net copper on layers where
+        // the pad exists — the pad check above only enforces the (smaller) copper clearance.
+        TileShape hole_tile;
+        if (p_board.rules.get_trace_angle_restriction() == AngleRestriction.NINETY_DEGREE) {
+          hole_tile = hole_shape.bounding_box();
+        } else {
+          hole_tile = hole_shape.bounding_octagon();
+        }
+        if (forced_pad_algo.check_forced_pad(hole_tile, from_side, i, p_net_no_arr, 0,
+            p_via_info.attach_smd_allowed(), null, p_max_recursion_depth,
+            p_max_via_recursion_depth, false, null) == ForcedPadAlgo.CheckDrillResult.NOT_DRILLABLE) {
+          p_board.set_shove_failing_layer(i);
+          return false;
+        }
       }
 
       if (p_trace_pen_halfwidth_arr != null && i < p_trace_pen_halfwidth_arr.length && p_trace_pen_halfwidth_arr[i] > 0
@@ -144,12 +168,19 @@ public class ForcedViaAlgo {
     int calc_from_side_offset = p_board.get_min_trace_half_width();
     ForcedPadAlgo forced_pad_algo = new ForcedPadAlgo(p_board);
     Padstack via_padstack = p_via_info.get_padstack();
+    Shape hole_shape = hole_check_shape(via_padstack, p_location, p_board);
     for (int i = via_padstack.from_layer(); i <= via_padstack.to_layer(); i++) {
       Shape curr_pad_shape = via_padstack.get_shape(i);
+      int curr_clearance_class = p_via_info.get_clearance_class();
       if (curr_pad_shape == null) {
-        continue;
+        if (hole_shape == null) {
+          continue;
+        }
+        curr_pad_shape = hole_shape;
+        curr_clearance_class = 0;
+      } else {
+        curr_pad_shape = (Shape) curr_pad_shape.translate_by(translate_vector);
       }
-      curr_pad_shape = (Shape) curr_pad_shape.translate_by(translate_vector);
       TileShape tile_shape;
       Circle start_trace_circle;
       if (p_trace_pen_halfwidth_arr[i] > 0 && p_location instanceof IntPoint point) {
@@ -169,11 +200,24 @@ public class ForcedViaAlgo {
           start_trace_shape = start_trace_circle.bounding_octagon();
         }
       }
-      CalcFromSide from_side = forced_pad_algo.calc_from_side(tile_shape, p_location, i, calc_from_side_offset, p_via_info.get_clearance_class());
-      if (!forced_pad_algo.forced_pad(tile_shape, from_side, i, p_net_no_arr, p_via_info.get_clearance_class(), p_via_info.attach_smd_allowed(), null, p_max_recursion_depth,
+      CalcFromSide from_side = forced_pad_algo.calc_from_side(tile_shape, p_location, i, calc_from_side_offset, curr_clearance_class);
+      if (!forced_pad_algo.forced_pad(tile_shape, from_side, i, p_net_no_arr, curr_clearance_class, p_via_info.attach_smd_allowed(), null, p_max_recursion_depth,
           p_max_via_recursion_depth)) {
         p_board.set_shove_failing_layer(i);
         return false;
+      }
+      if (curr_clearance_class != 0 && hole_shape != null) {
+        TileShape hole_tile;
+        if (p_board.rules.get_trace_angle_restriction() == AngleRestriction.NINETY_DEGREE) {
+          hole_tile = hole_shape.bounding_box();
+        } else {
+          hole_tile = hole_shape.bounding_octagon();
+        }
+        if (!forced_pad_algo.forced_pad(hole_tile, from_side, i, p_net_no_arr, 0, p_via_info.attach_smd_allowed(), null, p_max_recursion_depth,
+            p_max_via_recursion_depth)) {
+          p_board.set_shove_failing_layer(i);
+          return false;
+        }
       }
       if (start_trace_shape != null) {
         // necessary in case start_trace_shape is bigger than tile_shape
@@ -185,6 +229,26 @@ public class ForcedViaAlgo {
     }
     p_board.insert_via(via_padstack, p_location, p_net_no_arr, p_via_info.get_clearance_class(), FixedState.UNFIXED, p_via_info.attach_smd_allowed());
     return true;
+  }
+
+
+  /**
+   * Hole-clearance substitute shape for a copper-less layer of a via padstack: the drill
+   * still passes through, so other copper must stay hole_clearance away from it. Returns
+   * null when the rule is off or no drill radius is known.
+   */
+  private static Shape hole_check_shape(Padstack p_padstack, Point p_location, RoutingBoard p_board) {
+    int hole_clearance = p_board.rules.get_hole_clearance();
+    if (hole_clearance <= 0 || !(p_location instanceof IntPoint center)) {
+      return null;
+    }
+    double drill_radius = p_padstack.get_drill_radius();
+    if (drill_radius <= 0) {
+      return null;
+    }
+    // Inflate by the hole clearance itself and check with the null clearance class (0), so
+    // the requirement is exact hole-to-copper spacing regardless of the neighbor's class.
+    return new Circle(center, (int) Math.ceil(drill_radius + hole_clearance + 10));
   }
 
   private static CalcFromSide calculate_from_side(FloatPoint p_via_location, TileShape p_via_shape, Simplex p_room_shape, double p_dist, boolean is_90_degree) {

--- a/src/main/java/app/freerouting/board/SearchTreeManager.java
+++ b/src/main/java/app/freerouting/board/SearchTreeManager.java
@@ -197,10 +197,23 @@ public class SearchTreeManager {
   }
 
   /**
-   * Reinsert all items into the search trees
+   * Reinsert all items into the search trees. Public because rule changes that affect
+   * precalculated tree shapes (e.g. the drill-hole clearance override, applied after the
+   * board is loaded) must refresh the shapes of already-inserted items.
    */
-  void reinsert_tree_items() {
+  public void reinsert_tree_items() {
     remove_all_board_items();
+    // Removing clears the tree entries but NOT the precalculated tree shapes cached on each
+    // item; without dropping those, re-insertion silently reuses the stale shapes and rule
+    // changes (e.g. the drill-hole clearance override) never reach the trees.
+    Iterator<UndoableObjects.UndoableObjectNode> it = this.board.item_list.start_read_object();
+    for (;;) {
+      Item curr_item = (Item) this.board.item_list.read_object(it);
+      if (curr_item == null) {
+        break;
+      }
+      curr_item.clear_derived_data();
+    }
     insert_all_board_items();
   }
 

--- a/src/main/java/app/freerouting/board/ShapeSearchTree.java
+++ b/src/main/java/app/freerouting/board/ShapeSearchTree.java
@@ -4,13 +4,16 @@ import app.freerouting.autoroute.CompleteFreeSpaceExpansionRoom;
 import app.freerouting.autoroute.IncompleteFreeSpaceExpansionRoom;
 import app.freerouting.datastructures.MinAreaTree;
 import app.freerouting.datastructures.Signum;
+import app.freerouting.geometry.planar.Circle;
 import app.freerouting.geometry.planar.ConvexShape;
 import app.freerouting.geometry.planar.FloatPoint;
 import app.freerouting.geometry.planar.IntBox;
+import app.freerouting.geometry.planar.IntPoint;
 import app.freerouting.geometry.planar.IntOctagon;
 import app.freerouting.geometry.planar.Line;
 import app.freerouting.geometry.planar.LineSegment;
 import app.freerouting.geometry.planar.Polyline;
+import app.freerouting.geometry.planar.Point;
 import app.freerouting.geometry.planar.PolylineShape;
 import app.freerouting.geometry.planar.RegularTileShape;
 import app.freerouting.geometry.planar.Shape;
@@ -19,6 +22,7 @@ import app.freerouting.geometry.planar.Side;
 import app.freerouting.geometry.planar.Simplex;
 import app.freerouting.geometry.planar.TileShape;
 import app.freerouting.logger.FRLogger;
+import app.freerouting.rules.BoardRules;
 import app.freerouting.rules.ClearanceMatrix;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,6 +39,7 @@ import java.util.TreeSet;
  */
 public class ShapeSearchTree extends MinAreaTree {
 
+  private static final int DRILL_HOLE_CLEARANCE_MARGIN = 10;
   /**
    * used in objects of class EntrySortedByClearance
    */
@@ -841,6 +846,9 @@ public class ShapeSearchTree extends MinAreaTree {
     for (int i = 0; i < result.length; i++) {
       Shape curr_shape = p_drill_item.get_shape(i);
       if (curr_shape == null) {
+        curr_shape = drill_hole_obstacle(p_drill_item);
+      }
+      if (curr_shape == null) {
         result[i] = null;
       } else {
         TileShape curr_tile_shape;
@@ -853,6 +861,7 @@ public class ShapeSearchTree extends MinAreaTree {
         }
         int offset_width = this.clearance_compensation_value(p_drill_item.clearance_class_no(),
             p_drill_item.shape_layer(i));
+        offset_width += drill_hole_clearance_delta(p_drill_item, curr_shape, p_drill_item.shape_layer(i));
         if (curr_tile_shape == null) {
           FRLogger.warn("ShapeSearchTree.calculate_tree_shapes: shape is null");
         } else {
@@ -862,6 +871,65 @@ public class ShapeSearchTree extends MinAreaTree {
       }
     }
     return result;
+  }
+
+  /**
+   * Synthesized obstacle for copper layers where a drilled item has NO pad shape: the drill
+   * hole still passes through (e.g. a through-via with unused inner layers), so other-net
+   * copper on those layers must keep hole clearance from it. Returns null when the
+   * hole-clearance rule is disabled or no drill radius is known.
+   */
+  protected Shape drill_hole_obstacle(DrillItem p_drill_item) {
+    if (this.board == null || this.board.rules == null || this.board.rules.get_hole_clearance() <= 0
+        || p_drill_item.get_padstack() == null) {
+      return null;
+    }
+    double drill_radius = p_drill_item.get_padstack().get_drill_radius();
+    if (drill_radius <= 0) {
+      return null;
+    }
+    Point center = p_drill_item.get_center();
+    if (!(center instanceof IntPoint)) {
+      center = center.to_float().round();
+    }
+    return new Circle((IntPoint) center, (int) Math.ceil(drill_radius));
+  }
+
+  /**
+   * Extra obstacle inflation so that copper of other nets stays hole_clearance away from this
+   * item's drill hole (not just its copper pad). Applies to every drilled item — vias, PTH pins
+   * and hole-only (NPTH) padstacks alike; returns 0 when the hole-clearance rule is disabled.
+   */
+  protected int drill_hole_clearance_delta(DrillItem p_drill_item, Shape p_shape, int p_layer) {
+    if (this.board == null || this.board.rules == null) {
+      return 0;
+    }
+    int hole_clearance = this.board.rules.get_hole_clearance();
+    if (hole_clearance <= 0 || p_shape == null || p_drill_item.get_padstack() == null) {
+      return 0;
+    }
+
+    double drill_radius = p_drill_item.get_padstack().get_drill_radius();
+    if (drill_radius <= 0) {
+      return 0;
+    }
+    double copper_radius;
+    if (p_drill_item.get_padstack().hole_only) {
+      copper_radius = drill_radius;
+    } else {
+      copper_radius = p_shape.border_distance(p_drill_item.get_center().to_float());
+      if (copper_radius <= 0) {
+        Shape pad_shape = p_drill_item.get_padstack().get_shape(p_layer);
+        copper_radius = pad_shape == null ? drill_radius : pad_shape.border_distance(FloatPoint.ZERO);
+      }
+    }
+    int clearance_class = this.compensated_clearance_class_no > 0
+        ? this.compensated_clearance_class_no
+        : BoardRules.default_clearance_class();
+    int copper_clearance = this.board.rules.clearance_matrix.get_value(p_drill_item.clearance_class_no(),
+        clearance_class, p_layer, false);
+    return Math.max(0, (int) Math.ceil(
+        drill_radius + hole_clearance + DRILL_HOLE_CLEARANCE_MARGIN - copper_radius - copper_clearance));
   }
 
   TileShape[] calculate_tree_shapes(ObstacleArea p_obstacle_area) {

--- a/src/main/java/app/freerouting/board/ShapeSearchTree45Degree.java
+++ b/src/main/java/app/freerouting/board/ShapeSearchTree45Degree.java
@@ -415,6 +415,9 @@ public class ShapeSearchTree45Degree extends ShapeSearchTree {
     for (int i = 0; i < result.length; i++) {
       Shape curr_shape = p_drill_item.get_shape(i);
       if (curr_shape == null) {
+        curr_shape = drill_hole_obstacle(p_drill_item);
+      }
+      if (curr_shape == null) {
         result[i] = null;
       } else {
         TileShape curr_tile_shape = curr_shape.bounding_octagon();
@@ -426,6 +429,7 @@ public class ShapeSearchTree45Degree extends ShapeSearchTree {
         }
 
         int offset_width = this.clearance_compensation_value(p_drill_item.clearance_class_no(), p_drill_item.shape_layer(i));
+        offset_width += drill_hole_clearance_delta(p_drill_item, curr_shape, p_drill_item.shape_layer(i));
         curr_tile_shape = (TileShape) curr_tile_shape.offset(offset_width);
         result[i] = curr_tile_shape.bounding_octagon();
       }

--- a/src/main/java/app/freerouting/board/ShapeSearchTree90Degree.java
+++ b/src/main/java/app/freerouting/board/ShapeSearchTree90Degree.java
@@ -328,11 +328,15 @@ public class ShapeSearchTree90Degree extends ShapeSearchTree {
     for (int i = 0; i < result.length; i++) {
       Shape curr_shape = p_drill_item.get_shape(i);
       if (curr_shape == null) {
+        curr_shape = drill_hole_obstacle(p_drill_item);
+      }
+      if (curr_shape == null) {
         result[i] = null;
       } else {
         IntBox curr_tile_shape = curr_shape.bounding_box();
         int offset_width = this.clearance_compensation_value(p_drill_item.clearance_class_no(),
             p_drill_item.shape_layer(i));
+        offset_width += drill_hole_clearance_delta(p_drill_item, curr_shape, p_drill_item.shape_layer(i));
         if (curr_tile_shape == null) {
           FRLogger.warn("BoxShapeSearchTree.calculate_tree_shapes: shape is null");
         } else {

--- a/src/main/java/app/freerouting/core/Padstack.java
+++ b/src/main/java/app/freerouting/core/Padstack.java
@@ -29,6 +29,13 @@ public class Padstack implements Comparable<Padstack>, ObjectInfoPanel.Printable
   public final boolean placed_absolute;
   private final ConvexShape[] shapes;
   /**
+   * True for padstacks whose copper-layer shapes were synthesized from the drill radius because
+   * the source padstack had no copper at all (non-plated holes). Such shapes exist only so the
+   * hole becomes an obstacle for routing and DRC; they must not be treated as real copper (e.g.
+   * not re-exported).
+   */
+  public boolean hole_only = false;
+  /**
    * Pointer to the pacdstack list containing this padstack
    */
   private final Padstacks padstack_list;

--- a/src/main/java/app/freerouting/management/HeadlessBoardManager.java
+++ b/src/main/java/app/freerouting/management/HeadlessBoardManager.java
@@ -79,6 +79,7 @@ import java.io.OutputStream;
 public class HeadlessBoardManager implements BoardManager {
 
   private static final String BOARD_EDGE_CLEARANCE_CLASS_NAME = "board_edge";
+  private static final String HOLE_EDGE_CLEARANCE_CLASS_NAME = "hole_edge";
 
 
   /**
@@ -279,6 +280,107 @@ public class HeadlessBoardManager implements BoardManager {
     this.board = new RoutingBoard(p_bounding_box, p_layer_structure, p_outline_shapes, outline_cl_class_no, p_rules,
         p_board_communication);
     applyCopperToEdgeClearanceOverride();
+    applyHoleClearanceOverride();
+  }
+
+  private void applyHoleClearanceOverride() {
+    if (this.board == null || this.routingJob == null || this.routingJob.routerSettings == null
+        || this.routingJob.routerSettings.holeClearanceUm == null) {
+      return;
+    }
+
+    double configuredClearanceUm = this.routingJob.routerSettings.holeClearanceUm;
+    if (configuredClearanceUm < 0) {
+      FRLogger.warn("Ignoring router.hole_clearance_um because it is negative: " + configuredClearanceUm);
+      return;
+    }
+    if (this.board.rules == null) {
+      FRLogger.warn("Ignoring router.hole_clearance_um because board rules are unavailable.");
+      return;
+    }
+
+    int boardResolution = Math.max(1, this.board.communication.resolution);
+    int configuredClearanceBoardUnits = (int) Math.round(
+        Unit.scale(configuredClearanceUm * boardResolution, Unit.UM, this.board.communication.unit));
+    boolean changed = configuredClearanceBoardUnits != this.board.rules.get_hole_clearance();
+    this.board.rules.set_hole_clearance(configuredClearanceBoardUnits);
+    int holeKeepouts = 0;
+    if (configuredClearanceBoardUnits > 0) {
+      holeKeepouts = assignHoleKeepoutClearanceClass(configuredClearanceBoardUnits);
+    }
+    if (changed || holeKeepouts > 0) {
+      // Tree shapes are precalculated at insert time; items loaded before the override
+      // (all of them, on a DSN load) must be re-inserted so their obstacle shapes include
+      // the drill-hole inflation. Otherwise DRC (default tree) under-reports and routing
+      // trees created later disagree with it.
+      this.board.search_tree_manager.reinsert_tree_items();
+    }
+
+    if (configuredClearanceBoardUnits > 0) {
+      FRLogger.info("Applied drill-hole clearance override: " + configuredClearanceUm + " um ("
+          + configuredClearanceBoardUnits + " board units)"
+          + (holeKeepouts > 0 ? ", " + holeKeepouts + " hole keepouts reclassified." : "."));
+    }
+  }
+
+  /**
+   * KiCad's DSN export represents non-plated holes as circular per-copper-layer package
+   * keepouts, which by default only get the generic AREA copper clearance. Assign those
+   * circle keepouts to a dedicated "hole_edge" clearance class so other-net copper keeps
+   * hole clearance (not just copper clearance) from the hole boundary. Returns the number
+   * of keepouts reclassified.
+   */
+  private int assignHoleKeepoutClearanceClass(int holeClearanceBoardUnits) {
+    var matrix = this.board.rules.clearance_matrix;
+    if (matrix == null) {
+      return 0;
+    }
+    java.util.List<app.freerouting.board.ObstacleArea> holeKeepouts = new java.util.ArrayList<>();
+    for (app.freerouting.board.Item item : this.board.get_items()) {
+      if (item.getClass() != app.freerouting.board.ObstacleArea.class) {
+        continue;
+      }
+      app.freerouting.board.ObstacleArea keepout = (app.freerouting.board.ObstacleArea) item;
+      // Package keepouts belong to a component; a circular one is a drilled hole in the
+      // footprint (the only way KiCad expresses NPTH in DSN).
+      if (keepout.get_component_no() > 0
+          && keepout.get_area() instanceof app.freerouting.geometry.planar.Circle) {
+        holeKeepouts.add(keepout);
+      }
+    }
+    if (holeKeepouts.isEmpty()) {
+      return 0;
+    }
+    int holeEdgeClassNo = matrix.get_no(HOLE_EDGE_CLEARANCE_CLASS_NAME);
+    if (holeEdgeClassNo < 0) {
+      matrix.append_class(HOLE_EDGE_CLEARANCE_CLASS_NAME);
+      holeEdgeClassNo = matrix.get_no(HOLE_EDGE_CLEARANCE_CLASS_NAME);
+    }
+    if (holeEdgeClassNo < 0) {
+      FRLogger.warn("Unable to create/find the hole_edge clearance class for the hole clearance override.");
+      return 0;
+    }
+    int defaultAreaClassNo = this.board.rules.get_default_net_class().default_item_clearance_classes
+        .get(DefaultItemClearanceClasses.ItemClass.AREA);
+    for (int layer = 0; layer < matrix.get_layer_count(); layer++) {
+      for (int classNo = 1; classNo < matrix.get_class_count(); classNo++) {
+        // Never reduce an existing requirement: hole clearance is a floor on top of the
+        // normal copper clearance the keepout would otherwise get.
+        int value = Math.max(holeClearanceBoardUnits,
+            matrix.get_value(defaultAreaClassNo, classNo, layer, false));
+        matrix.set_value(holeEdgeClassNo, classNo, layer, value);
+        matrix.set_value(classNo, holeEdgeClassNo, layer, value);
+      }
+    }
+    int reclassified = 0;
+    for (app.freerouting.board.ObstacleArea keepout : holeKeepouts) {
+      if (keepout.clearance_class_no() != holeEdgeClassNo) {
+        keepout.set_clearance_class_no(holeEdgeClassNo);
+        keepout.clear_derived_data();
+        reclassified++;
+      }
+    }
+    return reclassified;
   }
 
   private void applyCopperToEdgeClearanceOverride() {
@@ -500,6 +602,7 @@ public class HeadlessBoardManager implements BoardManager {
         }
         this.routingJob.routerSettings.applyBoardSpecificOptimizations(this.board);
         applyCopperToEdgeClearanceOverride();
+        applyHoleClearanceOverride();
       }
 
       if (this.board != null) {
@@ -561,6 +664,7 @@ public class HeadlessBoardManager implements BoardManager {
         }
         this.routingJob.routerSettings.applyBoardSpecificOptimizations(this.board);
         applyCopperToEdgeClearanceOverride();
+        applyHoleClearanceOverride();
       }
 
       if (this.board != null) {

--- a/src/main/java/app/freerouting/rules/BoardRules.java
+++ b/src/main/java/app/freerouting/rules/BoardRules.java
@@ -51,6 +51,7 @@ public class BoardRules implements Serializable {
    */
   private double pin_edge_to_turn_dist;
   private boolean use_slow_autoroute_algorithm;
+  private int hole_clearance;
 
   /**
    * Creates a new instance of this class.
@@ -63,6 +64,7 @@ public class BoardRules implements Serializable {
 
     this.min_trace_half_width = 100000;
     this.max_trace_half_width = 100;
+    this.hole_clearance = 0;
   }
 
   /**
@@ -114,6 +116,14 @@ public class BoardRules implements Serializable {
    */
   public int get_max_trace_half_width() {
     return max_trace_half_width;
+  }
+
+  public int get_hole_clearance() {
+    return hole_clearance;
+  }
+
+  public void set_hole_clearance(int p_value) {
+    this.hole_clearance = Math.max(0, p_value);
   }
 
   /**

--- a/src/main/java/app/freerouting/settings/RouterSettings.java
+++ b/src/main/java/app/freerouting/settings/RouterSettings.java
@@ -24,6 +24,8 @@ public class RouterSettings implements Serializable, Cloneable {
   public FanoutSettings fanout;
   @SerializedName("copper_to_edge_clearance_um")
   public Double copperToEdgeClearanceUm;
+  @SerializedName("hole_clearance_um")
+  public Double holeClearanceUm;
   @SerializedName("job_timeout")
   public String jobTimeoutString;
   @SerializedName("max_passes")
@@ -390,6 +392,7 @@ public class RouterSettings implements Serializable, Cloneable {
     result.maxPasses = this.maxPasses;
     result.maxItems = this.maxItems;
     result.copperToEdgeClearanceUm = this.copperToEdgeClearanceUm;
+    result.holeClearanceUm = this.holeClearanceUm;
     result.ignoreNetClasses = (this.ignoreNetClasses != null) ? this.ignoreNetClasses.clone() : null;
     result.trace_pull_tight_accuracy = this.trace_pull_tight_accuracy;
     result.enabled = this.enabled;

--- a/src/main/java/app/freerouting/settings/sources/DefaultSettings.java
+++ b/src/main/java/app/freerouting/settings/sources/DefaultSettings.java
@@ -74,6 +74,8 @@ public class DefaultSettings implements SettingsSource {
     public static final double DEFAULT_UNDESIRED_DIRECTION_TRACE_COST = 1.0;
     /** Default copper-to-board-edge clearance in micrometres (0.5 mm). */
     public static final double DEFAULT_COPPER_TO_EDGE_CLEARANCE_UM = 500.0;
+    /** Default drill-hole-to-copper clearance in micrometres. Zero preserves legacy DSN behaviour. */
+    public static final double DEFAULT_HOLE_CLEARANCE_UM = 0.0;
     private static final int PRIORITY = 0;
 
     @Override
@@ -99,6 +101,7 @@ public class DefaultSettings implements SettingsSource {
         settings.ignoreNetClasses = new String[0];
         settings.maxThreads = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
         settings.copperToEdgeClearanceUm = DEFAULT_COPPER_TO_EDGE_CLEARANCE_UM;
+        settings.holeClearanceUm = DEFAULT_HOLE_CLEARANCE_UM;
 
         // layers is left null intentionally –
         // they will be populated by DsnFileSettings (from the DSN layer count) and then

--- a/src/test/java/app/freerouting/board/DrillHoleClearanceShapeTest.java
+++ b/src/test/java/app/freerouting/board/DrillHoleClearanceShapeTest.java
@@ -1,0 +1,136 @@
+package app.freerouting.board;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import app.freerouting.geometry.planar.FortyfiveDegreeBoundingDirections;
+import app.freerouting.geometry.planar.IntBox;
+import app.freerouting.geometry.planar.TileShape;
+import app.freerouting.io.specctra.DsnTestFixtures;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The drill-hole clearance inflation must apply to every drilled item (vias AND pins) in every
+ * search-tree variant — including the 45-degree tree, which is the default autoroute tree and
+ * historically skipped the delta entirely.
+ */
+class DrillHoleClearanceShapeTest {
+
+  private static final String FIXTURE = "Issue575-drc_dev-board_4_hole_clearance_violations.dsn";
+  private static final int HOLE_CLEARANCE_BOARD_UNITS = 200000;
+
+  private static List<DrillItem> drilledItems(RoutingBoard board) {
+    List<DrillItem> result = new ArrayList<>();
+    for (Via via : board.get_vias()) {
+      if (via.get_padstack() != null && via.get_padstack().get_drill_radius() > 0) {
+        result.add(via);
+        break;
+      }
+    }
+    for (Pin pin : board.get_pins()) {
+      if (pin.get_padstack() != null && pin.get_padstack().get_drill_radius() > 0
+          && pin.tile_shape_count() > 0 && pin.get_shape(0) != null) {
+        result.add(pin);
+        break;
+      }
+    }
+    return result;
+  }
+
+  private static long boxArea(TileShape shape) {
+    IntBox box = shape.bounding_box();
+    return (long) (box.ur.x - box.ll.x) * (box.ur.y - box.ll.y);
+  }
+
+  @Test
+  void holeClearanceInflatesDrilledItemShapesInAllTreeVariants() throws Exception {
+    RoutingBoard board = DsnTestFixtures.loadBoard(FIXTURE);
+    List<DrillItem> items = drilledItems(board);
+    assumeTrue(!items.isEmpty(), "fixture must contain drilled items");
+    boolean sawVia = items.stream().anyMatch(it -> it instanceof Via);
+    boolean sawPin = items.stream().anyMatch(it -> it instanceof Pin);
+    assertTrue(sawVia && sawPin, "fixture must provide both a via and a drilled pin");
+
+    for (DrillItem item : items) {
+      board.rules.set_hole_clearance(0);
+      TileShape[] base0 = new ShapeSearchTree(FortyfiveDegreeBoundingDirections.INSTANCE,
+          board, 0).calculate_tree_shapes(item);
+      TileShape[] tree45_0 = new ShapeSearchTree45Degree(board, 0).calculate_tree_shapes(item);
+      TileShape[] tree90_0 = new ShapeSearchTree90Degree(board, 0).calculate_tree_shapes(item);
+
+      board.rules.set_hole_clearance(HOLE_CLEARANCE_BOARD_UNITS);
+      TileShape[] base1 = new ShapeSearchTree(FortyfiveDegreeBoundingDirections.INSTANCE,
+          board, 0).calculate_tree_shapes(item);
+      TileShape[] tree45_1 = new ShapeSearchTree45Degree(board, 0).calculate_tree_shapes(item);
+      TileShape[] tree90_1 = new ShapeSearchTree90Degree(board, 0).calculate_tree_shapes(item);
+
+      String label = item.getClass().getSimpleName();
+      assertEquals(base0.length, base1.length, label);
+      for (int i = 0; i < base0.length; i++) {
+        if (base0[i] == null) {
+          continue;
+        }
+        assertTrue(boxArea(base1[i]) > boxArea(base0[i]),
+            label + " shape " + i + " must grow in the base tree");
+        assertTrue(boxArea(tree45_1[i]) > boxArea(tree45_0[i]),
+            label + " shape " + i + " must grow in the 45-degree tree");
+        assertTrue(boxArea(tree90_1[i]) > boxArea(tree90_0[i]),
+            label + " shape " + i + " must grow in the 90-degree tree");
+      }
+    }
+    board.rules.set_hole_clearance(0);
+  }
+
+  @Test
+  void nullShapeLayersGetSynthesizedHoleObstacles() throws Exception {
+    RoutingBoard board = DsnTestFixtures.loadBoard(FIXTURE);
+    Via via = null;
+    int nullIdx = -1;
+    for (Via v : board.get_vias()) {
+      if (v.get_padstack() == null || v.get_padstack().get_drill_radius() <= 0) {
+        continue;
+      }
+      for (int i = 0; i < v.tile_shape_count(); i++) {
+        if (v.get_shape(i) == null) {
+          via = v;
+          nullIdx = i;
+          break;
+        }
+      }
+      if (via != null) {
+        break;
+      }
+    }
+    assumeTrue(via != null, "fixture must contain a via with a copper-less layer");
+
+    board.rules.set_hole_clearance(0);
+    TileShape[] legacy = new ShapeSearchTree45Degree(board, 0).calculate_tree_shapes(via);
+    assertTrue(legacy[nullIdx] == null, "no obstacle without the hole-clearance rule");
+
+    board.rules.set_hole_clearance(2500);
+    TileShape[] holeAware = new ShapeSearchTree45Degree(board, 0).calculate_tree_shapes(via);
+    assertTrue(holeAware[nullIdx] != null,
+        "the drill hole must become an obstacle on copper-less layers");
+    board.rules.set_hole_clearance(0);
+  }
+
+  @Test
+  void zeroHoleClearanceKeepsLegacyShapes() throws Exception {
+    RoutingBoard board = DsnTestFixtures.loadBoard(FIXTURE);
+    List<DrillItem> items = drilledItems(board);
+    assumeTrue(!items.isEmpty());
+    board.rules.set_hole_clearance(0);
+    for (DrillItem item : items) {
+      TileShape[] a = new ShapeSearchTree45Degree(board, 0).calculate_tree_shapes(item);
+      TileShape[] b = new ShapeSearchTree45Degree(board, 0).calculate_tree_shapes(item);
+      for (int i = 0; i < a.length; i++) {
+        if (a[i] != null) {
+          assertEquals(boxArea(a[i]), boxArea(b[i]));
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/app/freerouting/fixtures/HoleKeepoutClearanceTest.java
+++ b/src/test/java/app/freerouting/fixtures/HoleKeepoutClearanceTest.java
@@ -1,0 +1,54 @@
+package app.freerouting.fixtures;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import app.freerouting.board.Item;
+import app.freerouting.board.ObstacleArea;
+import app.freerouting.core.RoutingJob;
+import app.freerouting.geometry.planar.Circle;
+import app.freerouting.settings.sources.TestingSettings;
+import org.junit.jupiter.api.Test;
+
+/**
+ * KiCad exports NPTH holes as circular per-copper-layer package keepouts. With the
+ * hole-clearance override active they must be assigned to the dedicated "hole_edge"
+ * clearance class so copper keeps hole clearance from the hole boundary.
+ */
+public class HoleKeepoutClearanceTest extends RoutingFixtureTest {
+
+  @Test
+  void npthKeepoutsGetHoleEdgeClearanceClass() {
+    var testingSettings = new TestingSettings();
+    testingSettings.setHoleClearanceUm(250.0);
+    // Load-only: all stages off — this test is about board preparation, not routing.
+    testingSettings.setFanoutEnabled(false);
+    testingSettings.setRouterEnabled(false);
+    testingSettings.setOptimizerEnabled(false);
+    testingSettings.setJobTimeoutString("00:02:00");
+    RoutingJob job = GetRoutingJob("Issue230-CNH_Functional_Tester_1.dsn", testingSettings);
+
+    job = RunRoutingJob(job);
+
+    var matrix = job.board.rules.clearance_matrix;
+    int holeEdgeClassNo = matrix.get_no("hole_edge");
+    assertTrue(holeEdgeClassNo > 0, "hole_edge clearance class must exist");
+
+    int reclassified = 0;
+    for (Item item : job.board.get_items()) {
+      if (item.getClass() == ObstacleArea.class && item.get_component_no() > 0
+          && ((ObstacleArea) item).get_area() instanceof Circle) {
+        assertEquals(holeEdgeClassNo, item.clearance_class_no(),
+            "circular package keepout (NPTH hole) must use the hole_edge class");
+        reclassified++;
+      }
+    }
+    assertTrue(reclassified > 0, "fixture must contain NPTH keepout circles");
+
+    int expectedBoardUnits = 250 * Math.max(1, job.board.communication.resolution);
+    for (int layer = 0; layer < matrix.get_layer_count(); layer++) {
+      assertTrue(matrix.get_value(holeEdgeClassNo, 1, layer, false) >= expectedBoardUnits,
+          "hole_edge clearance must be at least the configured hole clearance");
+    }
+  }
+}

--- a/src/test/java/app/freerouting/io/specctra/DsnTestFixtures.java
+++ b/src/test/java/app/freerouting/io/specctra/DsnTestFixtures.java
@@ -42,7 +42,7 @@ public final class DsnTestFixtures {
    * @return the loaded routing board
    * @throws IOException if the file cannot be found or the DSN is invalid
    */
-  static RoutingBoard loadBoard(String filename) throws IOException {
+  public static RoutingBoard loadBoard(String filename) throws IOException {
     return loadBoardFromStream(openFixtureStream(filename));
   }
 

--- a/src/test/java/app/freerouting/settings/sources/TestingSettings.java
+++ b/src/test/java/app/freerouting/settings/sources/TestingSettings.java
@@ -71,6 +71,10 @@ public class TestingSettings implements SettingsSource {
         this.settings.copperToEdgeClearanceUm = copperToEdgeClearanceUm;
     }
 
+    public void setHoleClearanceUm(double holeClearanceUm) {
+        this.settings.holeClearanceUm = holeClearanceUm;
+    }
+
     @Override
     public RouterSettings getSettings() {
         return settings;


### PR DESCRIPTION
Adds an optional --router.hole_clearance_um setting (default 0 = legacy behavior, zero cost when off) that enforces the board's hole-to-copper clearance rule everywhere copper can meet a drill:

- Search trees inflate every drilled item's obstacle shape so traces keep hole clearance from via/pin drills — including the 45/90-degree autoroute trees, which previously applied no hole inflation at all (the 45-degree tree is the default autoroute tree, so routing was entirely hole-blind), and including copper-less layers of through items, which previously contributed no obstacle whatsoever.
- ForcedViaAlgo checks the drill circle (inflated by the hole clearance, null clearance class) on every layer before placing or shoving a via, so vias no longer land with their hole a few tens of microns from existing traces.
- Circular package keepouts (how KiCad exports NPTH mounting holes to DSN) are assigned to a dedicated 'hole_edge' clearance class so copper keeps hole clearance from the hole boundary instead of the generic AREA copper clearance.
- Rule changes after board load re-insert tree items AND drop their cached precalculated shapes (previously re-insertion silently reused stale geometry).

Validated on a real 4-layer KiCad board (238-connection carrier, 0.25 mm hole clearance): KiCad DRC hole_clearance violations on the routed result drop from dozens to zero; routing quality on the project's own fixtures (BBD Mars-64, CNH tester) is unchanged.

Co-developed while driving freerouting headless from KiCad; all new behavior is opt-in via the setting and covered by unit tests (DrillHoleClearanceShapeTest, HoleKeepoutClearanceTest) plus a TestingSettings hook.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary