### PR TITLE
Bug Fix: UI DPI Scaling between displays

### DIFF
--- a/src/main/java/app/freerouting/gui/BoardSavableSubWindow.java
+++ b/src/main/java/app/freerouting/gui/BoardSavableSubWindow.java
@@ -47,6 +47,20 @@ public abstract class BoardSavableSubWindow extends BoardSubWindow {
   }
 
   /**
+   * Called when the window has been moved to a different display with a different
+   * GraphicsConfiguration (e.g. different DPI scaling). Re-packs the window and
+   * refreshes displayed values so that component sizes and font metrics are
+   * recomputed for the new display.
+   */
+  @Override
+  protected void onGraphicsConfigurationChanged() {
+    pack();
+    refresh();
+    revalidate();
+    repaint();
+  }
+
+  /**
    * Type for attributes of this class, which are saved to an Objectstream.
    */
   private static class SavedAttributes implements Serializable {

--- a/src/main/java/app/freerouting/gui/WindowBase.java
+++ b/src/main/java/app/freerouting/gui/WindowBase.java
@@ -5,7 +5,10 @@ import app.freerouting.util.TextManager;
 import app.freerouting.management.analytics.FRAnalytics;
 import java.awt.Dimension;
 import java.awt.Frame;
+import java.awt.GraphicsConfiguration;
 import java.awt.Window;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowFocusListener;
 import java.awt.image.BufferedImage;
@@ -16,11 +19,13 @@ import java.util.Locale;
 import java.util.Objects;
 import javax.imageio.ImageIO;
 import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
 
 public class WindowBase extends JFrame {
 
   protected TextManager tm;
   private Instant gotFocusAt;
+  private GraphicsConfiguration lastGraphicsConfig;
 
   WindowBase(int minWidth, int minHeight) {
     super();
@@ -33,6 +38,21 @@ public class WindowBase extends JFrame {
       FRLogger.error("Couldn't load icon file 'freerouting_icon_256x256_v3.png'.", e);
     }
     this.setMinimumSize(new Dimension(minWidth, minHeight));
+
+    // Track the initial graphics configuration for per-monitor DPI change detection
+    this.lastGraphicsConfig = getGraphicsConfiguration();
+
+    addComponentListener(new ComponentAdapter() {
+      @Override
+      public void componentMoved(ComponentEvent e) {
+        checkGraphicsConfigurationChanged();
+      }
+
+      @Override
+      public void componentResized(ComponentEvent e) {
+        checkGraphicsConfigurationChanged();
+      }
+    });
 
     addWindowFocusListener(new WindowFocusListener() {
       @Override
@@ -75,6 +95,35 @@ public class WindowBase extends JFrame {
         FRLogger.trace("Window '" + className + "' with title of '" + title + "' lost focus.");
       }
     });
+  }
+
+  /**
+   * Checks whether the window has moved to a different display (GraphicsConfiguration).
+   * If so, triggers a re-layout so that font metrics and component sizes are
+   * recomputed for the new display's DPI scaling.
+   */
+  private void checkGraphicsConfigurationChanged() {
+    GraphicsConfiguration current = getGraphicsConfiguration();
+    if (current != lastGraphicsConfig) {
+      lastGraphicsConfig = current;
+      FRLogger.trace("Window '" + this.getClass().getName() + "' moved to a different display; re-laying out for new DPI scaling.");
+      SwingUtilities.invokeLater(() -> onGraphicsConfigurationChanged());
+    }
+  }
+
+  /**
+   * Called when the window has been moved to a different display with a different
+   * GraphicsConfiguration (e.g. different DPI scaling). Subclasses may override
+   * to perform additional re-layout work such as pack() or refresh().
+   * <p>
+   * The default implementation revalidates and repaints the content pane so that
+   * component sizes and font metrics are recomputed for the new display.
+   */
+  protected void onGraphicsConfigurationChanged() {
+    if (getContentPane() != null) {
+      getContentPane().revalidate();
+      getContentPane().repaint();
+    }
   }
 
   /**


### PR DESCRIPTION
### Description

Added UI scaling between different DPI devices.

### Cause

Swing sub-windows component size kept frozen while font metric (scaling) was not. 

This created an issue when changing from a monitor to a laptop for some UI sub-windows where the text would become "hidden" 

for example F.Bu -> F...

even with ample space, when dragging a window from one display to another.