### PR TITLE
Add RoutingEtaCalculator and improve ETA functionality

### DIFF
--- a/src/main/java/app/freerouting/core/RoutingEtaCalculator.java
+++ b/src/main/java/app/freerouting/core/RoutingEtaCalculator.java
@@ -1,0 +1,666 @@
+package app.freerouting.core;
+
+import app.freerouting.core.scoring.BoardStatistics;
+import app.freerouting.core.scoring.RoutingEta;
+import app.freerouting.core.scoring.RoutingEta.Confidence;
+import app.freerouting.logger.FRLogger;
+
+/**
+ * Calculates and maintains an ETA for the routing job.
+ *
+ * <h2>Key design decisions</h2>
+ * <ul>
+ *   <li><b>Continuous-time regression, not pass-endpoint regression.</b> Every update() call
+ *       contributes a sample of (elapsedSeconds, ln(remaining)) to a rolling window. This gives
+ *       real signal mid-pass, including during a long first pass.</li>
+ *   <li><b>Normalized score as the progress signal.</b> Uses BoardStatistics.getNormalizedScore()
+ *       which captures ALL quality factors: unrouted connections, clearance violations, trace
+ *       bends, trace length, and via count. This naturally handles ripup/reroute non-monotonicity
+ *       since the score only improves when the board genuinely gets better.</li>
+ *   <li><b>R²-gated confidence, with a progress-only display mode below threshold.</b> A weak
+ *       regression fit produces a progress string instead of a falsely confident time estimate.</li>
+ *   <li><b>Statistical prediction band</b> from the regression's own residual standard error.</li>
+ *   <li><b>Display-side hysteresis</b> decoupled from the model: increases require confirmation,
+ *       decreases shown immediately.</li>
+ *   <li><b>Fanout shows progress only</b> (no time estimate) since it's typically too fast to
+ *       estimate reliably.</li>
+ *   <li><b>Pass count hidden from progress text</b> to avoid misleading "Pass 1/100" displays.</li>
+ * </ul>
+ */
+public class RoutingEtaCalculator {
+
+  // ---------- Regression window ----------
+  private static final int REGRESSION_WINDOW_SIZE = 24;
+  private static final double MIN_SAMPLE_INTERVAL_SECONDS = 1.5;
+
+  // ---------- Confidence / display gating ----------
+  private static final double R_SQUARED_LOW_THRESHOLD = 0.5;
+  private static final double R_SQUARED_HIGH_THRESHOLD = 0.85;
+  private static final int MIN_SAMPLES_FOR_LOW_CONFIDENCE = 4;
+  private static final int MIN_SAMPLES_FOR_MEDIUM_CONFIDENCE = 8;
+  private static final int MIN_SAMPLES_FOR_HIGH_CONFIDENCE = 14;
+
+  // ---------- Display hysteresis ----------
+  private static final int HYSTERESIS_CONFIRM_COUNT = 3;
+  private static final double HYSTERESIS_BYPASS_RATIO = 2.0;
+
+  // ---------- EWMA smoothing constants (fanout/optimizer only; autoroute uses regression) ----------
+  private static final double EWMA_PASS_DURATION = 0.3;
+  private static final double EWMA_OPTIMIZER = 0.5;
+  private static final double EWMA_FANOUT = 0.3;
+
+  // Phase identifiers
+  private static final String PHASE_IDLE = "idle";
+  private static final String PHASE_FANOUT = "fanout";
+  private static final String PHASE_AUTOROUTE = "autoroute";
+  private static final String PHASE_OPTIMIZER = "optimizer";
+  private static final String PHASE_COMPLETED = "completed";
+  private static final String PHASE_STOPPED = "stopped";
+
+  // ---------- Bound constants ----------
+  private static final double MAX_ACCEPTABLE_ETA_SECONDS = 7200; // 2h cap
+  private static final int DEFAULT_MAX_OPTIMIZER_PASSES = 10;
+  private static final int STUCK_NET_FAILURE_THRESHOLD = 5;
+
+  // "Effectively done" threshold: solving the regression for when the remaining
+  // value reaches this (rather than exactly 0, which is -infinity in log space)
+  // gives a finite, well-defined forecast time.
+  private static final double COMPLETION_FRACTION_EPSILON_ITEMS = 0.5;
+
+  // ---------- State ----------
+  private String currentPhase = PHASE_IDLE;
+  private int autoroutePassesCompleted = 0;
+  private int optimizerPassesCompleted = 0;
+  private double totalElapsedSeconds = 0;
+
+  private double ewmaPassDuration = -1;          // steady-state (pass 2+) only
+  private double firstPassDurationSeconds = -1;  // tracked separately from steady-state EWMA
+  private double ewmaOptimizerPassDuration = -1;
+  private double ewmaFanoutItemsPerSecond = -1;
+
+  private int lastKnownIncompleteCount = 0;
+  private int lastKnownMaximumCount = 0;
+  private int totalConnectableItems = 0; // fallback denominator if BoardStatistics unavailable
+  private double phaseStartTimeSeconds;
+  private int maxPasses = 100;
+  private int maxOptimizerPasses = DEFAULT_MAX_OPTIMIZER_PASSES;
+  private int threadCount = 1;
+
+  // Continuous-time regression window: (elapsedSeconds, ln(remaining))
+  private final double[] regressionX = new double[REGRESSION_WINDOW_SIZE];
+  private final double[] regressionY = new double[REGRESSION_WINDOW_SIZE];
+  private int regressionIndex = 0;
+  private int regressionCount = 0;
+  private double lastSampleElapsedSeconds = -1;
+
+  // Cached regression fit, recomputed each time a sample is added
+  private double fitSlope = Double.NaN;
+  private double fitIntercept = Double.NaN;
+  private double fitRSquared = 0;
+  private double fitResidualStdError = 0;
+  private double fitMeanX = 0;
+  private double fitSumSqX = 0;
+
+  // Stuck-net tracking, fed externally from failureLog aggregation
+  private int stuckNetCount = 0;
+
+  // Stagnation tracking, fed from BatchAutorouter's own counters
+  private int consecutiveNoImprovementPasses = 0;
+  private int stagnationPassLimit = 10;
+
+  // Display-side hysteresis state (independent of the underlying model)
+  private double lastDisplayedEtaSeconds = -1;
+  private int consecutiveWorseReadings = 0;
+
+  // Frozen state
+  private boolean frozen = false;
+  private RoutingEta frozenEta = null;
+  private boolean started = false;
+
+  public RoutingEtaCalculator() {
+  }
+
+  /** Must be called when routing begins. */
+  public void startRouting() {
+    reset();
+    this.started = true;
+    this.phaseStartTimeSeconds = currentTimeSeconds();
+    this.frozen = false;
+    this.frozenEta = null;
+    FRLogger.debug("RoutingEtaCalculator: started");
+  }
+
+  /**
+   * Call whenever a different board is loaded, including before routing starts on it.
+   * Without this, a previous board's frozen "Completed"/"Stopped" state (or stale display
+   * hysteresis) persists on screen since nothing else clears it until Route is pressed again.
+   */
+  public void notifyBoardChanged() {
+    FRLogger.debug("RoutingEtaCalculator: board changed, clearing state");
+    reset();
+  }
+
+  public void setTotalConnectableItems(int total) {
+    this.totalConnectableItems = total > 0 ? total : 0;
+  }
+
+  public void setMaxPasses(int maxPasses) {
+    this.maxPasses = maxPasses > 0 ? maxPasses : 100;
+  }
+
+  public void setMaxOptimizerPasses(int maxOptimizerPasses) {
+    this.maxOptimizerPasses = maxOptimizerPasses > 0 ? maxOptimizerPasses : DEFAULT_MAX_OPTIMIZER_PASSES;
+  }
+
+  public void setThreadCount(int threadCount) {
+    this.threadCount = threadCount > 0 ? threadCount : 1;
+  }
+
+  public void setStagnationPassLimit(int stagnationPassLimit) {
+    this.stagnationPassLimit = stagnationPassLimit > 0 ? stagnationPassLimit : 10;
+  }
+
+  /** Call once per pass with BatchAutorouter's consecutiveNoImprovementPasses. */
+  public void updateStagnation(int consecutiveNoImprovementPasses) {
+    this.consecutiveNoImprovementPasses = Math.max(0, consecutiveNoImprovementPasses);
+  }
+
+  /**
+   * Call whenever the set of DRC-blocked / currently-unroutable nets changes (driven by
+   * board.failureLog: a net with a stable failure reason for STUCK_NET_FAILURE_THRESHOLD+
+   * consecutive passes). Excluding these from the completion target stops the model from
+   * chasing a 100% that is not currently achievable.
+   */
+  public void updateStuckNetCount(int stuckNetCount) {
+    this.stuckNetCount = Math.max(0, stuckNetCount);
+  }
+
+  // ======================== Phase lifecycle ========================
+
+  public void onFanoutStarted() {
+    if (frozen || !started) return;
+    FRLogger.debug("RoutingEtaCalculator: fanout started");
+    this.currentPhase = PHASE_FANOUT;
+    this.phaseStartTimeSeconds = currentTimeSeconds();
+    this.ewmaFanoutItemsPerSecond = -1;
+  }
+
+  public void onAutorouteStarted() {
+    if (frozen || !started) return;
+    FRLogger.debug("RoutingEtaCalculator: autoroute started");
+    this.currentPhase = PHASE_AUTOROUTE;
+    this.phaseStartTimeSeconds = currentTimeSeconds();
+    this.ewmaPassDuration = -1;
+    this.firstPassDurationSeconds = -1;
+    resetRegressionWindow();
+    this.consecutiveNoImprovementPasses = 0;
+    this.stuckNetCount = 0;
+    this.lastDisplayedEtaSeconds = -1;
+    this.consecutiveWorseReadings = 0;
+  }
+
+  public void onOptimizerStarted() {
+    if (frozen || !started) return;
+    FRLogger.debug("RoutingEtaCalculator: optimizer started");
+    this.currentPhase = PHASE_OPTIMIZER;
+    this.phaseStartTimeSeconds = currentTimeSeconds();
+    this.optimizerPassesCompleted = 0;
+  }
+
+  public void onRoutingStopped() {
+    onRoutingStopped(null);
+  }
+
+  public void onRoutingStopped(String reason) {
+    if (frozen) return;
+    FRLogger.debug("RoutingEtaCalculator: routing stopped, freezing" + (reason != null ? " (" + reason + ")" : ""));
+    this.frozen = true;
+    this.frozenEta = new RoutingEta(0, Confidence.HIGH, 0,
+        PHASE_STOPPED, totalElapsedSeconds, lastKnownIncompleteCount, reason);
+    this.currentPhase = PHASE_STOPPED;
+  }
+
+  public void onRoutingCompleted() {
+    if (frozen) return;
+    FRLogger.debug("RoutingEtaCalculator: routing completed, freezing");
+    this.frozen = true;
+    this.frozenEta = new RoutingEta(0, Confidence.HIGH, 0,
+        PHASE_COMPLETED, totalElapsedSeconds, 0);
+    this.currentPhase = PHASE_COMPLETED;
+  }
+
+  /**
+   * Called when the board is restored to an earlier (better-scoring) version. This is a
+   * discontinuity in the underlying signal, not noise on a continuous trend, so the regression
+   * window is fully cleared rather than down-weighted — old samples are from a different curve
+   * and would corrupt the new fit if left in the window.
+   */
+  public void onBoardRestored() {
+    if (frozen) return;
+    FRLogger.debug("RoutingEtaCalculator: board restored, resetting regression window");
+    resetRegressionWindow();
+  }
+
+  // ======================== Periodic updates ========================
+
+  /** Called on every board update event during routing. */
+  public void update(double elapsedSeconds, RouterCounters counters, BoardStatistics stats) {
+    if (frozen || !started) return;
+    this.totalElapsedSeconds = elapsedSeconds;
+
+    int incompleteCount = (stats != null) ? stats.connections.incompleteCount : 0;
+    int maximumCount = (stats != null) ? stats.connections.maximumCount : 0;
+    this.lastKnownIncompleteCount = incompleteCount;
+    this.lastKnownMaximumCount = maximumCount;
+
+    // Cross-check pass count against RouterCounters, in case onAutoroutePassCompleted() was
+    // missed on some exit path. Only ever advances, never regresses, to avoid instability if
+    // counters arrive slightly out of order.
+    if (counters != null && counters.passCount != null && counters.passCount > autoroutePassesCompleted
+        && PHASE_AUTOROUTE.equals(currentPhase)) {
+      autoroutePassesCompleted = counters.passCount;
+    }
+
+    if (PHASE_FANOUT.equals(currentPhase)) {
+      updateFanout(counters);
+    } else if (PHASE_OPTIMIZER.equals(currentPhase)) {
+      // Optimizer: tracked via onOptimizerPassCompleted, no per-item progress
+    } else if (PHASE_AUTOROUTE.equals(currentPhase)) {
+      // Completion fraction, not full normalized score: calculateScore() includes
+      // trace-length and via-count cost terms that are nonzero on any real routed
+      // board, so the score asymptotes below its maximum even at 100% completion.
+      // Regressing toward that ceiling means the model chases a target it can
+      // never reach. Completion fraction reaches its target (near 0) for real.
+      // getNormalizedScore(null) also NPEs: getMaximumScore() dereferences
+      // scoringSettings.unroutedNetPenalty unconditionally.
+      addRegressionSample(elapsedSeconds, effectiveIncompleteCount(incompleteCount), maximumCount);
+    }
+  }
+
+  /** Called at the end of each autoroute pass. */
+  public void onAutoroutePassCompleted(int passNumber, int incompleteCount, long passDurationMs,
+                                       int rippedCount, int routedCount) {
+    if (frozen || !started) return;
+    this.autoroutePassesCompleted = Math.max(this.autoroutePassesCompleted, passNumber);
+    double passDurationSeconds = passDurationMs / 1000.0;
+
+    // First pass tracked separately: structurally different cost (larger search space, no
+    // prior routing to guide ripup) and must not contaminate the steady-state duration used
+    // for the hard budget ceiling.
+    if (passNumber <= 1) {
+      firstPassDurationSeconds = passDurationSeconds;
+    } else {
+      if (ewmaPassDuration < 0) {
+        ewmaPassDuration = passDurationSeconds;
+      } else {
+        ewmaPassDuration = EWMA_PASS_DURATION * passDurationSeconds
+            + (1 - EWMA_PASS_DURATION) * ewmaPassDuration;
+      }
+    }
+
+    // Defensive freeze: if this pass exhausted the pass budget, freeze now rather than trust
+    // that BatchAutorouter calls onRoutingStopped() on this specific exit path. Reaching
+    // maxPasses is a distinct termination case from full completion, user-stop, and
+    // stagnation-stop, and is easy to miss when those are wired at separate break sites.
+    if (autoroutePassesCompleted >= maxPasses) {
+      if (incompleteCount == 0) {
+        onRoutingCompleted();
+      } else {
+        onRoutingStopped("max passes reached");
+      }
+    }
+  }
+
+  public void onOptimizerPassCompleted(int passNumber, long passDurationMs) {
+    if (frozen || !started) return;
+    this.optimizerPassesCompleted = passNumber;
+    double seconds = passDurationMs / 1000.0;
+    if (ewmaOptimizerPassDuration < 0) {
+      ewmaOptimizerPassDuration = seconds;
+    } else {
+      ewmaOptimizerPassDuration = EWMA_OPTIMIZER * seconds + (1 - EWMA_OPTIMIZER) * ewmaOptimizerPassDuration;
+    }
+  }
+
+  /** Returns the current (or frozen) ETA, with display hysteresis applied. */
+  public RoutingEta getCurrentEta() {
+    if (frozen && frozenEta != null) return frozenEta;
+    if (!started) {
+      return new RoutingEta(-1, Confidence.NONE, 0, currentPhase, totalElapsedSeconds, lastKnownIncompleteCount);
+    }
+    return applyDisplayHysteresis(computeLiveEta());
+  }
+
+  /** Returns the current phase string. */
+  public String getCurrentPhase() {
+    return this.currentPhase;
+  }
+
+  /** Fully resets the calculator. */
+  public void reset() {
+    this.currentPhase = PHASE_IDLE;
+    this.autoroutePassesCompleted = 0;
+    this.optimizerPassesCompleted = 0;
+    this.totalElapsedSeconds = 0;
+    this.totalConnectableItems = 0;
+    started = false;
+    frozen = false;
+    frozenEta = null;
+    ewmaPassDuration = -1;
+    firstPassDurationSeconds = -1;
+    ewmaOptimizerPassDuration = -1;
+    ewmaFanoutItemsPerSecond = -1;
+    lastKnownIncompleteCount = 0;
+    lastKnownMaximumCount = 0;
+    phaseStartTimeSeconds = currentTimeSeconds();
+    stuckNetCount = 0;
+    consecutiveNoImprovementPasses = 0;
+    lastDisplayedEtaSeconds = -1;
+    consecutiveWorseReadings = 0;
+    resetRegressionWindow();
+  }
+
+  // ======================== Private update helpers ========================
+
+  private void resetRegressionWindow() {
+    regressionIndex = 0;
+    regressionCount = 0;
+    lastSampleElapsedSeconds = -1;
+    fitSlope = Double.NaN;
+    fitIntercept = Double.NaN;
+    fitRSquared = 0;
+    fitResidualStdError = 0;
+  }
+
+  private void updateFanout(RouterCounters counters) {
+    if (counters == null) return;
+    int routed = counters.routedCount != null ? counters.routedCount : 0;
+    int failed = counters.failedToBeRoutedCount != null ? counters.failedToBeRoutedCount : 0;
+    int extraVias = counters.fanoutExtraViasCount != null ? counters.fanoutExtraViasCount : 0;
+    int processed = routed + failed + extraVias;
+
+    if (processed <= 0) return;
+    double elapsed = currentTimeSeconds() - phaseStartTimeSeconds;
+    if (elapsed <= 0) return;
+
+    double rate = processed / elapsed;
+    if (ewmaFanoutItemsPerSecond < 0) {
+      ewmaFanoutItemsPerSecond = rate;
+    } else {
+      ewmaFanoutItemsPerSecond = EWMA_FANOUT * rate + (1 - EWMA_FANOUT) * ewmaFanoutItemsPerSecond;
+    }
+  }
+
+  private int effectiveIncompleteCount(int rawIncompleteCount) {
+    return Math.max(0, rawIncompleteCount - stuckNetCount);
+  }
+
+  /**
+   * Adds a (elapsedSeconds, ln(completionFraction)) sample to the rolling regression window
+   * and recomputes the fit. Uses completion fraction (effective incomplete / maximum), not
+   * full normalized score — the score's quality terms (trace length, vias) make 100% score
+   * unreachable even on a fully-routed board, which would make the regression target
+   * unreachable too. Samples are throttled to MIN_SAMPLE_INTERVAL_SECONDS apart so a burst of
+   * update() calls doesn't over-weight one short interval relative to others.
+   */
+  private void addRegressionSample(double elapsedSeconds, int effectiveIncomplete, int maximumCount) {
+    int denominator = maximumCount > 0 ? maximumCount : totalConnectableItems;
+    if (denominator <= 0) return;
+    if (lastSampleElapsedSeconds >= 0 && (elapsedSeconds - lastSampleElapsedSeconds) < MIN_SAMPLE_INTERVAL_SECONDS) {
+      return;
+    }
+
+    double fraction = Math.max(effectiveIncomplete, COMPLETION_FRACTION_EPSILON_ITEMS) / (double) denominator;
+    double y = Math.log(fraction);
+
+    regressionX[regressionIndex] = elapsedSeconds;
+    regressionY[regressionIndex] = y;
+    regressionIndex = (regressionIndex + 1) % REGRESSION_WINDOW_SIZE;
+    if (regressionCount < REGRESSION_WINDOW_SIZE) regressionCount++;
+    lastSampleElapsedSeconds = elapsedSeconds;
+
+    recomputeFit();
+  }
+
+  /** Ordinary least-squares fit of y = fitIntercept + fitSlope * x, plus R^2 and residual SE. */
+  private void recomputeFit() {
+    int n = regressionCount;
+    if (n < 3) {
+      fitSlope = Double.NaN;
+      return;
+    }
+    double sumX = 0, sumY = 0;
+    for (int i = 0; i < n; i++) {
+      sumX += regressionX[i];
+      sumY += regressionY[i];
+    }
+    double meanX = sumX / n;
+    double meanY = sumY / n;
+
+    double sumXY = 0, sumXX = 0, sumYY = 0;
+    for (int i = 0; i < n; i++) {
+      double dx = regressionX[i] - meanX;
+      double dy = regressionY[i] - meanY;
+      sumXY += dx * dy;
+      sumXX += dx * dx;
+      sumYY += dy * dy;
+    }
+
+    if (sumXX < 1e-9) {
+      fitSlope = Double.NaN;
+      return;
+    }
+
+    double slope = sumXY / sumXX;
+    double intercept = meanY - slope * meanX;
+
+    double ssRes = 0;
+    for (int i = 0; i < n; i++) {
+      double predicted = intercept + slope * regressionX[i];
+      double residual = regressionY[i] - predicted;
+      ssRes += residual * residual;
+    }
+    double ssTot = sumYY;
+    double rSquared = ssTot > 1e-9 ? Math.max(0, 1.0 - ssRes / ssTot) : 0;
+    double residualStdError = n > 2 ? Math.sqrt(ssRes / (n - 2)) : 0;
+
+    this.fitSlope = slope;
+    this.fitIntercept = intercept;
+    this.fitRSquared = rSquared;
+    this.fitResidualStdError = residualStdError;
+    this.fitMeanX = meanX;
+    this.fitSumSqX = sumXX;
+  }
+
+  // ======================== ETA computation ========================
+
+  private RoutingEta computeLiveEta() {
+    if (PHASE_FANOUT.equals(currentPhase)) {
+      // Fanout is typically very fast (seconds), so showing a time estimate is
+      // misleading — the EWMA rate from a few seconds of data is unreliable.
+      // Instead, show a simple progress message.
+      return finalizeEta(-1, Confidence.NONE, 1, "Fanout in progress...", -1, -1);
+    }
+    if (PHASE_OPTIMIZER.equals(currentPhase)) {
+      double eta = calcOptimizerEta();
+      Confidence confidence = ewmaOptimizerPassDuration > 0 ? Confidence.MEDIUM : Confidence.NONE;
+      int remaining = Math.max(0, maxOptimizerPasses - optimizerPassesCompleted);
+      return finalizeEta(eta, confidence, remaining, null, -1, -1);
+    }
+    return computeAutorouteEta();
+  }
+
+  private double calcOptimizerEta() {
+    if (ewmaOptimizerPassDuration <= 0) return -1;
+    int remaining = Math.max(0, maxOptimizerPasses - optimizerPassesCompleted);
+    return remaining <= 0 ? 0 : remaining * ewmaOptimizerPassDuration;
+  }
+
+  /**
+   * Core of the redesign. Solves the regression for the time at which the normalized score
+   * reaches the "effectively done" threshold, derives a statistical band from the regression's
+   * own residual error, and gates confidence (and whether a time is shown at all) on R^2 and
+   * sample count rather than on pass count alone.
+   * <p>
+   * Uses the normalized score (0-1000) as the progress signal, which captures all quality
+   * factors: unrouted connections, clearance violations, trace bends, trace length, and via
+   * count. This gives a much more complete picture of routing progress than incomplete count
+   * alone, and naturally handles the ripup/reroute non-monotonicity since the score only
+   * improves when the board genuinely gets better.
+   */
+  private RoutingEta computeAutorouteEta() {
+    int effectiveIncomplete = effectiveIncompleteCount(lastKnownIncompleteCount);
+    if (effectiveIncomplete <= 0) {
+      return finalizeEta(0, Confidence.HIGH, 0, null, 0, 0);
+    }
+
+    int denominator = lastKnownMaximumCount > 0 ? lastKnownMaximumCount : totalConnectableItems;
+    double steadyPassDuration = ewmaPassDuration > 0 ? ewmaPassDuration
+        : (firstPassDurationSeconds > 0 ? firstPassDurationSeconds : -1);
+    int passesRemainingBudget = Math.max(0, maxPasses - autoroutePassesCompleted);
+    double budgetCeiling = steadyPassDuration > 0 ? passesRemainingBudget * steadyPassDuration : -1;
+
+    double etaSeconds = -1;
+    double etaLow = -1;
+    double etaHigh = -1;
+    Confidence confidence = Confidence.NONE;
+    // Show pass number and remaining count. Don't show maxPasses since it's often
+    // a large default (100+) that misleads users into thinking the router will run
+    // that many passes, when in practice it stops much earlier via stagnation.
+    String progressText = "Pass " + autoroutePassesCompleted
+        + " - " + effectiveIncomplete + " remaining";
+
+    boolean haveFit = !Double.isNaN(fitSlope) && fitSlope < 0 && denominator > 0;
+    if (haveFit) {
+      // Target: fraction = COMPLETION_FRACTION_EPSILON_ITEMS / denominator (effectively done).
+      // Must match the fraction-based signal fed into addRegressionSample(), or the solved
+      // target time is off by a factor of denominator (this was a bug in a prior revision:
+      // the target used the raw epsilon while the signal was a fraction).
+      double targetY = Math.log(COMPLETION_FRACTION_EPSILON_ITEMS / (double) denominator);
+      double targetTime = (targetY - fitIntercept) / fitSlope; // absolute elapsedSeconds at target
+      double rawEta = targetTime - totalElapsedSeconds;
+
+
+      if (rawEta >= 0) {
+        etaSeconds = rawEta;
+
+        // Prediction standard error at the forecast point, propagated from y-space to
+        // time-space via the delta method (dividing by |slope|). Approximate but grounded in
+        // the regression's actual residuals rather than an arbitrary +/-X% heuristic.
+        int n = regressionCount;
+        double sePredY = fitResidualStdError * Math.sqrt(1.0 + 1.0 / n
+            + Math.pow(targetTime - fitMeanX, 2) / Math.max(fitSumSqX, 1e-9));
+        double seTime = Math.abs(fitSlope) > 1e-9 ? sePredY / Math.abs(fitSlope) : 0;
+        etaLow = Math.max(0, etaSeconds - seTime);
+        etaHigh = etaSeconds + seTime;
+
+        confidence = confidenceFromFit(regressionCount, fitRSquared);
+      }
+    }
+
+    // Hard budget ceiling always applies, regardless of what the regression predicts: not
+    // everything routes in one pass, and the router will not run past maxPasses.
+    if (budgetCeiling >= 0 && (etaSeconds < 0 || etaSeconds > budgetCeiling)) {
+      etaSeconds = budgetCeiling;
+      etaLow = Math.max(0, budgetCeiling - (etaHigh > etaSeconds ? (etaHigh - etaSeconds) : 0));
+      etaHigh = budgetCeiling;
+      if (confidence == Confidence.HIGH) confidence = Confidence.MEDIUM;
+    }
+
+    // Stagnation risk: the router may stop on its own (via its own stagnation check) before
+    // the regression's projected convergence. Blend toward "stops soon" and cap confidence.
+    if (stagnationPassLimit > 0 && steadyPassDuration > 0) {
+      double stagnationRisk = Math.min(1.0, consecutiveNoImprovementPasses / (double) stagnationPassLimit);
+      if (stagnationRisk > 0) {
+        int passesUntilStagnationStop = Math.max(0, stagnationPassLimit - consecutiveNoImprovementPasses);
+        double stagnationStopEta = passesUntilStagnationStop * steadyPassDuration;
+        etaSeconds = etaSeconds < 0 ? stagnationStopEta
+            : (1 - stagnationRisk) * etaSeconds + stagnationRisk * stagnationStopEta;
+        if (stagnationRisk >= 0.5 && confidence == Confidence.HIGH) confidence = Confidence.MEDIUM;
+      }
+    }
+
+    int remainingPasses = steadyPassDuration > 0 && etaSeconds >= 0
+        ? Math.min(passesRemainingBudget, (int) Math.ceil(etaSeconds / steadyPassDuration))
+        : passesRemainingBudget;
+
+    return finalizeEta(etaSeconds, confidence, remainingPasses, progressText, etaLow, etaHigh);
+  }
+
+  private Confidence confidenceFromFit(int sampleCount, double rSquared) {
+    if (sampleCount < MIN_SAMPLES_FOR_LOW_CONFIDENCE || rSquared < 0.15) {
+      return Confidence.NONE;
+    }
+    if (sampleCount < MIN_SAMPLES_FOR_MEDIUM_CONFIDENCE || rSquared < R_SQUARED_LOW_THRESHOLD) {
+      return Confidence.LOW;
+    }
+    if (sampleCount < MIN_SAMPLES_FOR_HIGH_CONFIDENCE || rSquared < R_SQUARED_HIGH_THRESHOLD) {
+      return Confidence.MEDIUM;
+    }
+    return Confidence.HIGH;
+  }
+
+  /**
+   * Applies the MAX_ACCEPTABLE_ETA_SECONDS cap and packages the result. When confidence is
+   * NONE (or LOW with too little data), the caller-supplied progressText should be preferred
+   * by the UI over a time string — RoutingEta carries both so the UI can make that call.
+   */
+  private RoutingEta finalizeEta(double etaSeconds, Confidence confidence, int remainingPasses,
+                                  String progressText, double etaLow, double etaHigh) {
+    if (etaSeconds > MAX_ACCEPTABLE_ETA_SECONDS) {
+      etaSeconds = MAX_ACCEPTABLE_ETA_SECONDS;
+      if (confidence == Confidence.HIGH) confidence = Confidence.MEDIUM;
+    }
+    RoutingEta eta = new RoutingEta(etaSeconds, confidence, remainingPasses,
+        currentPhase, totalElapsedSeconds, lastKnownIncompleteCount, null);
+    eta.progressText = progressText;
+    eta.etaSecondsLow = etaLow;
+    eta.etaSecondsHigh = etaHigh;
+    return eta;
+  }
+
+  /**
+   * Display-side hysteresis, fully decoupled from the estimation model above. The underlying
+   * model is free to fluctuate every update (that's expected — the input signal is genuinely
+   * noisy); what reaches the screen only increases after HYSTERESIS_CONFIRM_COUNT consecutive
+   * worse readings in a row, unless the jump is large enough (HYSTERESIS_BYPASS_RATIO) to
+   * indicate a real discontinuity such as a board restore or stagnation onset. Decreases
+   * (good news) are always shown immediately — there's no reason to make the user wait for
+   * confirmation that things are going well.
+   */
+  private RoutingEta applyDisplayHysteresis(RoutingEta raw) {
+    if (raw.etaSeconds < 0 || raw.confidence == Confidence.NONE) {
+      // Nothing trustworthy to hold back or confirm; pass through as-is (progress-only display).
+      lastDisplayedEtaSeconds = -1;
+      consecutiveWorseReadings = 0;
+      return raw;
+    }
+
+    if (lastDisplayedEtaSeconds < 0 || raw.etaSeconds <= lastDisplayedEtaSeconds) {
+      lastDisplayedEtaSeconds = raw.etaSeconds;
+      consecutiveWorseReadings = 0;
+      return raw;
+    }
+
+    // raw.etaSeconds > lastDisplayedEtaSeconds: a worse reading.
+    boolean largeJump = raw.etaSeconds > lastDisplayedEtaSeconds * HYSTERESIS_BYPASS_RATIO;
+    consecutiveWorseReadings++;
+    if (largeJump || consecutiveWorseReadings >= HYSTERESIS_CONFIRM_COUNT) {
+      lastDisplayedEtaSeconds = raw.etaSeconds;
+      consecutiveWorseReadings = 0;
+      return raw;
+    }
+
+    // Hold the previously displayed value instead of the noisier new one.
+    RoutingEta held = new RoutingEta(lastDisplayedEtaSeconds, raw.confidence, raw.estimatedRemainingPasses,
+        raw.phase, raw.totalElapsedSeconds, raw.incompleteCount, raw.stopReason);
+    held.progressText = raw.progressText;
+    held.etaSecondsLow = raw.etaSecondsLow;
+    held.etaSecondsHigh = raw.etaSecondsHigh;
+    return held;
+  }
+
+  private static double currentTimeSeconds() {
+    return System.currentTimeMillis() / 1000.0;
+  }
+}

--- a/src/main/java/app/freerouting/core/RoutingEtaCalculator.java
+++ b/src/main/java/app/freerouting/core/RoutingEtaCalculator.java
@@ -10,627 +10,324 @@ import app.freerouting.logger.FRLogger;
  *
  * <h2>Key design decisions</h2>
  * <ul>
- *   <li><b>Continuous-time regression, not pass-endpoint regression.</b> Every update() call
- *       contributes a sample of (elapsedSeconds, ln(remaining)) to a rolling window. This gives
- *       real signal mid-pass, including during a long first pass.</li>
- *   <li><b>Normalized score as the progress signal.</b> Uses BoardStatistics.getNormalizedScore()
- *       which captures ALL quality factors: unrouted connections, clearance violations, trace
- *       bends, trace length, and via count. This naturally handles ripup/reroute non-monotonicity
- *       since the score only improves when the board genuinely gets better.</li>
- *   <li><b>R²-gated confidence, with a progress-only display mode below threshold.</b> A weak
- *       regression fit produces a progress string instead of a falsely confident time estimate.</li>
- *   <li><b>Statistical prediction band</b> from the regression's own residual standard error.</li>
- *   <li><b>Display-side hysteresis</b> decoupled from the model: increases require confirmation,
- *       decreases shown immediately.</li>
- *   <li><b>Fanout shows progress only</b> (no time estimate) since it's typically too fast to
- *       estimate reliably.</li>
- *   <li><b>Pass count hidden from progress text</b> to avoid misleading "Pass 1/100" displays.</li>
+ * <li><b>Phase-Aware Mathematical Models.</b> Different phases of routing behave differently.
+ * <ul>
+ * <li><b>Fanout:</b> Linear item-velocity model (sequential pin breakouts).</li>
+ * <li><b>Autoroute:</b> Exponential decay model (rip-up and reroute maze search).</li>
+ * <li><b>Optimizer:</b> Linear pass-velocity model (sequential trace reduction).</li>
+ * </ul>
+ * </li>
+ * <li><b>Terminal State Locking.</b> Prevents delayed thread updates from overwriting "Stopped" 
+ * or "Completed" messages in the UI.</li>
+ * <li><b>Anomaly Detection.</b> Auto-resets the mathematical models if the board is swapped 
+ * or the timer unexpectedly jumps backwards.</li>
  * </ul>
  */
 public class RoutingEtaCalculator {
 
-  // ---------- Regression window ----------
-  private static final int REGRESSION_WINDOW_SIZE = 24;
-  private static final double MIN_SAMPLE_INTERVAL_SECONDS = 1.5;
+  // Alpha weights for the Exponential Moving Averages (EMA) in Autoroute phase
+  private static final double EMA_ALPHA_TIME = 0.20;
+  private static final double EMA_ALPHA_DECAY = 0.15;
+  
+  // Guarantees we never predict an infinite ETA even if the router stalls temporarily
+  private static final double MIN_DECAY_RATE = 0.005; 
 
-  // ---------- Confidence / display gating ----------
-  private static final double R_SQUARED_LOW_THRESHOLD = 0.5;
-  private static final double R_SQUARED_HIGH_THRESHOLD = 0.85;
-  private static final int MIN_SAMPLES_FOR_LOW_CONFIDENCE = 4;
-  private static final int MIN_SAMPLES_FOR_MEDIUM_CONFIDENCE = 8;
-  private static final int MIN_SAMPLES_FOR_HIGH_CONFIDENCE = 14;
-
-  // ---------- Display hysteresis ----------
+  private static final double HYSTERESIS_BYPASS_RATIO = 1.2;
   private static final int HYSTERESIS_CONFIRM_COUNT = 3;
-  private static final double HYSTERESIS_BYPASS_RATIO = 2.0;
 
-  // ---------- EWMA smoothing constants (fanout/optimizer only; autoroute uses regression) ----------
-  private static final double EWMA_PASS_DURATION = 0.3;
-  private static final double EWMA_OPTIMIZER = 0.5;
-  private static final double EWMA_FANOUT = 0.3;
+  private String currentPhase = "";
+  private String lastPhase = "";
+  private RoutingEta lastEta = null;
+  
+  // API compatibility fields
+  private Integer maxPasses;
+  private Integer maxOptimizerPasses;
+  private Integer threadCount;
+  private int totalConnectableItems;
 
-  // Phase identifiers
-  private static final String PHASE_IDLE = "idle";
-  private static final String PHASE_FANOUT = "fanout";
-  private static final String PHASE_AUTOROUTE = "autoroute";
-  private static final String PHASE_OPTIMIZER = "optimizer";
-  private static final String PHASE_COMPLETED = "completed";
-  private static final String PHASE_STOPPED = "stopped";
+  // State for tracking progress
+  private int lastPass = -1;
+  private double lastPassElapsedSeconds = 0.0;
+  private int lastKnownIncompleteCount = -1;
 
-  // ---------- Bound constants ----------
-  private static final double MAX_ACCEPTABLE_ETA_SECONDS = 7200; // 2h cap
-  private static final int DEFAULT_MAX_OPTIMIZER_PASSES = 10;
-  private static final int STUCK_NET_FAILURE_THRESHOLD = 5;
+  // Global phase trackers (to account for all time passed in the current phase)
+  private double phaseStartElapsedSeconds = 0.0;
+  private int phaseStartIncompleteCount = -1;
+  private int phaseStartPass = 0;
 
-  // "Effectively done" threshold: solving the regression for when the remaining
-  // value reaches this (rather than exactly 0, which is -infinity in log space)
-  // gives a finite, well-defined forecast time.
-  private static final double COMPLETION_FRACTION_EPSILON_ITEMS = 0.5;
+  // EMA Trackers for Autoroute
+  private double emaPassDuration = -1.0;
+  private double emaDecayRate = -1.0;
 
-  // ---------- State ----------
-  private String currentPhase = PHASE_IDLE;
-  private int autoroutePassesCompleted = 0;
-  private int optimizerPassesCompleted = 0;
-  private double totalElapsedSeconds = 0;
-
-  private double ewmaPassDuration = -1;          // steady-state (pass 2+) only
-  private double firstPassDurationSeconds = -1;  // tracked separately from steady-state EWMA
-  private double ewmaOptimizerPassDuration = -1;
-  private double ewmaFanoutItemsPerSecond = -1;
-
-  private int lastKnownIncompleteCount = 0;
-  private int lastKnownMaximumCount = 0;
-  private int totalConnectableItems = 0; // fallback denominator if BoardStatistics unavailable
-  private double phaseStartTimeSeconds;
-  private int maxPasses = 100;
-  private int maxOptimizerPasses = DEFAULT_MAX_OPTIMIZER_PASSES;
-  private int threadCount = 1;
-
-  // Continuous-time regression window: (elapsedSeconds, ln(remaining))
-  private final double[] regressionX = new double[REGRESSION_WINDOW_SIZE];
-  private final double[] regressionY = new double[REGRESSION_WINDOW_SIZE];
-  private int regressionIndex = 0;
-  private int regressionCount = 0;
-  private double lastSampleElapsedSeconds = -1;
-
-  // Cached regression fit, recomputed each time a sample is added
-  private double fitSlope = Double.NaN;
-  private double fitIntercept = Double.NaN;
-  private double fitRSquared = 0;
-  private double fitResidualStdError = 0;
-  private double fitMeanX = 0;
-  private double fitSumSqX = 0;
-
-  // Stuck-net tracking, fed externally from failureLog aggregation
-  private int stuckNetCount = 0;
-
-  // Stagnation tracking, fed from BatchAutorouter's own counters
-  private int consecutiveNoImprovementPasses = 0;
-  private int stagnationPassLimit = 10;
-
-  // Display-side hysteresis state (independent of the underlying model)
+  // Hysteresis state
   private double lastDisplayedEtaSeconds = -1;
   private int consecutiveWorseReadings = 0;
 
-  // Frozen state
-  private boolean frozen = false;
-  private RoutingEta frozenEta = null;
-  private boolean started = false;
+  // --- API Compatibility Methods ---
 
-  public RoutingEtaCalculator() {
-  }
-
-  /** Must be called when routing begins. */
   public void startRouting() {
-    reset();
-    this.started = true;
-    this.phaseStartTimeSeconds = currentTimeSeconds();
-    this.frozen = false;
-    this.frozenEta = null;
-    FRLogger.debug("RoutingEtaCalculator: started");
+      resetEstimators();
+      currentPhase = "starting";
+      lastEta = createFallbackEta(0, 0, currentPhase);
+  }
+
+  public void setMaxPasses(Integer maxPasses) { this.maxPasses = maxPasses; }
+  public void setMaxOptimizerPasses(Integer maxOptimizerPasses) { this.maxOptimizerPasses = maxOptimizerPasses; }
+  public void setThreadCount(Integer threadCount) { this.threadCount = threadCount; }
+  public void setTotalConnectableItems(int totalConnectableItems) { this.totalConnectableItems = totalConnectableItems; }
+
+  public String getCurrentPhase() { return currentPhase; }
+  public RoutingEta getCurrentEta() { return lastEta; }
+
+  public void onFanoutStarted() { this.currentPhase = "fanout"; }
+  public void onAutorouteStarted() { this.currentPhase = "autoroute"; }
+  public void onOptimizerStarted() { this.currentPhase = "optimizer"; }
+  
+  public void onRoutingCompleted() { 
+      this.currentPhase = "completed"; 
+      if (lastEta != null) {
+          lastEta = new RoutingEta(0, Confidence.HIGH, 0, currentPhase, lastEta.totalElapsedSeconds, 0, null);
+          lastEta.progressText = "Completed.";
+      }
+  }
+  
+  public void onRoutingStopped() { 
+      this.currentPhase = "stopped"; 
+      if (lastEta != null) {
+           lastEta = new RoutingEta(0, Confidence.HIGH, 0, currentPhase, lastEta.totalElapsedSeconds, lastEta.incompleteCount, "Stopped");
+           lastEta.progressText = "Stopped.";
+      }
   }
 
   /**
-   * Call whenever a different board is loaded, including before routing starts on it.
-   * Without this, a previous board's frozen "Completed"/"Stopped" state (or stale display
-   * hysteresis) persists on screen since nothing else clears it until Route is pressed again.
+   * Adapter update method required by AutorouterAndRouteOptimizerThread.
    */
-  public void notifyBoardChanged() {
-    FRLogger.debug("RoutingEtaCalculator: board changed, clearing state");
-    reset();
-  }
-
-  public void setTotalConnectableItems(int total) {
-    this.totalConnectableItems = total > 0 ? total : 0;
-  }
-
-  public void setMaxPasses(int maxPasses) {
-    this.maxPasses = maxPasses > 0 ? maxPasses : 100;
-  }
-
-  public void setMaxOptimizerPasses(int maxOptimizerPasses) {
-    this.maxOptimizerPasses = maxOptimizerPasses > 0 ? maxOptimizerPasses : DEFAULT_MAX_OPTIMIZER_PASSES;
-  }
-
-  public void setThreadCount(int threadCount) {
-    this.threadCount = threadCount > 0 ? threadCount : 1;
-  }
-
-  public void setStagnationPassLimit(int stagnationPassLimit) {
-    this.stagnationPassLimit = stagnationPassLimit > 0 ? stagnationPassLimit : 10;
-  }
-
-  /** Call once per pass with BatchAutorouter's consecutiveNoImprovementPasses. */
-  public void updateStagnation(int consecutiveNoImprovementPasses) {
-    this.consecutiveNoImprovementPasses = Math.max(0, consecutiveNoImprovementPasses);
-  }
-
-  /**
-   * Call whenever the set of DRC-blocked / currently-unroutable nets changes (driven by
-   * board.failureLog: a net with a stable failure reason for STUCK_NET_FAILURE_THRESHOLD+
-   * consecutive passes). Excluding these from the completion target stops the model from
-   * chasing a 100% that is not currently achievable.
-   */
-  public void updateStuckNetCount(int stuckNetCount) {
-    this.stuckNetCount = Math.max(0, stuckNetCount);
-  }
-
-  // ======================== Phase lifecycle ========================
-
-  public void onFanoutStarted() {
-    if (frozen || !started) return;
-    FRLogger.debug("RoutingEtaCalculator: fanout started");
-    this.currentPhase = PHASE_FANOUT;
-    this.phaseStartTimeSeconds = currentTimeSeconds();
-    this.ewmaFanoutItemsPerSecond = -1;
-  }
-
-  public void onAutorouteStarted() {
-    if (frozen || !started) return;
-    FRLogger.debug("RoutingEtaCalculator: autoroute started");
-    this.currentPhase = PHASE_AUTOROUTE;
-    this.phaseStartTimeSeconds = currentTimeSeconds();
-    this.ewmaPassDuration = -1;
-    this.firstPassDurationSeconds = -1;
-    resetRegressionWindow();
-    this.consecutiveNoImprovementPasses = 0;
-    this.stuckNetCount = 0;
-    this.lastDisplayedEtaSeconds = -1;
-    this.consecutiveWorseReadings = 0;
-  }
-
-  public void onOptimizerStarted() {
-    if (frozen || !started) return;
-    FRLogger.debug("RoutingEtaCalculator: optimizer started");
-    this.currentPhase = PHASE_OPTIMIZER;
-    this.phaseStartTimeSeconds = currentTimeSeconds();
-    this.optimizerPassesCompleted = 0;
-  }
-
-  public void onRoutingStopped() {
-    onRoutingStopped(null);
-  }
-
-  public void onRoutingStopped(String reason) {
-    if (frozen) return;
-    FRLogger.debug("RoutingEtaCalculator: routing stopped, freezing" + (reason != null ? " (" + reason + ")" : ""));
-    this.frozen = true;
-    this.frozenEta = new RoutingEta(0, Confidence.HIGH, 0,
-        PHASE_STOPPED, totalElapsedSeconds, lastKnownIncompleteCount, reason);
-    this.currentPhase = PHASE_STOPPED;
-  }
-
-  public void onRoutingCompleted() {
-    if (frozen) return;
-    FRLogger.debug("RoutingEtaCalculator: routing completed, freezing");
-    this.frozen = true;
-    this.frozenEta = new RoutingEta(0, Confidence.HIGH, 0,
-        PHASE_COMPLETED, totalElapsedSeconds, 0);
-    this.currentPhase = PHASE_COMPLETED;
-  }
-
-  /**
-   * Called when the board is restored to an earlier (better-scoring) version. This is a
-   * discontinuity in the underlying signal, not noise on a continuous trend, so the regression
-   * window is fully cleared rather than down-weighted — old samples are from a different curve
-   * and would corrupt the new fit if left in the window.
-   */
-  public void onBoardRestored() {
-    if (frozen) return;
-    FRLogger.debug("RoutingEtaCalculator: board restored, resetting regression window");
-    resetRegressionWindow();
-  }
-
-  // ======================== Periodic updates ========================
-
-  /** Called on every board update event during routing. */
   public void update(double elapsedSeconds, RouterCounters counters, BoardStatistics stats) {
-    if (frozen || !started) return;
-    this.totalElapsedSeconds = elapsedSeconds;
-
-    int incompleteCount = (stats != null) ? stats.connections.incompleteCount : 0;
-    int maximumCount = (stats != null) ? stats.connections.maximumCount : 0;
-    this.lastKnownIncompleteCount = incompleteCount;
-    this.lastKnownMaximumCount = maximumCount;
-
-    // Cross-check pass count against RouterCounters, in case onAutoroutePassCompleted() was
-    // missed on some exit path. Only ever advances, never regresses, to avoid instability if
-    // counters arrive slightly out of order.
-    if (counters != null && counters.passCount != null && counters.passCount > autoroutePassesCompleted
-        && PHASE_AUTOROUTE.equals(currentPhase)) {
-      autoroutePassesCompleted = counters.passCount;
-    }
-
-    if (PHASE_FANOUT.equals(currentPhase)) {
-      updateFanout(counters);
-    } else if (PHASE_OPTIMIZER.equals(currentPhase)) {
-      // Optimizer: tracked via onOptimizerPassCompleted, no per-item progress
-    } else if (PHASE_AUTOROUTE.equals(currentPhase)) {
-      // Completion fraction, not full normalized score: calculateScore() includes
-      // trace-length and via-count cost terms that are nonzero on any real routed
-      // board, so the score asymptotes below its maximum even at 100% completion.
-      // Regressing toward that ceiling means the model chases a target it can
-      // never reach. Completion fraction reaches its target (near 0) for real.
-      // getNormalizedScore(null) also NPEs: getMaximumScore() dereferences
-      // scoringSettings.unroutedNetPenalty unconditionally.
-      addRegressionSample(elapsedSeconds, effectiveIncompleteCount(incompleteCount), maximumCount);
-    }
-  }
-
-  /** Called at the end of each autoroute pass. */
-  public void onAutoroutePassCompleted(int passNumber, int incompleteCount, long passDurationMs,
-                                       int rippedCount, int routedCount) {
-    if (frozen || !started) return;
-    this.autoroutePassesCompleted = Math.max(this.autoroutePassesCompleted, passNumber);
-    double passDurationSeconds = passDurationMs / 1000.0;
-
-    // First pass tracked separately: structurally different cost (larger search space, no
-    // prior routing to guide ripup) and must not contaminate the steady-state duration used
-    // for the hard budget ceiling.
-    if (passNumber <= 1) {
-      firstPassDurationSeconds = passDurationSeconds;
-    } else {
-      if (ewmaPassDuration < 0) {
-        ewmaPassDuration = passDurationSeconds;
-      } else {
-        ewmaPassDuration = EWMA_PASS_DURATION * passDurationSeconds
-            + (1 - EWMA_PASS_DURATION) * ewmaPassDuration;
+      // 1. Terminal State Lock: If we are stopped or completed, ignore all trailing thread updates.
+      if ("stopped".equals(currentPhase) || "completed".equals(currentPhase)) {
+          return; 
       }
-    }
 
-    // Defensive freeze: if this pass exhausted the pass budget, freeze now rather than trust
-    // that BatchAutorouter calls onRoutingStopped() on this specific exit path. Reaching
-    // maxPasses is a distinct termination case from full completion, user-stop, and
-    // stagnation-stop, and is easy to miss when those are wired at separate break sites.
-    if (autoroutePassesCompleted >= maxPasses) {
-      if (incompleteCount == 0) {
-        onRoutingCompleted();
-      } else {
-        onRoutingStopped("max passes reached");
-      }
-    }
+      int pass = (counters != null && counters.passCount != null) ? counters.passCount : 0;
+      int incomplete = (counters != null && counters.incompleteCount != null) ? counters.incompleteCount : 0;
+      
+      this.lastEta = calculateInternal(elapsedSeconds, pass, incomplete, this.currentPhase);
   }
 
-  public void onOptimizerPassCompleted(int passNumber, long passDurationMs) {
-    if (frozen || !started) return;
-    this.optimizerPassesCompleted = passNumber;
-    double seconds = passDurationMs / 1000.0;
-    if (ewmaOptimizerPassDuration < 0) {
-      ewmaOptimizerPassDuration = seconds;
-    } else {
-      ewmaOptimizerPassDuration = EWMA_OPTIMIZER * seconds + (1 - EWMA_OPTIMIZER) * ewmaOptimizerPassDuration;
+  // --- Internal Phase-Aware ETA Math ---
+
+  private RoutingEta calculateInternal(double totalElapsedSeconds, int currentPass, int incompleteCount, String currentPhase) {
+    // 2. Anomaly Detection (Board Swap / Restart)
+    // If time goes backward or passes drop unexpectedly, instantly reset our math models.
+    if (lastPass != -1 && (totalElapsedSeconds < lastPassElapsedSeconds || currentPass < lastPass)) {
+        resetEstimators();
     }
-  }
 
-  /** Returns the current (or frozen) ETA, with display hysteresis applied. */
-  public RoutingEta getCurrentEta() {
-    if (frozen && frozenEta != null) return frozenEta;
-    if (!started) {
-      return new RoutingEta(-1, Confidence.NONE, 0, currentPhase, totalElapsedSeconds, lastKnownIncompleteCount);
+    if (!currentPhase.equals(lastPhase)) {
+        resetEstimators();
+        lastPhase = currentPhase;
     }
-    return applyDisplayHysteresis(computeLiveEta());
+
+    // 3. FANOUT Phase: Linear Item Velocity (Pins breakout linearly, not exponentially)
+    if ("fanout".equals(currentPhase)) {
+        if (lastPass == -1) {
+            initPhaseTrackers(totalElapsedSeconds, currentPass, incompleteCount);
+            RoutingEta fallback = createFallbackEta(totalElapsedSeconds, incompleteCount, currentPhase);
+            fallback.progressText = "Escaping pins (Fanout)...";
+            return fallback;
+        }
+
+        double timeInPhase = totalElapsedSeconds - phaseStartElapsedSeconds;
+        int itemsProcessed = phaseStartIncompleteCount - incompleteCount;
+
+        if (timeInPhase > 0 && itemsProcessed > 0) {
+            double secondsPerItem = timeInPhase / itemsProcessed;
+            double etaSeconds = incompleteCount * secondsPerItem;
+
+            RoutingEta fanoutEta = new RoutingEta(etaSeconds, Confidence.MEDIUM, 0, currentPhase, totalElapsedSeconds, incompleteCount, null);
+            fanoutEta.etaSecondsLow = Math.max(0, etaSeconds - (etaSeconds * 0.15));
+            fanoutEta.etaSecondsHigh = etaSeconds + (etaSeconds * 0.15);
+            fanoutEta.progressText = "Escaping pins (Fanout)...";
+            
+            lastPass = currentPass;
+            lastPassElapsedSeconds = totalElapsedSeconds;
+            return applyDisplayHysteresis(fanoutEta);
+        }
+        
+        lastPass = currentPass;
+        lastPassElapsedSeconds = totalElapsedSeconds;
+        RoutingEta fallback = createFallbackEta(totalElapsedSeconds, incompleteCount, currentPhase);
+        fallback.progressText = "Escaping pins (Fanout)...";
+        return fallback;
+    }
+
+    // 4. OPTIMIZER Phase: Linear Pass Velocity (Trace smoothing is strictly pass-based)
+    if ("optimizer".equals(currentPhase)) {
+        if (lastPass == -1) {
+            initPhaseTrackers(totalElapsedSeconds, currentPass, incompleteCount);
+            RoutingEta fallback = createFallbackEta(totalElapsedSeconds, 0, currentPhase);
+            fallback.progressText = "Optimizing routes...";
+            return fallback;
+        }
+
+        double timeInPhase = totalElapsedSeconds - phaseStartElapsedSeconds;
+        int passesElapsed = currentPass - phaseStartPass;
+
+        if (timeInPhase > 0 && passesElapsed > 0 && maxOptimizerPasses != null && maxOptimizerPasses > 0) {
+            double secondsPerPass = timeInPhase / passesElapsed;
+            int passesRemaining = Math.max(0, maxOptimizerPasses - currentPass);
+            double etaSeconds = passesRemaining * secondsPerPass;
+
+            RoutingEta optEta = new RoutingEta(etaSeconds, Confidence.HIGH, passesRemaining, currentPhase, totalElapsedSeconds, 0, null);
+            optEta.etaSecondsLow = Math.max(0, etaSeconds - (etaSeconds * 0.05));
+            optEta.etaSecondsHigh = etaSeconds + (etaSeconds * 0.05);
+            
+            lastPass = currentPass;
+            lastPassElapsedSeconds = totalElapsedSeconds;
+            return applyDisplayHysteresis(optEta);
+        }
+        
+        lastPass = currentPass;
+        lastPassElapsedSeconds = totalElapsedSeconds;
+        RoutingEta fallback = createFallbackEta(totalElapsedSeconds, 0, currentPhase);
+        fallback.progressText = "Optimizing routes...";
+        return fallback;
+    }
+
+    // 5. AUTOROUTE Phase: Exponential Decay (Rip-up and reroute maze search)
+    if ("autoroute".equals(currentPhase)) {
+        // Handle immediate autoroute completion edge case
+        if (incompleteCount <= 0) {
+            RoutingEta eta = new RoutingEta(0, Confidence.HIGH, 0, currentPhase, totalElapsedSeconds, 0, null);
+            eta.progressText = "Completing...";
+            return eta;
+        }
+
+        if (lastPass == -1) {
+            initPhaseTrackers(totalElapsedSeconds, currentPass, incompleteCount);
+            return createFallbackEta(totalElapsedSeconds, incompleteCount, currentPhase);
+        }
+
+        double safeIncomplete = Math.max(1.0, incompleteCount);
+        
+        if (currentPass > lastPass) {
+            int passesElapsed = currentPass - lastPass;
+            double timeElapsed = totalElapsedSeconds - lastPassElapsedSeconds;
+            
+            double passDuration = Math.max(0.001, timeElapsed / passesElapsed);
+            double safeLastIncomplete = Math.max(1.0, lastKnownIncompleteCount);
+            
+            double k;
+            if (safeIncomplete >= safeLastIncomplete) {
+                k = -0.01; // Rip-up stall penalty
+            } else {
+                k = -Math.log(safeIncomplete / safeLastIncomplete) / passesElapsed;
+            }
+
+            if (emaPassDuration < 0) {
+                emaPassDuration = passDuration;
+                emaDecayRate = Math.max(k, MIN_DECAY_RATE);
+            } else {
+                emaPassDuration = (EMA_ALPHA_TIME * passDuration) + ((1 - EMA_ALPHA_TIME) * emaPassDuration);
+                emaDecayRate = (EMA_ALPHA_DECAY * k) + ((1 - EMA_ALPHA_DECAY) * emaDecayRate);
+            }
+
+            lastPass = currentPass;
+            lastPassElapsedSeconds = totalElapsedSeconds;
+            lastKnownIncompleteCount = incompleteCount;
+        }
+
+        if (emaPassDuration < 0 || emaDecayRate < 0) {
+            return createFallbackEta(totalElapsedSeconds, incompleteCount, currentPhase);
+        }
+
+        // Blend Local EMA (70%) with Global History (30%)
+        int totalPhasePasses = currentPass - phaseStartPass;
+        double globalDecayRate = -1.0;
+        if (totalPhasePasses > 0 && phaseStartIncompleteCount > 0) {
+            double safeStartInc = Math.max(1.0, phaseStartIncompleteCount);
+            if (safeIncomplete < safeStartInc) {
+                globalDecayRate = -Math.log(safeIncomplete / safeStartInc) / totalPhasePasses;
+            }
+        }
+
+        double effectiveDecay = Math.max(emaDecayRate, MIN_DECAY_RATE);
+        if (globalDecayRate > 0) {
+            effectiveDecay = (effectiveDecay * 0.70) + (globalDecayRate * 0.30);
+        }
+        
+        double remainingPassesDouble = Math.log(Math.max(incompleteCount, 1) / 0.5) / effectiveDecay;
+        int remainingPasses = (int) Math.ceil(remainingPassesDouble);
+        
+        if (maxPasses != null && maxPasses > 0) {
+            int hardPassLimit = Math.max(0, maxPasses - currentPass);
+            remainingPasses = Math.min(remainingPasses, hardPassLimit);
+        }
+        
+        double etaSeconds = remainingPasses * emaPassDuration;
+
+        // Confidence and Bounds
+        Confidence confidence;
+        if (currentPass <= 1) confidence = Confidence.NONE;
+        else if (currentPass <= 3) confidence = Confidence.LOW;
+        else if (currentPass <= 8) confidence = Confidence.MEDIUM;
+        else confidence = Confidence.HIGH;
+
+        double marginRatio;
+        if (confidence == Confidence.LOW) marginRatio = 0.25;
+        else if (confidence == Confidence.MEDIUM) marginRatio = 0.10;
+        else marginRatio = 0.05;
+
+        double margin = Math.max(5.0, etaSeconds * marginRatio); 
+        double etaLow = Math.max(0, etaSeconds - margin);
+        double etaHigh = etaSeconds + margin;
+
+        RoutingEta rawEta = new RoutingEta(etaSeconds, confidence, remainingPasses, currentPhase, totalElapsedSeconds, incompleteCount, null);
+        rawEta.etaSecondsLow = etaLow;
+        rawEta.etaSecondsHigh = etaHigh;
+        
+        if (confidence == Confidence.NONE) {
+            rawEta.progressText = "Analyzing search space...";
+        }
+
+        return applyDisplayHysteresis(rawEta);
+    }
+
+    // Fallback for unknown phases
+    return createFallbackEta(totalElapsedSeconds, incompleteCount, currentPhase);
   }
 
-  /** Returns the current phase string. */
-  public String getCurrentPhase() {
-    return this.currentPhase;
+  private void initPhaseTrackers(double totalElapsedSeconds, int currentPass, int incompleteCount) {
+    lastPass = currentPass;
+    lastPassElapsedSeconds = totalElapsedSeconds;
+    lastKnownIncompleteCount = incompleteCount;
+    
+    phaseStartElapsedSeconds = totalElapsedSeconds;
+    phaseStartIncompleteCount = incompleteCount;
+    phaseStartPass = currentPass;
   }
 
-  /** Fully resets the calculator. */
-  public void reset() {
-    this.currentPhase = PHASE_IDLE;
-    this.autoroutePassesCompleted = 0;
-    this.optimizerPassesCompleted = 0;
-    this.totalElapsedSeconds = 0;
-    this.totalConnectableItems = 0;
-    started = false;
-    frozen = false;
-    frozenEta = null;
-    ewmaPassDuration = -1;
-    firstPassDurationSeconds = -1;
-    ewmaOptimizerPassDuration = -1;
-    ewmaFanoutItemsPerSecond = -1;
-    lastKnownIncompleteCount = 0;
-    lastKnownMaximumCount = 0;
-    phaseStartTimeSeconds = currentTimeSeconds();
-    stuckNetCount = 0;
-    consecutiveNoImprovementPasses = 0;
+  private void resetEstimators() {
+    lastPass = -1;
+    lastPassElapsedSeconds = 0.0;
+    emaPassDuration = -1.0;
+    emaDecayRate = -1.0;
     lastDisplayedEtaSeconds = -1;
     consecutiveWorseReadings = 0;
-    resetRegressionWindow();
+    
+    phaseStartElapsedSeconds = 0.0;
+    phaseStartIncompleteCount = -1;
+    phaseStartPass = 0;
   }
 
-  // ======================== Private update helpers ========================
-
-  private void resetRegressionWindow() {
-    regressionIndex = 0;
-    regressionCount = 0;
-    lastSampleElapsedSeconds = -1;
-    fitSlope = Double.NaN;
-    fitIntercept = Double.NaN;
-    fitRSquared = 0;
-    fitResidualStdError = 0;
-  }
-
-  private void updateFanout(RouterCounters counters) {
-    if (counters == null) return;
-    int routed = counters.routedCount != null ? counters.routedCount : 0;
-    int failed = counters.failedToBeRoutedCount != null ? counters.failedToBeRoutedCount : 0;
-    int extraVias = counters.fanoutExtraViasCount != null ? counters.fanoutExtraViasCount : 0;
-    int processed = routed + failed + extraVias;
-
-    if (processed <= 0) return;
-    double elapsed = currentTimeSeconds() - phaseStartTimeSeconds;
-    if (elapsed <= 0) return;
-
-    double rate = processed / elapsed;
-    if (ewmaFanoutItemsPerSecond < 0) {
-      ewmaFanoutItemsPerSecond = rate;
-    } else {
-      ewmaFanoutItemsPerSecond = EWMA_FANOUT * rate + (1 - EWMA_FANOUT) * ewmaFanoutItemsPerSecond;
-    }
-  }
-
-  private int effectiveIncompleteCount(int rawIncompleteCount) {
-    return Math.max(0, rawIncompleteCount - stuckNetCount);
-  }
-
-  /**
-   * Adds a (elapsedSeconds, ln(completionFraction)) sample to the rolling regression window
-   * and recomputes the fit. Uses completion fraction (effective incomplete / maximum), not
-   * full normalized score — the score's quality terms (trace length, vias) make 100% score
-   * unreachable even on a fully-routed board, which would make the regression target
-   * unreachable too. Samples are throttled to MIN_SAMPLE_INTERVAL_SECONDS apart so a burst of
-   * update() calls doesn't over-weight one short interval relative to others.
-   */
-  private void addRegressionSample(double elapsedSeconds, int effectiveIncomplete, int maximumCount) {
-    int denominator = maximumCount > 0 ? maximumCount : totalConnectableItems;
-    if (denominator <= 0) return;
-    if (lastSampleElapsedSeconds >= 0 && (elapsedSeconds - lastSampleElapsedSeconds) < MIN_SAMPLE_INTERVAL_SECONDS) {
-      return;
-    }
-
-    double fraction = Math.max(effectiveIncomplete, COMPLETION_FRACTION_EPSILON_ITEMS) / (double) denominator;
-    double y = Math.log(fraction);
-
-    regressionX[regressionIndex] = elapsedSeconds;
-    regressionY[regressionIndex] = y;
-    regressionIndex = (regressionIndex + 1) % REGRESSION_WINDOW_SIZE;
-    if (regressionCount < REGRESSION_WINDOW_SIZE) regressionCount++;
-    lastSampleElapsedSeconds = elapsedSeconds;
-
-    recomputeFit();
-  }
-
-  /** Ordinary least-squares fit of y = fitIntercept + fitSlope * x, plus R^2 and residual SE. */
-  private void recomputeFit() {
-    int n = regressionCount;
-    if (n < 3) {
-      fitSlope = Double.NaN;
-      return;
-    }
-    double sumX = 0, sumY = 0;
-    for (int i = 0; i < n; i++) {
-      sumX += regressionX[i];
-      sumY += regressionY[i];
-    }
-    double meanX = sumX / n;
-    double meanY = sumY / n;
-
-    double sumXY = 0, sumXX = 0, sumYY = 0;
-    for (int i = 0; i < n; i++) {
-      double dx = regressionX[i] - meanX;
-      double dy = regressionY[i] - meanY;
-      sumXY += dx * dy;
-      sumXX += dx * dx;
-      sumYY += dy * dy;
-    }
-
-    if (sumXX < 1e-9) {
-      fitSlope = Double.NaN;
-      return;
-    }
-
-    double slope = sumXY / sumXX;
-    double intercept = meanY - slope * meanX;
-
-    double ssRes = 0;
-    for (int i = 0; i < n; i++) {
-      double predicted = intercept + slope * regressionX[i];
-      double residual = regressionY[i] - predicted;
-      ssRes += residual * residual;
-    }
-    double ssTot = sumYY;
-    double rSquared = ssTot > 1e-9 ? Math.max(0, 1.0 - ssRes / ssTot) : 0;
-    double residualStdError = n > 2 ? Math.sqrt(ssRes / (n - 2)) : 0;
-
-    this.fitSlope = slope;
-    this.fitIntercept = intercept;
-    this.fitRSquared = rSquared;
-    this.fitResidualStdError = residualStdError;
-    this.fitMeanX = meanX;
-    this.fitSumSqX = sumXX;
-  }
-
-  // ======================== ETA computation ========================
-
-  private RoutingEta computeLiveEta() {
-    if (PHASE_FANOUT.equals(currentPhase)) {
-      // Fanout is typically very fast (seconds), so showing a time estimate is
-      // misleading — the EWMA rate from a few seconds of data is unreliable.
-      // Instead, show a simple progress message.
-      return finalizeEta(-1, Confidence.NONE, 1, "Fanout in progress...", -1, -1);
-    }
-    if (PHASE_OPTIMIZER.equals(currentPhase)) {
-      double eta = calcOptimizerEta();
-      Confidence confidence = ewmaOptimizerPassDuration > 0 ? Confidence.MEDIUM : Confidence.NONE;
-      int remaining = Math.max(0, maxOptimizerPasses - optimizerPassesCompleted);
-      return finalizeEta(eta, confidence, remaining, null, -1, -1);
-    }
-    return computeAutorouteEta();
-  }
-
-  private double calcOptimizerEta() {
-    if (ewmaOptimizerPassDuration <= 0) return -1;
-    int remaining = Math.max(0, maxOptimizerPasses - optimizerPassesCompleted);
-    return remaining <= 0 ? 0 : remaining * ewmaOptimizerPassDuration;
-  }
-
-  /**
-   * Core of the redesign. Solves the regression for the time at which the normalized score
-   * reaches the "effectively done" threshold, derives a statistical band from the regression's
-   * own residual error, and gates confidence (and whether a time is shown at all) on R^2 and
-   * sample count rather than on pass count alone.
-   * <p>
-   * Uses the normalized score (0-1000) as the progress signal, which captures all quality
-   * factors: unrouted connections, clearance violations, trace bends, trace length, and via
-   * count. This gives a much more complete picture of routing progress than incomplete count
-   * alone, and naturally handles the ripup/reroute non-monotonicity since the score only
-   * improves when the board genuinely gets better.
-   */
-  private RoutingEta computeAutorouteEta() {
-    int effectiveIncomplete = effectiveIncompleteCount(lastKnownIncompleteCount);
-    if (effectiveIncomplete <= 0) {
-      return finalizeEta(0, Confidence.HIGH, 0, null, 0, 0);
-    }
-
-    int denominator = lastKnownMaximumCount > 0 ? lastKnownMaximumCount : totalConnectableItems;
-    double steadyPassDuration = ewmaPassDuration > 0 ? ewmaPassDuration
-        : (firstPassDurationSeconds > 0 ? firstPassDurationSeconds : -1);
-    int passesRemainingBudget = Math.max(0, maxPasses - autoroutePassesCompleted);
-    double budgetCeiling = steadyPassDuration > 0 ? passesRemainingBudget * steadyPassDuration : -1;
-
-    double etaSeconds = -1;
-    double etaLow = -1;
-    double etaHigh = -1;
-    Confidence confidence = Confidence.NONE;
-    // Show pass number and remaining count. Don't show maxPasses since it's often
-    // a large default (100+) that misleads users into thinking the router will run
-    // that many passes, when in practice it stops much earlier via stagnation.
-    String progressText = "Pass " + autoroutePassesCompleted
-        + " - " + effectiveIncomplete + " remaining";
-
-    boolean haveFit = !Double.isNaN(fitSlope) && fitSlope < 0 && denominator > 0;
-    if (haveFit) {
-      // Target: fraction = COMPLETION_FRACTION_EPSILON_ITEMS / denominator (effectively done).
-      // Must match the fraction-based signal fed into addRegressionSample(), or the solved
-      // target time is off by a factor of denominator (this was a bug in a prior revision:
-      // the target used the raw epsilon while the signal was a fraction).
-      double targetY = Math.log(COMPLETION_FRACTION_EPSILON_ITEMS / (double) denominator);
-      double targetTime = (targetY - fitIntercept) / fitSlope; // absolute elapsedSeconds at target
-      double rawEta = targetTime - totalElapsedSeconds;
-
-
-      if (rawEta >= 0) {
-        etaSeconds = rawEta;
-
-        // Prediction standard error at the forecast point, propagated from y-space to
-        // time-space via the delta method (dividing by |slope|). Approximate but grounded in
-        // the regression's actual residuals rather than an arbitrary +/-X% heuristic.
-        int n = regressionCount;
-        double sePredY = fitResidualStdError * Math.sqrt(1.0 + 1.0 / n
-            + Math.pow(targetTime - fitMeanX, 2) / Math.max(fitSumSqX, 1e-9));
-        double seTime = Math.abs(fitSlope) > 1e-9 ? sePredY / Math.abs(fitSlope) : 0;
-        etaLow = Math.max(0, etaSeconds - seTime);
-        etaHigh = etaSeconds + seTime;
-
-        confidence = confidenceFromFit(regressionCount, fitRSquared);
-      }
-    }
-
-    // Hard budget ceiling always applies, regardless of what the regression predicts: not
-    // everything routes in one pass, and the router will not run past maxPasses.
-    if (budgetCeiling >= 0 && (etaSeconds < 0 || etaSeconds > budgetCeiling)) {
-      etaSeconds = budgetCeiling;
-      etaLow = Math.max(0, budgetCeiling - (etaHigh > etaSeconds ? (etaHigh - etaSeconds) : 0));
-      etaHigh = budgetCeiling;
-      if (confidence == Confidence.HIGH) confidence = Confidence.MEDIUM;
-    }
-
-    // Stagnation risk: the router may stop on its own (via its own stagnation check) before
-    // the regression's projected convergence. Blend toward "stops soon" and cap confidence.
-    if (stagnationPassLimit > 0 && steadyPassDuration > 0) {
-      double stagnationRisk = Math.min(1.0, consecutiveNoImprovementPasses / (double) stagnationPassLimit);
-      if (stagnationRisk > 0) {
-        int passesUntilStagnationStop = Math.max(0, stagnationPassLimit - consecutiveNoImprovementPasses);
-        double stagnationStopEta = passesUntilStagnationStop * steadyPassDuration;
-        etaSeconds = etaSeconds < 0 ? stagnationStopEta
-            : (1 - stagnationRisk) * etaSeconds + stagnationRisk * stagnationStopEta;
-        if (stagnationRisk >= 0.5 && confidence == Confidence.HIGH) confidence = Confidence.MEDIUM;
-      }
-    }
-
-    int remainingPasses = steadyPassDuration > 0 && etaSeconds >= 0
-        ? Math.min(passesRemainingBudget, (int) Math.ceil(etaSeconds / steadyPassDuration))
-        : passesRemainingBudget;
-
-    return finalizeEta(etaSeconds, confidence, remainingPasses, progressText, etaLow, etaHigh);
-  }
-
-  private Confidence confidenceFromFit(int sampleCount, double rSquared) {
-    if (sampleCount < MIN_SAMPLES_FOR_LOW_CONFIDENCE || rSquared < 0.15) {
-      return Confidence.NONE;
-    }
-    if (sampleCount < MIN_SAMPLES_FOR_MEDIUM_CONFIDENCE || rSquared < R_SQUARED_LOW_THRESHOLD) {
-      return Confidence.LOW;
-    }
-    if (sampleCount < MIN_SAMPLES_FOR_HIGH_CONFIDENCE || rSquared < R_SQUARED_HIGH_THRESHOLD) {
-      return Confidence.MEDIUM;
-    }
-    return Confidence.HIGH;
-  }
-
-  /**
-   * Applies the MAX_ACCEPTABLE_ETA_SECONDS cap and packages the result. When confidence is
-   * NONE (or LOW with too little data), the caller-supplied progressText should be preferred
-   * by the UI over a time string — RoutingEta carries both so the UI can make that call.
-   */
-  private RoutingEta finalizeEta(double etaSeconds, Confidence confidence, int remainingPasses,
-                                  String progressText, double etaLow, double etaHigh) {
-    if (etaSeconds > MAX_ACCEPTABLE_ETA_SECONDS) {
-      etaSeconds = MAX_ACCEPTABLE_ETA_SECONDS;
-      if (confidence == Confidence.HIGH) confidence = Confidence.MEDIUM;
-    }
-    RoutingEta eta = new RoutingEta(etaSeconds, confidence, remainingPasses,
-        currentPhase, totalElapsedSeconds, lastKnownIncompleteCount, null);
-    eta.progressText = progressText;
-    eta.etaSecondsLow = etaLow;
-    eta.etaSecondsHigh = etaHigh;
+  private RoutingEta createFallbackEta(double totalElapsedSeconds, int incompleteCount, String currentPhase) {
+    RoutingEta eta = new RoutingEta(-1, Confidence.NONE, -1, currentPhase, totalElapsedSeconds, incompleteCount, null);
+    eta.progressText = "Calculating ETA...";
     return eta;
   }
 
-  /**
-   * Display-side hysteresis, fully decoupled from the estimation model above. The underlying
-   * model is free to fluctuate every update (that's expected — the input signal is genuinely
-   * noisy); what reaches the screen only increases after HYSTERESIS_CONFIRM_COUNT consecutive
-   * worse readings in a row, unless the jump is large enough (HYSTERESIS_BYPASS_RATIO) to
-   * indicate a real discontinuity such as a board restore or stagnation onset. Decreases
-   * (good news) are always shown immediately — there's no reason to make the user wait for
-   * confirmation that things are going well.
-   */
   private RoutingEta applyDisplayHysteresis(RoutingEta raw) {
     if (raw.etaSeconds < 0 || raw.confidence == Confidence.NONE) {
-      // Nothing trustworthy to hold back or confirm; pass through as-is (progress-only display).
       lastDisplayedEtaSeconds = -1;
       consecutiveWorseReadings = 0;
       return raw;
@@ -642,7 +339,6 @@ public class RoutingEtaCalculator {
       return raw;
     }
 
-    // raw.etaSeconds > lastDisplayedEtaSeconds: a worse reading.
     boolean largeJump = raw.etaSeconds > lastDisplayedEtaSeconds * HYSTERESIS_BYPASS_RATIO;
     consecutiveWorseReadings++;
     if (largeJump || consecutiveWorseReadings >= HYSTERESIS_CONFIRM_COUNT) {
@@ -651,16 +347,11 @@ public class RoutingEtaCalculator {
       return raw;
     }
 
-    // Hold the previously displayed value instead of the noisier new one.
     RoutingEta held = new RoutingEta(lastDisplayedEtaSeconds, raw.confidence, raw.estimatedRemainingPasses,
         raw.phase, raw.totalElapsedSeconds, raw.incompleteCount, raw.stopReason);
     held.progressText = raw.progressText;
     held.etaSecondsLow = raw.etaSecondsLow;
     held.etaSecondsHigh = raw.etaSecondsHigh;
     return held;
-  }
-
-  private static double currentTimeSeconds() {
-    return System.currentTimeMillis() / 1000.0;
   }
 }

--- a/src/main/java/app/freerouting/core/RoutingEtaCalculator.java
+++ b/src/main/java/app/freerouting/core/RoutingEtaCalculator.java
@@ -5,6 +5,8 @@ import app.freerouting.core.scoring.RoutingEta;
 import app.freerouting.core.scoring.RoutingEta.Confidence;
 import app.freerouting.logger.FRLogger;
 
+import java.util.ArrayDeque;
+
 /**
  * Calculates and maintains an ETA for the routing job.
  *
@@ -12,9 +14,9 @@ import app.freerouting.logger.FRLogger;
  * <ul>
  * <li><b>Phase-Aware Mathematical Models.</b> Different phases of routing behave differently.
  * <ul>
- * <li><b>Fanout:</b> Linear item-velocity model (sequential pin breakouts).</li>
+ * <li><b>Fanout:</b> Bypasses numeric ETA entirely (too fast/erratic).</li>
  * <li><b>Autoroute:</b> Exponential decay model (rip-up and reroute maze search).</li>
- * <li><b>Optimizer:</b> Linear pass-velocity model (sequential trace reduction).</li>
+ * <li><b>Optimizer:</b> Aggressively weighted pass-velocity model to ignore the slow 1st pass.</li>
  * </ul>
  * </li>
  * <li><b>Terminal State Locking.</b> Prevents delayed thread updates from overwriting "Stopped" 
@@ -30,7 +32,10 @@ public class RoutingEtaCalculator {
   private static final double EMA_ALPHA_DECAY = 0.15;
   
   // Guarantees we never predict an infinite ETA even if the router stalls temporarily
+  // (units: per-pass, used only by the legacy pass-boundary decay estimator)
   private static final double MIN_DECAY_RATE = 0.005; 
+  // Floor for the intra-pass regression decay rate (units: per-second)
+  private static final double MIN_DECAY_RATE_PER_SECOND = 0.0005;
 
   private static final double HYSTERESIS_BYPASS_RATIO = 1.2;
   private static final int HYSTERESIS_CONFIRM_COUNT = 3;
@@ -59,6 +64,15 @@ public class RoutingEtaCalculator {
   private double emaPassDuration = -1.0;
   private double emaDecayRate = -1.0;
 
+  // Rolling-regression decay trackers. BatchAutorouterThread and BatchFanout both fire
+  // board-updated events roughly every second (ProgressThrottler(1000)) WITHIN a pass, with
+  // real decreasing incompleteCount - not just at pass boundaries. Items are shuffled per pass,
+  // so this intra-pass rate is not front-loaded with "easy" items/pins. Each tracker fits
+  // ln(count) vs. wall-clock time by OLS to get a statistically grounded decay rate quickly,
+  // with safeguards against small-sample overconfidence and confidence flapping (see the class).
+  private final PhaseDecayTracker autorouteTracker = new PhaseDecayTracker();
+  private final PhaseDecayTracker fanoutTracker = new PhaseDecayTracker();
+
   // Hysteresis state
   private double lastDisplayedEtaSeconds = -1;
   private int consecutiveWorseReadings = 0;
@@ -66,9 +80,23 @@ public class RoutingEtaCalculator {
   // --- API Compatibility Methods ---
 
   public void startRouting() {
-      resetEstimators();
+      resetForBoardSwap();
       currentPhase = "starting";
       lastEta = createFallbackEta(0, 0, currentPhase);
+  }
+
+  /**
+   * Clears ETA state carried over from a previous board/session.
+   *
+   * <p>This is intentionally stronger than {@link #resetEstimators()} because it also clears the
+   * last emitted phase and ETA payload, allowing a newly loaded board to start from a clean UI
+   * state instead of inheriting the previous board's completion/stopped text.
+   */
+  public void resetForBoardSwap() {
+      resetEstimators();
+      currentPhase = "";
+      lastPhase = "";
+      lastEta = null;
   }
 
   public void setMaxPasses(Integer maxPasses) { this.maxPasses = maxPasses; }
@@ -85,18 +113,17 @@ public class RoutingEtaCalculator {
   
   public void onRoutingCompleted() { 
       this.currentPhase = "completed"; 
-      if (lastEta != null) {
-          lastEta = new RoutingEta(0, Confidence.HIGH, 0, currentPhase, lastEta.totalElapsedSeconds, 0, null);
-          lastEta.progressText = "Completed.";
-      }
+      double totalElapsedSeconds = lastEta != null ? lastEta.totalElapsedSeconds : 0.0;
+      lastEta = new RoutingEta(0, Confidence.HIGH, 0, currentPhase, totalElapsedSeconds, 0, null);
+      lastEta.progressText = "Completed.";
   }
   
   public void onRoutingStopped() { 
       this.currentPhase = "stopped"; 
-      if (lastEta != null) {
-           lastEta = new RoutingEta(0, Confidence.HIGH, 0, currentPhase, lastEta.totalElapsedSeconds, lastEta.incompleteCount, "Stopped");
-           lastEta.progressText = "Stopped.";
-      }
+      double totalElapsedSeconds = lastEta != null ? lastEta.totalElapsedSeconds : 0.0;
+      int incompleteCount = lastEta != null ? lastEta.incompleteCount : 0;
+      lastEta = new RoutingEta(0, Confidence.HIGH, 0, currentPhase, totalElapsedSeconds, incompleteCount, "Stopped");
+      lastEta.progressText = "Stopped.";
   }
 
   /**
@@ -128,69 +155,111 @@ public class RoutingEtaCalculator {
         lastPhase = currentPhase;
     }
 
-    // 3. FANOUT Phase: Linear Item Velocity (Pins breakout linearly, not exponentially)
+    // 3. FANOUT Phase
     if ("fanout".equals(currentPhase)) {
+        // Fanout is fast/erratic pin escaping, so - unlike autoroute - we deliberately cap
+        // confidence at MEDIUM even with a great fit; this phase can still churn (rip-up of
+        // fanout vias) in ways a short regression window won't see coming.
+        fanoutTracker.record(totalElapsedSeconds, incompleteCount);
+
         if (lastPass == -1) {
             initPhaseTrackers(totalElapsedSeconds, currentPass, incompleteCount);
-            RoutingEta fallback = createFallbackEta(totalElapsedSeconds, incompleteCount, currentPhase);
-            fallback.progressText = "Escaping pins (Fanout)...";
-            return fallback;
         }
-
-        double timeInPhase = totalElapsedSeconds - phaseStartElapsedSeconds;
-        int itemsProcessed = phaseStartIncompleteCount - incompleteCount;
-
-        if (timeInPhase > 0 && itemsProcessed > 0) {
-            double secondsPerItem = timeInPhase / itemsProcessed;
-            double etaSeconds = incompleteCount * secondsPerItem;
-
-            RoutingEta fanoutEta = new RoutingEta(etaSeconds, Confidence.MEDIUM, 0, currentPhase, totalElapsedSeconds, incompleteCount, null);
-            fanoutEta.etaSecondsLow = Math.max(0, etaSeconds - (etaSeconds * 0.15));
-            fanoutEta.etaSecondsHigh = etaSeconds + (etaSeconds * 0.15);
-            fanoutEta.progressText = "Escaping pins (Fanout)...";
-            
+        if (currentPass > lastPass) {
             lastPass = currentPass;
             lastPassElapsedSeconds = totalElapsedSeconds;
+        }
+
+        PhaseDecayTracker.Fit fit = fanoutTracker.fit();
+        if (fit != null) {
+            double decay = Math.max(fit.decayPerSecond, MIN_DECAY_RATE_PER_SECOND);
+            double etaSeconds = Math.log(Math.max(incompleteCount, 1) / 0.5) / decay;
+            Confidence confidence = minConfidence(fit.confidence, Confidence.MEDIUM);
+
+            double marginRatio = confidence == Confidence.MEDIUM ? 0.20 : 0.35;
+            double margin = Math.max(3.0, etaSeconds * marginRatio);
+
+            RoutingEta fanoutEta = new RoutingEta(Math.max(0.0, etaSeconds), confidence, 0,
+                currentPhase, totalElapsedSeconds, incompleteCount, null);
+            fanoutEta.etaSecondsLow = Math.max(0.0, etaSeconds - margin);
+            fanoutEta.etaSecondsHigh = etaSeconds + margin;
+            if (confidence != Confidence.MEDIUM) {
+                // NONE/LOW still render as text per RoutingEta.toDisplayString - keep it labeled.
+                fanoutEta.progressText = "Escaping pins (Fanout)...";
+            }
             return applyDisplayHysteresis(fanoutEta);
         }
-        
-        lastPass = currentPass;
-        lastPassElapsedSeconds = totalElapsedSeconds;
+
         RoutingEta fallback = createFallbackEta(totalElapsedSeconds, incompleteCount, currentPhase);
         fallback.progressText = "Escaping pins (Fanout)...";
         return fallback;
     }
 
-    // 4. OPTIMIZER Phase: Linear Pass Velocity (Trace smoothing is strictly pass-based)
+    // 4. OPTIMIZER Phase
     if ("optimizer".equals(currentPhase)) {
         if (lastPass == -1) {
             initPhaseTrackers(totalElapsedSeconds, currentPass, incompleteCount);
+            if (maxOptimizerPasses != null && maxOptimizerPasses > currentPass && totalElapsedSeconds > 0) {
+                int roughPassesRemaining = Math.max(1, maxOptimizerPasses - currentPass);
+                double etaSeconds = totalElapsedSeconds * roughPassesRemaining;
+                RoutingEta roughEta = new RoutingEta(etaSeconds, Confidence.LOW, roughPassesRemaining,
+                    currentPhase, totalElapsedSeconds, 0, null);
+                roughEta.etaSecondsLow = Math.max(0.0, etaSeconds * 0.80);
+                roughEta.etaSecondsHigh = Math.max(roughEta.etaSecondsLow + 1.0, etaSeconds * 1.20);
+                roughEta.progressText = "Optimizing routes...";
+                return applyDisplayHysteresis(roughEta);
+            }
             RoutingEta fallback = createFallbackEta(totalElapsedSeconds, 0, currentPhase);
             fallback.progressText = "Optimizing routes...";
             return fallback;
         }
 
-        double timeInPhase = totalElapsedSeconds - phaseStartElapsedSeconds;
-        int passesElapsed = currentPass - phaseStartPass;
-
-        if (timeInPhase > 0 && passesElapsed > 0 && maxOptimizerPasses != null && maxOptimizerPasses > 0) {
-            double secondsPerPass = timeInPhase / passesElapsed;
-            int passesRemaining = Math.max(0, maxOptimizerPasses - currentPass);
-            double etaSeconds = passesRemaining * secondsPerPass;
-
-            RoutingEta optEta = new RoutingEta(etaSeconds, Confidence.HIGH, passesRemaining, currentPhase, totalElapsedSeconds, 0, null);
-            optEta.etaSecondsLow = Math.max(0, etaSeconds - (etaSeconds * 0.05));
-            optEta.etaSecondsHigh = etaSeconds + (etaSeconds * 0.05);
+        if (currentPass > lastPass) {
+            double timeElapsed = totalElapsedSeconds - lastPassElapsedSeconds;
+            int passesElapsed = currentPass - lastPass;
+            double passDuration = Math.max(0.001, timeElapsed / passesElapsed);
+            
+            // Pass 1 of the optimizer does heavy rip-up and is notoriously slow. 
+            // Passes 2+ are very fast. We use an aggressive weight to quickly adapt to the fast passes.
+            if (emaPassDuration < 0 || currentPass <= 2) {
+                emaPassDuration = passDuration;
+            } else {
+                emaPassDuration = (0.60 * passDuration) + (0.40 * emaPassDuration);
+            }
             
             lastPass = currentPass;
             lastPassElapsedSeconds = totalElapsedSeconds;
+        }
+
+        if (emaPassDuration > 0 && maxOptimizerPasses != null && maxOptimizerPasses > 0) {
+            int passesRemaining = Math.max(0, maxOptimizerPasses - currentPass);
+            double etaSeconds = passesRemaining * emaPassDuration;
+
+            // Optimizer passes 3+ are fast and stable, so this converges quickly once we have a
+            // real target pass count - but don't claim HIGH confidence off a single sample.
+            Confidence confidence = currentPass <= 1 ? Confidence.LOW
+                : currentPass <= 3 ? Confidence.MEDIUM : Confidence.HIGH;
+            double marginRatio = confidence == Confidence.HIGH ? 0.05 : 0.15;
+
+            RoutingEta optEta = new RoutingEta(etaSeconds, confidence, passesRemaining, currentPhase, totalElapsedSeconds, 0, null);
+            optEta.etaSecondsLow = Math.max(0, etaSeconds - (etaSeconds * marginRatio));
+            optEta.etaSecondsHigh = etaSeconds + (etaSeconds * marginRatio);
             return applyDisplayHysteresis(optEta);
         }
-        
-        lastPass = currentPass;
-        lastPassElapsedSeconds = totalElapsedSeconds;
+
+        // NOTE: BatchOptimizer's real stop condition is score-improvement vs.
+        // optimizationImprovementThreshold, not a fixed pass count - job.routerSettings.optimizer
+        // .maxPasses is explicitly optional there. When no pass cap is configured (the common
+        // case), maxOptimizerPasses is never populated here, so a real numeric ETA isn't possible
+        // without also being fed the actual improvement-vs-threshold ratio. Rather than fabricate
+        // a fake countdown, surface honest live progress instead of a static string.
         RoutingEta fallback = createFallbackEta(totalElapsedSeconds, 0, currentPhase);
-        fallback.progressText = "Optimizing routes...";
+        if (emaPassDuration > 0) {
+            fallback.progressText = String.format("Optimizing routes (pass %d, ~%.0fs/pass)...",
+                currentPass, emaPassDuration);
+        } else {
+            fallback.progressText = "Optimizing routes...";
+        }
         return fallback;
     }
 
@@ -203,20 +272,28 @@ public class RoutingEtaCalculator {
             return eta;
         }
 
+        // Record this sample immediately (even before any pass boundary) so the intra-pass
+        // regression has data from the very first throttled update in pass 1.
+        autorouteTracker.record(totalElapsedSeconds, incompleteCount);
+
         if (lastPass == -1) {
             initPhaseTrackers(totalElapsedSeconds, currentPass, incompleteCount);
-            return createFallbackEta(totalElapsedSeconds, incompleteCount, currentPhase);
         }
 
         double safeIncomplete = Math.max(1.0, incompleteCount);
-        
+
+        // --- Legacy pass-boundary decay estimator (per-pass units) ---
+        // Still needed for: (a) emaPassDuration, used to translate a decay-per-second ETA into
+        // an approximate "remaining passes" figure for display, and (b) as a fallback/blend
+        // input once real pass boundaries exist, since it captures rip-up/reroute churn across
+        // full passes that a single pass's intra-pass regression cannot see.
         if (currentPass > lastPass) {
             int passesElapsed = currentPass - lastPass;
             double timeElapsed = totalElapsedSeconds - lastPassElapsedSeconds;
-            
+
             double passDuration = Math.max(0.001, timeElapsed / passesElapsed);
             double safeLastIncomplete = Math.max(1.0, lastKnownIncompleteCount);
-            
+
             double k;
             if (safeIncomplete >= safeLastIncomplete) {
                 k = -0.01; // Rip-up stall penalty
@@ -237,55 +314,94 @@ public class RoutingEtaCalculator {
             lastKnownIncompleteCount = incompleteCount;
         }
 
-        if (emaPassDuration < 0 || emaDecayRate < 0) {
-            return createFallbackEta(totalElapsedSeconds, incompleteCount, currentPhase);
+        // --- Intra-pass regression estimator (per-second units) ---
+        PhaseDecayTracker.Fit fit = autorouteTracker.fit();
+        boolean regressionUsable = fit != null;
+
+        int totalPhasePasses = currentPass - phaseStartPass;
+        boolean legacyUsable = emaPassDuration > 0 && emaDecayRate > 0;
+
+        if (!regressionUsable && !legacyUsable) {
+            // Not enough data from either estimator yet (e.g. very first update of the phase).
+            RoutingEta fallback = createFallbackEta(totalElapsedSeconds, incompleteCount, currentPhase);
+            fallback.progressText = "Analyzing search space...";
+            return applyDisplayHysteresis(fallback);
         }
 
-        // Blend Local EMA (70%) with Global History (30%)
-        int totalPhasePasses = currentPass - phaseStartPass;
-        double globalDecayRate = -1.0;
-        if (totalPhasePasses > 0 && phaseStartIncompleteCount > 0) {
-            double safeStartInc = Math.max(1.0, phaseStartIncompleteCount);
-            if (safeIncomplete < safeStartInc) {
-                globalDecayRate = -Math.log(safeIncomplete / safeStartInc) / totalPhasePasses;
+        double effectiveDecayPerSecond;
+        Confidence confidence;
+
+        if (regressionUsable) {
+            effectiveDecayPerSecond = fit.decayPerSecond;
+            confidence = fit.confidence;
+
+            if (legacyUsable && totalPhasePasses >= 2) {
+                // Blend in the pass-boundary decay (converted to per-second) once we have at
+                // least two completed passes worth of macro rip-up/reroute behavior. Weight
+                // shifts toward the pass-based signal as more full passes accumulate, since it
+                // sees dynamics a single pass's regression can't (temporary incomplete spikes
+                // from rip-up between passes, layer/via churn, etc).
+                double legacyDecayPerSecond = emaDecayRate / emaPassDuration;
+                double passWeight = Math.min(0.5, totalPhasePasses * 0.08);
+                effectiveDecayPerSecond = (1 - passWeight) * fit.decayPerSecond
+                    + passWeight * legacyDecayPerSecond;
+                // totalPhasePasses >= 2 here already implies currentPass >= 2, so
+                // passCountConfidence is never NONE in this branch - taking the min is safe
+                // and just guards against a young phase overclaiming despite a lucky-looking fit.
+                confidence = minConfidence(confidence, passCountConfidence(currentPass));
+            }
+        } else {
+            // Regression not yet trustworthy (too few/short samples, or a bad/rising fit,
+            // e.g. single-threaded runs where board-updated events are sparse) - fall back
+            // to the original pass-boundary-only estimator.
+            double globalDecayRate = -1.0;
+            if (totalPhasePasses > 0 && phaseStartIncompleteCount > 0) {
+                double safeStartInc = Math.max(1.0, phaseStartIncompleteCount);
+                if (safeIncomplete < safeStartInc) {
+                    globalDecayRate = -Math.log(safeIncomplete / safeStartInc) / totalPhasePasses;
+                }
+            }
+            double legacyDecay = Math.max(emaDecayRate, MIN_DECAY_RATE);
+            if (globalDecayRate > 0) {
+                legacyDecay = (legacyDecay * 0.70) + (globalDecayRate * 0.30);
+            }
+            effectiveDecayPerSecond = legacyDecay / emaPassDuration;
+            confidence = passCountConfidence(currentPass);
+        }
+
+        effectiveDecayPerSecond = Math.max(effectiveDecayPerSecond, MIN_DECAY_RATE_PER_SECOND);
+
+        double etaSeconds = Math.log(Math.max(incompleteCount, 1) / 0.5) / effectiveDecayPerSecond;
+
+        // Approximate remaining-pass count, for display/telemetry only - the real ETA above is
+        // computed directly in seconds and does not depend on this being exact.
+        int remainingPasses = emaPassDuration > 0 ? (int) Math.ceil(etaSeconds / emaPassDuration) : -1;
+
+        if (maxPasses != null && maxPasses > 0 && emaPassDuration > 0) {
+            int hardPassLimit = Math.max(0, maxPasses - currentPass);
+            double hardCapSeconds = hardPassLimit * emaPassDuration;
+            if (etaSeconds > hardCapSeconds) {
+                etaSeconds = hardCapSeconds;
+            }
+            if (remainingPasses >= 0) {
+                remainingPasses = Math.min(remainingPasses, hardPassLimit);
             }
         }
-
-        double effectiveDecay = Math.max(emaDecayRate, MIN_DECAY_RATE);
-        if (globalDecayRate > 0) {
-            effectiveDecay = (effectiveDecay * 0.70) + (globalDecayRate * 0.30);
-        }
-        
-        double remainingPassesDouble = Math.log(Math.max(incompleteCount, 1) / 0.5) / effectiveDecay;
-        int remainingPasses = (int) Math.ceil(remainingPassesDouble);
-        
-        if (maxPasses != null && maxPasses > 0) {
-            int hardPassLimit = Math.max(0, maxPasses - currentPass);
-            remainingPasses = Math.min(remainingPasses, hardPassLimit);
-        }
-        
-        double etaSeconds = remainingPasses * emaPassDuration;
-
-        // Confidence and Bounds
-        Confidence confidence;
-        if (currentPass <= 1) confidence = Confidence.NONE;
-        else if (currentPass <= 3) confidence = Confidence.LOW;
-        else if (currentPass <= 8) confidence = Confidence.MEDIUM;
-        else confidence = Confidence.HIGH;
 
         double marginRatio;
         if (confidence == Confidence.LOW) marginRatio = 0.25;
         else if (confidence == Confidence.MEDIUM) marginRatio = 0.10;
-        else marginRatio = 0.05;
+        else if (confidence == Confidence.HIGH) marginRatio = 0.05;
+        else marginRatio = 0.35;
 
-        double margin = Math.max(5.0, etaSeconds * marginRatio); 
+        double margin = Math.max(5.0, etaSeconds * marginRatio);
         double etaLow = Math.max(0, etaSeconds - margin);
         double etaHigh = etaSeconds + margin;
 
         RoutingEta rawEta = new RoutingEta(etaSeconds, confidence, remainingPasses, currentPhase, totalElapsedSeconds, incompleteCount, null);
         rawEta.etaSecondsLow = etaLow;
         rawEta.etaSecondsHigh = etaHigh;
-        
+
         if (confidence == Confidence.NONE) {
             rawEta.progressText = "Analyzing search space...";
         }
@@ -314,10 +430,36 @@ public class RoutingEtaCalculator {
     emaDecayRate = -1.0;
     lastDisplayedEtaSeconds = -1;
     consecutiveWorseReadings = 0;
+    autorouteTracker.reset();
+    fanoutTracker.reset();
     
     phaseStartElapsedSeconds = 0.0;
     phaseStartIncompleteCount = -1;
     phaseStartPass = 0;
+  }
+
+  /** Confidence purely from how many autoroute passes have completed (legacy heuristic). */
+  private static Confidence passCountConfidence(int currentPass) {
+    if (currentPass <= 1) return Confidence.NONE;
+    if (currentPass <= 3) return Confidence.LOW;
+    if (currentPass <= 8) return Confidence.MEDIUM;
+    return Confidence.HIGH;
+  }
+
+  // Explicit rank map rather than a.ordinal() - safer than assuming Confidence's declared
+  // enum order without having sight of RoutingEta.java.
+  private static int confidenceRank(Confidence c) {
+    switch (c) {
+      case NONE: return 0;
+      case LOW: return 1;
+      case MEDIUM: return 2;
+      case HIGH: return 3;
+      default: return 0;
+    }
+  }
+
+  private static Confidence minConfidence(Confidence a, Confidence b) {
+    return confidenceRank(a) <= confidenceRank(b) ? a : b;
   }
 
   private RoutingEta createFallbackEta(double totalElapsedSeconds, int incompleteCount, String currentPhase) {
@@ -353,5 +495,170 @@ public class RoutingEtaCalculator {
     held.etaSecondsLow = raw.etaSecondsLow;
     held.etaSecondsHigh = raw.etaSecondsHigh;
     return held;
+  }
+
+  /**
+   * Tracks (time, ln(count)) samples for a monotonically-decaying quantity (incomplete
+   * connections, pins-to-go) and fits an OLS regression to estimate its decay rate.
+   *
+   * <p>Three safeguards beyond a plain regression, added after observing on real boards:
+   * <ul>
+   * <li><b>Adjusted R^2</b> instead of raw R^2. Raw R^2 is inflated with few points (a 5-point
+   * fit can look "perfect" by chance), which was causing premature high-confidence ETAs on
+   * large boards during the first ~30-40s that then had to visibly climb once more data came
+   * in. Adjusted R^2 penalizes small sample counts and removes most of that bias.</li>
+   * <li><b>Split-half slope-stability check.</b> Large boards often show a fast burst in the
+   * first few seconds of a pass (whatever routes easily) before settling into a slower,
+   * representative rate as the board fills in. Comparing the decay rate in the first half of
+   * the sample window against the second half catches this directly - if the rate has slowed by
+   * more than {@code MAX_SLOWDOWN_RATIO}, the fit is capped at LOW confidence regardless of its
+   * raw fit quality, since the full-window average is still contaminated by the early burst.</li>
+   * <li><b>Confidence-downgrade hysteresis.</b> A single noisy update can transiently drop R^2
+   * below a threshold. Without damping, that flashes the UI back to "Calculating ETA..." for one
+   * cycle before recovering - this requires several consecutive weaker readings before actually
+   * downgrading the displayed confidence (upgrades are still immediate).</li>
+   * </ul>
+   */
+  private static final class PhaseDecayTracker {
+    private static final int MAX_SAMPLES = 60;
+    private static final int MIN_SAMPLES = 5;
+    private static final double MIN_SPAN_SECONDS = 2.0;
+    private static final double MIN_ADJUSTED_R2 = 0.4;
+    private static final double MAX_SLOWDOWN_RATIO = 1.6;
+    private static final int CONFIDENCE_DOWNGRADE_CONFIRM_COUNT = 3;
+
+    private final ArrayDeque<double[]> samples = new ArrayDeque<>();
+    private Confidence displayedConfidence = Confidence.NONE;
+    private int consecutiveWeakerReadings = 0;
+
+    void reset() {
+      samples.clear();
+      displayedConfidence = Confidence.NONE;
+      consecutiveWeakerReadings = 0;
+    }
+
+    void record(double elapsedSeconds, int count) {
+      if (count <= 0) {
+        return;
+      }
+      double[] last = samples.peekLast();
+      if (last != null && elapsedSeconds <= last[0] + 1e-6) {
+        return; // no new information (duplicate/throttle-collision timestamp)
+      }
+      samples.addLast(new double[] {elapsedSeconds, Math.log(count)});
+      while (samples.size() > MAX_SAMPLES) {
+        samples.pollFirst();
+      }
+    }
+
+    static final class Fit {
+      final double decayPerSecond;
+      final Confidence confidence;
+      final int sampleCount;
+
+      Fit(double decayPerSecond, Confidence confidence, int sampleCount) {
+        this.decayPerSecond = decayPerSecond;
+        this.confidence = confidence;
+        this.sampleCount = sampleCount;
+      }
+    }
+
+    /** Returns null if there isn't enough data yet, or the trend isn't actually decaying. */
+    Fit fit() {
+      int n = samples.size();
+      if (n < MIN_SAMPLES) {
+        return null;
+      }
+      double span = samples.peekLast()[0] - samples.peekFirst()[0];
+      if (span < MIN_SPAN_SECONDS) {
+        return null;
+      }
+
+      double[] full = fitLinearRegression(samples, n);
+      if (full == null || full[0] >= 0) {
+        return null; // not decaying (flat or rising) - nothing usable to report
+      }
+      double decayPerSecond = -full[0];
+      double adjustedR2 = adjustedR2(full[2], n);
+
+      Confidence rawConfidence;
+      if (adjustedR2 >= 0.85 && n >= 10) rawConfidence = Confidence.HIGH;
+      else if (adjustedR2 >= 0.6 && n >= 6) rawConfidence = Confidence.MEDIUM;
+      else if (adjustedR2 >= MIN_ADJUSTED_R2) rawConfidence = Confidence.LOW;
+      else rawConfidence = Confidence.NONE;
+
+      if (rawConfidence != Confidence.NONE && n >= 8) {
+        double[][] arr = samples.toArray(new double[0][]);
+        int mid = n / 2;
+        double[] firstHalf = fitLinearRegression(java.util.Arrays.asList(arr).subList(0, mid), mid);
+        double[] secondHalf = fitLinearRegression(java.util.Arrays.asList(arr).subList(mid, n), n - mid);
+        if (firstHalf != null && secondHalf != null && firstHalf[0] < 0 && secondHalf[0] < 0) {
+          double firstDecay = -firstHalf[0];
+          double secondDecay = -secondHalf[0];
+          if (firstDecay / Math.max(secondDecay, 1e-9) > MAX_SLOWDOWN_RATIO) {
+            // Rate has genuinely slowed within this window - the early burst is skewing the
+            // full-window average, so don't trust it beyond LOW confidence yet.
+            rawConfidence = minConfidence(rawConfidence, Confidence.LOW);
+          }
+        }
+      }
+
+      // Confidence-downgrade hysteresis: allow immediate upgrades, but require several
+      // consecutive weaker readings before actually downgrading what's displayed.
+      if (confidenceRank(rawConfidence) >= confidenceRank(displayedConfidence)) {
+        displayedConfidence = rawConfidence;
+        consecutiveWeakerReadings = 0;
+      } else {
+        consecutiveWeakerReadings++;
+        if (consecutiveWeakerReadings >= CONFIDENCE_DOWNGRADE_CONFIRM_COUNT) {
+          displayedConfidence = rawConfidence;
+          consecutiveWeakerReadings = 0;
+        }
+      }
+
+      if (displayedConfidence == Confidence.NONE) {
+        return null;
+      }
+      return new Fit(decayPerSecond, displayedConfidence, n);
+    }
+
+    private static double adjustedR2(double r2, int n) {
+      if (n <= 2) {
+        return r2;
+      }
+      return 1.0 - (1.0 - r2) * (n - 1.0) / (n - 2.0);
+    }
+
+    /**
+     * Ordinary least squares fit of y = intercept + slope * x.
+     *
+     * @return {slope, intercept, r2}, or null if the samples are degenerate (e.g. all same x).
+     */
+    private static double[] fitLinearRegression(Iterable<double[]> samples, int n) {
+      double sumX = 0, sumY = 0, sumXY = 0, sumXX = 0;
+      for (double[] s : samples) {
+        sumX += s[0];
+        sumY += s[1];
+        sumXY += s[0] * s[1];
+        sumXX += s[0] * s[0];
+      }
+      double denom = n * sumXX - sumX * sumX;
+      if (Math.abs(denom) < 1e-9) {
+        return null;
+      }
+      double slope = (n * sumXY - sumX * sumY) / denom;
+      double intercept = (sumY - slope * sumX) / n;
+
+      double meanY = sumY / n;
+      double ssTot = 0, ssRes = 0;
+      for (double[] s : samples) {
+        double predicted = intercept + slope * s[0];
+        double residual = s[1] - predicted;
+        ssRes += residual * residual;
+        ssTot += (s[1] - meanY) * (s[1] - meanY);
+      }
+      double r2 = ssTot > 1e-9 ? 1.0 - (ssRes / ssTot) : (ssRes < 1e-9 ? 1.0 : 0.0);
+      return new double[] {slope, intercept, r2};
+    }
   }
 }

--- a/src/main/java/app/freerouting/core/RoutingJob.java
+++ b/src/main/java/app/freerouting/core/RoutingJob.java
@@ -5,6 +5,7 @@ import app.freerouting.core.events.RoutingJobLogEntryAddedEvent;
 import app.freerouting.core.events.RoutingJobLogEntryAddedEventListener;
 import app.freerouting.core.events.RoutingJobUpdatedEvent;
 import app.freerouting.core.events.RoutingJobUpdatedEventListener;
+import app.freerouting.core.scoring.RoutingEta;
 import app.freerouting.io.specctra.RulesReader;
 import app.freerouting.io.FileFormat;
 import app.freerouting.logger.FRLogger;
@@ -93,8 +94,14 @@ public class RoutingJob implements Serializable, Comparable<RoutingJob> {
   @Schema(name = "drc_settings", description = "DRC configuration settings")
   public DesignRulesCheckerSettings drcSettings = new DesignRulesCheckerSettings();
   @SerializedName("resource_usage")
-  @Schema(name = "resource_usage", description = "Resource usage stats")
+  @Schema(name = "resource_usage", description = "Resource usage of the job")
   public RouterJobResourceUsage resourceUsage = new RouterJobResourceUsage();
+
+  /**
+   * The ETA calculator for this routing job.
+   * Transient because it's runtime-only state, not serialized.
+   */
+  public transient RoutingEtaCalculator etaCalculator = new RoutingEtaCalculator();
   public transient StoppableThread thread;
   public transient RoutingBoard board;
   public transient Instant timeoutAt;

--- a/src/main/java/app/freerouting/core/scoring/RoutingEta.java
+++ b/src/main/java/app/freerouting/core/scoring/RoutingEta.java
@@ -35,7 +35,7 @@ public class RoutingEta implements Serializable {
   @SerializedName("estimated_remaining_passes")
   public final int estimatedRemainingPasses;
 
-  /** Current phase description for display ("fanout", "autoroute", "optimizer", "completing"). */
+  /** Current phase description for display ("fanout", "autoroute", "optimizer", "completed", "stopped"). */
   @SerializedName("phase")
   public final String phase;
 
@@ -43,37 +43,22 @@ public class RoutingEta implements Serializable {
   @SerializedName("total_elapsed_seconds")
   public final double totalElapsedSeconds;
 
-  /** Number of incomplete connections remaining. */
+  /** Number of items still unrouted. */
   @SerializedName("incomplete_count")
   public final int incompleteCount;
 
-  /** Reason routing stopped, for display (e.g. "max passes reached", "stagnation", "user stop"). Null if not applicable. */
+  /** Optional message if routing was stopped early. */
   @SerializedName("stop_reason")
   public final String stopReason;
 
-  /**
-   * Human-readable progress fallback ("Pass 3/8 - 12 remaining") for use when confidence is
-   * too low to show a trustworthy time estimate. Null if not applicable (e.g. fanout/optimizer
-   * phases, or frozen terminal states).
-   */
-  @SerializedName("progress_text")
-  public String progressText;
+  /** Human-readable progress text used when confidence is LOW/NONE or in terminal states. */
+  public transient String progressText;
 
-  /** Lower bound of the statistical prediction band, in seconds. -1 if not available. */
-  @SerializedName("eta_seconds_low")
-  public double etaSecondsLow = -1;
-
-  /** Upper bound of the statistical prediction band, in seconds. -1 if not available. */
-  @SerializedName("eta_seconds_high")
-  public double etaSecondsHigh = -1;
+  public transient double etaSecondsLow = -1;
+  public transient double etaSecondsHigh = -1;
 
   public RoutingEta(double etaSeconds, Confidence confidence, int estimatedRemainingPasses,
-                    String phase, double totalElapsedSeconds, int incompleteCount) {
-    this(etaSeconds, confidence, estimatedRemainingPasses, phase, totalElapsedSeconds, incompleteCount, null);
-  }
-
-  public RoutingEta(double etaSeconds, Confidence confidence, int estimatedRemainingPasses,
-                    String phase, double totalElapsedSeconds, int incompleteCount, String stopReason) {
+      String phase, double totalElapsedSeconds, int incompleteCount, String stopReason) {
     this.etaSeconds = etaSeconds;
     this.confidence = confidence;
     this.estimatedRemainingPasses = estimatedRemainingPasses;
@@ -84,58 +69,36 @@ public class RoutingEta implements Serializable {
   }
 
   /**
-   * Returns a readable ETA string for display in the status bar.
+   * Generates the appropriate text for the UI Status Panel based on the current phase,
+   * confidence, and numerical range.
    */
   public String toDisplayString() {
-    // Pre-start state: no board is currently being routed. Distinct from
-    // "Estimating..." (routing in progress, not enough data yet) so a board
-    // change can't visually look like an in-progress or completed run.
-    if ("idle".equals(phase)) {
-      return "";
-    }
-
-    // Handle frozen terminal states
+    // 1. Hard terminal states always win over numeric ETAs.
     if ("completed".equals(phase)) {
-      return "Completed";
+      return "Completed.";
     }
     if ("stopped".equals(phase)) {
-      String reasonSuffix = (stopReason != null && !stopReason.isEmpty()) ? " — " + stopReason : "";
-      if (incompleteCount > 0) {
-        return "Stopped (" + incompleteCount + " unrouted)" + reasonSuffix;
-      }
-      return "Stopped" + reasonSuffix;
+      return "Stopped.";
     }
-
-    // Not enough data yet for a trustworthy time — show progress instead of a number.
-    if (confidence == Confidence.NONE) {
-      if (progressText != null && !progressText.isEmpty()) {
-        return progressText;
-      }
-      if (etaSeconds < 0) {
-        return "Estimating...";
-      }
-      return "ETA: ~" + formatDuration(etaSeconds);
-    }
-
-    // All done or finishing
-    if (incompleteCount == 0 && !"optimizer".equals(phase)) {
+    if ("completing".equals(phase)) {
       return "Completing...";
     }
 
-    // Low confidence: still show progress text if we have it, since a wide/uncertain
-    // band can be more honest than a single number the person will over-trust.
-    if (confidence == Confidence.LOW && progressText != null && !progressText.isEmpty()) {
-      return progressText;
+    // 2. Low confidence or explicit fallback text (like Fanout phase)
+    if (confidence == Confidence.NONE || confidence == Confidence.LOW) {
+      if (progressText != null && !progressText.isEmpty()) {
+        return progressText;
+      }
+      return "Calculating ETA...";
     }
 
-    // Medium/high confidence with a real statistical band: show the range instead of
-    // false precision on a single number.
+    // 3. Medium/high confidence with a real statistical band: show the range instead of false precision
     if (etaSecondsLow >= 0 && etaSecondsHigh > etaSecondsLow
         && (etaSecondsHigh - etaSecondsLow) > Math.max(5, etaSeconds * 0.15)) {
       return "ETA: " + formatDuration(etaSecondsLow) + " - " + formatDuration(etaSecondsHigh);
     }
 
-    // Show the ETA with appropriate precision based on confidence
+    // 4. High confidence single precise number
     return "ETA: " + formatDuration(etaSeconds);
   }
 
@@ -155,11 +118,11 @@ public class RoutingEta implements Serializable {
     }
     int minutes = (int) (etaSeconds / 60);
     int seconds = (int) (etaSeconds % 60);
-    if (minutes < 60) {
-      return minutes + "m " + seconds + "s";
-    }
-    int hours = minutes / 60;
-    minutes = minutes % 60;
-    return hours + "h " + minutes + "m";
+    return minutes + "m " + seconds + "s";
+  }
+
+  @Override
+  public String toString() {
+    return toDisplayString();
   }
 }

--- a/src/main/java/app/freerouting/core/scoring/RoutingEta.java
+++ b/src/main/java/app/freerouting/core/scoring/RoutingEta.java
@@ -1,0 +1,165 @@
+package app.freerouting.core.scoring;
+
+import com.google.gson.annotations.SerializedName;
+import java.io.Serializable;
+
+/**
+ * Value object representing an estimated time of arrival (ETA) for the routing job.
+ * Immutable once created; thread-safe by design.
+ */
+public class RoutingEta implements Serializable {
+
+  /**
+   * Confidence level of the ETA estimate.
+   */
+  public enum Confidence {
+    /** Not enough data to estimate yet (first 1-2 passes). */
+    NONE,
+    /** Rough estimate based on limited data. */
+    LOW,
+    /** Reasonable estimate with moderate confidence. */
+    MEDIUM,
+    /** High confidence estimate (many passes completed, stable trend). */
+    HIGH
+  }
+
+  /** Estimated seconds remaining until routing completes. */
+  @SerializedName("eta_seconds")
+  public final double etaSeconds;
+
+  /** Confidence level of this estimate. */
+  @SerializedName("confidence")
+  public final Confidence confidence;
+
+  /** Estimated number of remaining passes (autoroute phase). */
+  @SerializedName("estimated_remaining_passes")
+  public final int estimatedRemainingPasses;
+
+  /** Current phase description for display ("fanout", "autoroute", "optimizer", "completing"). */
+  @SerializedName("phase")
+  public final String phase;
+
+  /** Total wall-clock seconds elapsed so far. */
+  @SerializedName("total_elapsed_seconds")
+  public final double totalElapsedSeconds;
+
+  /** Number of incomplete connections remaining. */
+  @SerializedName("incomplete_count")
+  public final int incompleteCount;
+
+  /** Reason routing stopped, for display (e.g. "max passes reached", "stagnation", "user stop"). Null if not applicable. */
+  @SerializedName("stop_reason")
+  public final String stopReason;
+
+  /**
+   * Human-readable progress fallback ("Pass 3/8 - 12 remaining") for use when confidence is
+   * too low to show a trustworthy time estimate. Null if not applicable (e.g. fanout/optimizer
+   * phases, or frozen terminal states).
+   */
+  @SerializedName("progress_text")
+  public String progressText;
+
+  /** Lower bound of the statistical prediction band, in seconds. -1 if not available. */
+  @SerializedName("eta_seconds_low")
+  public double etaSecondsLow = -1;
+
+  /** Upper bound of the statistical prediction band, in seconds. -1 if not available. */
+  @SerializedName("eta_seconds_high")
+  public double etaSecondsHigh = -1;
+
+  public RoutingEta(double etaSeconds, Confidence confidence, int estimatedRemainingPasses,
+                    String phase, double totalElapsedSeconds, int incompleteCount) {
+    this(etaSeconds, confidence, estimatedRemainingPasses, phase, totalElapsedSeconds, incompleteCount, null);
+  }
+
+  public RoutingEta(double etaSeconds, Confidence confidence, int estimatedRemainingPasses,
+                    String phase, double totalElapsedSeconds, int incompleteCount, String stopReason) {
+    this.etaSeconds = etaSeconds;
+    this.confidence = confidence;
+    this.estimatedRemainingPasses = estimatedRemainingPasses;
+    this.phase = phase;
+    this.totalElapsedSeconds = totalElapsedSeconds;
+    this.incompleteCount = incompleteCount;
+    this.stopReason = stopReason;
+  }
+
+  /**
+   * Returns a readable ETA string for display in the status bar.
+   */
+  public String toDisplayString() {
+    // Pre-start state: no board is currently being routed. Distinct from
+    // "Estimating..." (routing in progress, not enough data yet) so a board
+    // change can't visually look like an in-progress or completed run.
+    if ("idle".equals(phase)) {
+      return "";
+    }
+
+    // Handle frozen terminal states
+    if ("completed".equals(phase)) {
+      return "Completed";
+    }
+    if ("stopped".equals(phase)) {
+      String reasonSuffix = (stopReason != null && !stopReason.isEmpty()) ? " — " + stopReason : "";
+      if (incompleteCount > 0) {
+        return "Stopped (" + incompleteCount + " unrouted)" + reasonSuffix;
+      }
+      return "Stopped" + reasonSuffix;
+    }
+
+    // Not enough data yet for a trustworthy time — show progress instead of a number.
+    if (confidence == Confidence.NONE) {
+      if (progressText != null && !progressText.isEmpty()) {
+        return progressText;
+      }
+      if (etaSeconds < 0) {
+        return "Estimating...";
+      }
+      return "ETA: ~" + formatDuration(etaSeconds);
+    }
+
+    // All done or finishing
+    if (incompleteCount == 0 && !"optimizer".equals(phase)) {
+      return "Completing...";
+    }
+
+    // Low confidence: still show progress text if we have it, since a wide/uncertain
+    // band can be more honest than a single number the person will over-trust.
+    if (confidence == Confidence.LOW && progressText != null && !progressText.isEmpty()) {
+      return progressText;
+    }
+
+    // Medium/high confidence with a real statistical band: show the range instead of
+    // false precision on a single number.
+    if (etaSecondsLow >= 0 && etaSecondsHigh > etaSecondsLow
+        && (etaSecondsHigh - etaSecondsLow) > Math.max(5, etaSeconds * 0.15)) {
+      return "ETA: " + formatDuration(etaSecondsLow) + " - " + formatDuration(etaSecondsHigh);
+    }
+
+    // Show the ETA with appropriate precision based on confidence
+    return "ETA: " + formatDuration(etaSeconds);
+  }
+
+  /**
+   * Formats a duration in seconds into a readable string with decreasing
+   * precision as the duration increases.
+   */
+  private static String formatDuration(double etaSeconds) {
+    if (etaSeconds <= 0) {
+      return "0s";
+    }
+    if (etaSeconds > 3600) {
+      return ">1h";
+    }
+    if (etaSeconds < 60) {
+      return (int) etaSeconds + "s";
+    }
+    int minutes = (int) (etaSeconds / 60);
+    int seconds = (int) (etaSeconds % 60);
+    if (minutes < 60) {
+      return minutes + "m " + seconds + "s";
+    }
+    int hours = minutes / 60;
+    minutes = minutes % 60;
+    return hours + "h " + minutes + "m";
+  }
+}

--- a/src/main/java/app/freerouting/gui/BoardFrame.java
+++ b/src/main/java/app/freerouting/gui/BoardFrame.java
@@ -392,6 +392,10 @@ public class BoardFrame extends WindowBase {
     this.routingJob = job;
     board_panel.reset_board_handling(job);
     board_panel.board_handling.replaceRoutingBoard(board);
+    if (this.routingJob != null && this.routingJob.etaCalculator != null) {
+      this.routingJob.etaCalculator.resetForBoardSwap();
+      board_panel.board_handling.screen_messages.set_routing_eta(this.routingJob.etaCalculator.getCurrentEta());
+    }
 
     // Close other child windows
     for (int i = 0; i < this.permanent_subwindows.length; i++) {
@@ -504,6 +508,11 @@ public class BoardFrame extends WindowBase {
         // Raise an event to notify the observers that a new board has been loaded
         this.boardLoadedEventListeners
             .forEach(listener -> listener.accept(board_panel.board_handling.get_routing_board()));
+
+        if (this.routingJob != null && this.routingJob.etaCalculator != null) {
+          this.routingJob.etaCalculator.resetForBoardSwap();
+          board_panel.board_handling.screen_messages.set_routing_eta(this.routingJob.etaCalculator.getCurrentEta());
+        }
       }
     } else {
       ObjectInputStream object_stream;

--- a/src/main/java/app/freerouting/gui/BoardFrame.java
+++ b/src/main/java/app/freerouting/gui/BoardFrame.java
@@ -351,8 +351,8 @@ public class BoardFrame extends WindowBase {
     // Screen messages are displayed in the status bar, below the canvas.
     this.screen_messages = new ScreenMessages(this.message_panel.errorLabel, this.message_panel.warningLabel,
         this.message_panel.statusMessage, this.message_panel.additionalMessage,
-        this.message_panel.currentLayer, this.message_panel.currentBoardScore, this.message_panel.mousePosition,
-        this.message_panel.unitLabel, this.locale);
+        this.message_panel.currentLayer, this.message_panel.currentBoardScore, this.message_panel.etaLabel,
+        this.message_panel.mousePosition, this.message_panel.unitLabel, this.locale);
 
     // The scroll pane for the canvas of the routing board.
     this.scroll_pane = new JScrollPane();

--- a/src/main/java/app/freerouting/gui/BoardPanelStatus.java
+++ b/src/main/java/app/freerouting/gui/BoardPanelStatus.java
@@ -26,6 +26,7 @@ class BoardPanelStatus extends JPanel {
   public final JLabel additionalMessage;
   public final JLabel currentLayer;
   public final JLabel currentBoardScore;
+  public final JLabel etaLabel;
   public final JLabel mousePosition;
   public final JLabel unitLabel;
   // An icon for errors and warnings
@@ -107,6 +108,15 @@ class BoardPanelStatus extends JPanel {
     currentBoardScore = new JLabel();
     tm.setText(currentBoardScore, "current_board_score");
     rightMessagePanel.add(currentBoardScore, BorderLayout.CENTER);
+
+    // Initialize ETA label
+    etaLabel = new JLabel();
+    etaLabel.setText("");
+    etaLabel.setHorizontalAlignment(SwingConstants.CENTER);
+    etaLabel.setMaximumSize(new Dimension(180, 14));
+    etaLabel.setMinimumSize(new Dimension(100, 14));
+    etaLabel.setPreferredSize(new Dimension(140, 14));
+    rightMessagePanel.add(etaLabel, BorderLayout.CENTER);
 
     // Create cursor panel
     JPanel cursorPanel = new JPanel(new BorderLayout());

--- a/src/main/java/app/freerouting/interactive/AutorouterAndRouteOptimizerThread.java
+++ b/src/main/java/app/freerouting/interactive/AutorouterAndRouteOptimizerThread.java
@@ -14,9 +14,11 @@ import app.freerouting.autoroute.events.TaskStateChangedEvent;
 import app.freerouting.autoroute.events.TaskStateChangedEventListener;
 import app.freerouting.board.AngleRestriction;
 import app.freerouting.board.Unit;
+import app.freerouting.core.RoutingEtaCalculator;
 import app.freerouting.core.RoutingJob;
 import app.freerouting.core.RoutingJobState;
 import app.freerouting.core.scoring.BoardStatistics;
+import app.freerouting.core.scoring.RoutingEta;
 import app.freerouting.geometry.planar.FloatLine;
 import app.freerouting.geometry.planar.FloatPoint;
 import app.freerouting.io.FileFormat;
@@ -152,6 +154,11 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread {
   private BatchOptimizer batchOptimizer;
 
   /**
+   * The ETA calculator instance for this routing session.
+   */
+  private final RoutingEtaCalculator etaCalculator;
+
+  /**
    * Creates a new autorouter and optimizer thread for GUI-based routing.
    *
    * <p>Initialization process:
@@ -199,6 +206,8 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread {
   protected AutorouterAndRouteOptimizerThread(GuiBoardManager p_board_handling, RoutingJob routingJob) {
     super(p_board_handling, routingJob);
 
+    this.etaCalculator = routingJob.etaCalculator;
+
     routingJob.thread = this;
     routingJob.board = p_board_handling.get_routing_board();
 
@@ -238,6 +247,33 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread {
         boardManager.screen_messages.set_batch_autoroute_info(event.getRouterCounters());
         boardManager.screen_messages.set_board_score(boardScore, event.getBoardStatistics().connections.incompleteCount,
             event.getBoardStatistics().clearanceViolations.totalCount);
+
+        // Update ETA calculator with current progress
+        RoutingEta currentEta = null;
+        if (event.getRouterCounters() != null) {
+          double elapsedSeconds = routingJob.startedAt != null
+              ? java.time.Duration.between(routingJob.startedAt, java.time.Instant.now()).toMillis() / 1000.0
+              : 0;
+          // Detect phase transitions from RouterCounters.phase
+          String phase = event.getRouterCounters().phase;
+          if (phase != null) {
+            if ("fanout".equals(phase)) {
+              // Only call onFanoutStarted once per phase; subsequent events with
+              // phase="fanout" should just update the fanout rate, not reset it.
+              // We use a flag to avoid repeated resets.
+              if (!"fanout".equals(etaCalculator.getCurrentPhase())) {
+                etaCalculator.onFanoutStarted();
+              }
+            } else if ("autoroute".equals(phase)) {
+              if (!"autoroute".equals(etaCalculator.getCurrentPhase())) {
+                etaCalculator.onAutorouteStarted();
+              }
+            }
+          }
+          etaCalculator.update(elapsedSeconds, event.getRouterCounters(), event.getBoardStatistics());
+        }
+        currentEta = etaCalculator.getCurrentEta();
+        boardManager.screen_messages.set_routing_eta(currentEta);
         boardManager.repaint();
       }
     });
@@ -451,7 +487,22 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread {
   protected void thread_action() {
     routingJob.startedAt = Instant.now();
     routingJob.state = RoutingJobState.RUNNING;
-      boardManager.set_num_threads(routingJob.routerSettings.maxThreads);
+    boardManager.set_num_threads(routingJob.routerSettings.maxThreads);
+
+    // Initialize the ETA calculator with settings
+    etaCalculator.startRouting();
+    if (routingJob.routerSettings.maxPasses != null) {
+      etaCalculator.setMaxPasses(routingJob.routerSettings.maxPasses);
+    }
+    if (routingJob.routerSettings.optimizer.maxPasses != null) {
+      etaCalculator.setMaxOptimizerPasses(routingJob.routerSettings.optimizer.maxPasses);
+    }
+    etaCalculator.setThreadCount(routingJob.routerSettings.maxThreads);
+
+    // Set total connectable items so the item-count model works from pass 1
+    // Use the total number of nets as an approximate scaling factor
+    etaCalculator.setTotalConnectableItems(
+        routingJob.board != null ? routingJob.board.rules.nets.max_net_no() : 0);
 
     // Start a background thread that periodically samples CPU time, total allocated
     // memory, and peak heap usage — mirroring the headless RoutingJobSchedulerActionThread.
@@ -501,6 +552,13 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread {
       String start_message = tm.getText("batch_autorouter") + " " + tm.getText("stop_message");
       boardManager.screen_messages.set_status_message(start_message);
 
+      // Determine if fanout will run (it happens inside runBatchLoop())
+      boolean fanoutWillRun = routingJob.routerSettings.isFanoutEnabled()
+          && !this.is_stop_auto_router_requested();
+      if (fanoutWillRun) {
+        etaCalculator.onFanoutStarted();
+      }
+
       // Let's run the autorouter
       if (routingJob.routerSettings.getRunRouter() && !this.is_stop_auto_router_requested()) {
         // Cast to access runBatchLoop() which exists on both BatchAutorouter and
@@ -510,7 +568,7 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread {
         } else if (batchAutorouter instanceof BatchAutorouterV19) {
           ((BatchAutorouterV19) batchAutorouter).runBatchLoop();
         }
-      } else if (routingJob.routerSettings.isFanoutEnabled() && !this.is_stop_auto_router_requested()) {
+      } else if (fanoutWillRun) {
         // Run only the fanout pre-pass
         Integer originalMaxPasses = routingJob.routerSettings.maxPasses;
         try {
@@ -524,6 +582,11 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread {
           routingJob.routerSettings.maxPasses = originalMaxPasses;
         }
       }
+
+      // After runBatchLoop returns, we've finished autoroute (and possibly fanout).
+      // The ETA calculator should now know we're in the autoroute phase.
+      // If fanout ran, it will have fired events with phase="fanout" that we detect,
+      // but we also ensure the phase is properly set for subsequent optimizer phase.
 
       boardManager.replaceRoutingBoard(routingJob.board);
 
@@ -580,6 +643,15 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread {
       FRAnalytics.autorouterFinished();
 
       Thread.sleep(100);
+
+      // Before optimizer starts, signal the ETA calculator
+      boolean optimizerWillRun = (boardManager.get_num_threads() > 0)
+          && (routingJob.routerSettings.optimizer.enabled)
+          && routingJob.routerSettings.getRunOptimizer()
+          && !this.isStopRequested();
+      if (optimizerWillRun) {
+        etaCalculator.onOptimizerStarted();
+      }
 
       // Let's run the optimizer if it's enabled
       int num_threads = boardManager.get_num_threads();
@@ -678,10 +750,18 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread {
     if (this.isStopRequested()) {
       routingJob.finishedAt = Instant.now();
       routingJob.state = RoutingJobState.CANCELLED;
+      etaCalculator.onRoutingStopped();
     } else {
       routingJob.finishedAt = Instant.now();
       routingJob.state = RoutingJobState.COMPLETED;
       globalSettings.statistics.incrementJobsCompleted();
+      // Check if all nets were routed
+      int incompleteCount = boardManager.get_ratsnest().incomplete_count();
+      if (incompleteCount == 0) {
+        etaCalculator.onRoutingCompleted();
+      } else {
+        etaCalculator.onRoutingStopped();
+      }
     }
 
     for (ThreadActionListener hl : this.listeners) {

--- a/src/main/java/app/freerouting/interactive/AutorouterAndRouteOptimizerThread.java
+++ b/src/main/java/app/freerouting/interactive/AutorouterAndRouteOptimizerThread.java
@@ -499,10 +499,10 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread {
     }
     etaCalculator.setThreadCount(routingJob.routerSettings.maxThreads);
 
-    // Set total connectable items so the item-count model works from pass 1
-    // Use the total number of nets as an approximate scaling factor
+    // Seed the ETA model with the actual fanout workload so the first estimate has a realistic
+    // board-size baseline instead of a rough net-count approximation.
     etaCalculator.setTotalConnectableItems(
-        routingJob.board != null ? routingJob.board.rules.nets.max_net_no() : 0);
+      routingJob.board != null ? routingJob.board.get_smd_pins().size() : 0);
 
     // Start a background thread that periodically samples CPU time, total allocated
     // memory, and peak heap usage — mirroring the headless RoutingJobSchedulerActionThread.
@@ -763,6 +763,8 @@ public class AutorouterAndRouteOptimizerThread extends InteractiveActionThread {
         etaCalculator.onRoutingStopped();
       }
     }
+
+    boardManager.screen_messages.set_routing_eta(etaCalculator.getCurrentEta());
 
     for (ThreadActionListener hl : this.listeners) {
       if (this.isStopRequested()) {

--- a/src/main/java/app/freerouting/interactive/ScreenMessages.java
+++ b/src/main/java/app/freerouting/interactive/ScreenMessages.java
@@ -2,6 +2,7 @@ package app.freerouting.interactive;
 
 import app.freerouting.board.Unit;
 import app.freerouting.core.RouterCounters;
+import app.freerouting.core.scoring.RoutingEta;
 import app.freerouting.geometry.planar.FloatPoint;
 import app.freerouting.logger.FRLogger;
 import app.freerouting.util.TextManager;
@@ -28,6 +29,7 @@ public class ScreenMessages {
   private final JLabel status_field;
   private final JLabel layer_field;
   private final JLabel score_field;
+  private final JLabel eta_field;
   private final JLabel mouse_position;
   private final JLabel unit_label;
   private final TextManager tm;
@@ -38,7 +40,7 @@ public class ScreenMessages {
    * Creates a new instance of ScreenMessages
    */
   public ScreenMessages(JLabel errorLabel, JLabel warningLabel, JLabel p_status_field, JLabel p_add_field,
-      JLabel p_layer_field, JLabel p_score_field, JLabel p_mouse_position, JLabel p_unit_label,
+      JLabel p_layer_field, JLabel p_score_field, JLabel p_eta_field, JLabel p_mouse_position, JLabel p_unit_label,
       Locale p_locale) {
 
     tm = new TextManager(this.getClass(), p_locale);
@@ -50,6 +52,7 @@ public class ScreenMessages {
     add_field = p_add_field;
     layer_field = p_layer_field;
     score_field = p_score_field;
+    eta_field = p_eta_field;
     mouse_position = p_mouse_position;
     unit_label = p_unit_label;
     add_field.setText(empty_string);
@@ -180,5 +183,18 @@ public class ScreenMessages {
   public void set_board_score(float score, int unrouted_count, int violation_count) {
     score_field.setText(tm.getText("score", FRLogger.defaultFloatFormat.format(score), String.valueOf(unrouted_count),
         String.valueOf(violation_count)));
+  }
+
+  /**
+   * Sets the ETA display text in the status bar.
+   *
+   * @param eta the current routing ETA, or null to clear the display
+   */
+  public void set_routing_eta(RoutingEta eta) {
+    if (eta == null || eta.confidence == RoutingEta.Confidence.NONE) {
+      eta_field.setText(tm.getText("eta_estimating"));
+      return;
+    }
+    eta_field.setText(eta.toDisplayString());
   }
 }

--- a/src/main/resources/app/freerouting/interactive/ScreenMessages_en.properties
+++ b/src/main/resources/app/freerouting/interactive/ScreenMessages_en.properties
@@ -12,3 +12,4 @@ still=still
 via_count=Via Count:
 trace_length=Trace Length:
 score=Score: {{score}} ({{unrouted_count}} unrouted)
+eta_estimating=Estimating...

--- a/src/test/java/app/freerouting/core/RoutingEtaCalculatorTest.java
+++ b/src/test/java/app/freerouting/core/RoutingEtaCalculatorTest.java
@@ -1,0 +1,82 @@
+package app.freerouting.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class RoutingEtaCalculatorTest {
+
+  @Test
+  void terminalStateIsPreservedUntilTheNextBoardStarts() {
+    RoutingEtaCalculator calculator = new RoutingEtaCalculator();
+
+    calculator.startRouting();
+    calculator.onAutorouteStarted();
+    calculator.update(12.5, null, null);
+    calculator.onRoutingCompleted();
+
+    assertEquals("completed", calculator.getCurrentEta().phase);
+    assertEquals("Completed.", calculator.getCurrentEta().toDisplayString());
+
+    calculator.update(20.0, null, null);
+
+    assertEquals("completed", calculator.getCurrentEta().phase);
+    assertEquals("Completed.", calculator.getCurrentEta().toDisplayString());
+  }
+
+  @Test
+  void boardSwapClearsAnyPreviousTerminalEta() {
+    RoutingEtaCalculator calculator = new RoutingEtaCalculator();
+
+    calculator.startRouting();
+    calculator.onRoutingStopped();
+    assertEquals("Stopped.", calculator.getCurrentEta().toDisplayString());
+
+    calculator.resetForBoardSwap();
+    assertNull(calculator.getCurrentEta());
+
+    calculator.startRouting();
+    assertEquals("starting", calculator.getCurrentEta().phase);
+    assertEquals("Calculating ETA...", calculator.getCurrentEta().toDisplayString());
+  }
+
+  @Test
+  void fanoutPhaseProducesARoughEarlyEtaAfterProgressAppears() {
+    RoutingEtaCalculator calculator = new RoutingEtaCalculator();
+
+    calculator.startRouting();
+    calculator.setTotalConnectableItems(100);
+    calculator.onFanoutStarted();
+
+    calculator.update(2.0, new RouterCounters() {{
+      passCount = 1;
+      incompleteCount = 80;
+      phase = "fanout";
+    }}, null);
+
+    assertEquals("fanout", calculator.getCurrentEta().phase);
+    assertEquals("Escaping pins (Fanout)...", calculator.getCurrentEta().progressText);
+    assertEquals(RoutingEta.Confidence.LOW, calculator.getCurrentEta().confidence);
+  }
+
+  @Test
+  void autoroutePhaseShowsARoughFirstPassEstimateWhenMaxPassesIsKnown() {
+    RoutingEtaCalculator calculator = new RoutingEtaCalculator();
+
+    calculator.startRouting();
+    calculator.setMaxPasses(20);
+    calculator.onAutorouteStarted();
+
+    calculator.update(3.0, new RouterCounters() {{
+      passCount = 1;
+      incompleteCount = 75;
+      phase = "autoroute";
+    }}, null);
+
+    assertEquals("autoroute", calculator.getCurrentEta().phase);
+    assertEquals(RoutingEta.Confidence.LOW, calculator.getCurrentEta().confidence);
+    assertEquals("Analyzing search space...", calculator.getCurrentEta().progressText);
+    assertTrue(calculator.getCurrentEta().etaSeconds > 0);
+  }
+}


### PR DESCRIPTION
### Description
Introduce the RoutingEtaCalculator to enhance ETA estimation during routing processes. Revise the calculator to utilize search progress instead of board progress, and improve the overall functionality and testing of the ETA calculator.

As of right now it is about 10-12% +/- for the first few displayed numbers however I found that after pass 3 it drops to about 3-7% +/- its actual time for routing. (Note these are just my findings and it could be different for other people)

Future
- Improved optomizer and fanout ETA estimations
- Add a possible enhanced mode where it will run on another core (this is unlikely though since I have found that it would just impact performance.
- Fix the transition to pass 3 (where the calculator is able to give a more reliable ETA)
- Improve initial estimations for bigger boards (this is because the first few traces on big boards take much less time)
- and more
- Add tooltip to inform users that this is only an estimation based off math and will not always be 100% correct

## NOTE
This feature is still in v0.3 since it is very difficult, as it involves multiple phases, and is based off a non linear trace method.

