### PR TITLE
Guard null corners in insert_forced_trace_polyline

### DIFF
--- a/src/main/java/app/freerouting/board/RoutingBoard.java
+++ b/src/main/java/app/freerouting/board/RoutingBoard.java
@@ -595,6 +595,14 @@ public class RoutingBoard extends BasicBoard implements Serializable {
     clear_shove_failing_obstacle();
     Point from_corner = p_polyline.first_corner();
     Point to_corner = p_polyline.last_corner();
+    if (from_corner == null || to_corner == null) {
+      // A degenerate polyline (parallel/near-parallel lines produced while shoving against
+      // fixed multi-layer copper) has no well-defined first/last corner -- corner(i) returns
+      // null. The trace cannot be inserted; return null so the caller treats this segment as
+      // not inserted and reroutes, instead of dereferencing a null corner (NPE at .equals).
+      FRLogger.trace("RoutingBoard.insert_forced_trace_polyline: degenerate polyline (null corner), skipping");
+      return null;
+    }
     if (from_corner.equals(to_corner)) {
       return to_corner;
     }


### PR DESCRIPTION
### Description

Fixes a `NullPointerException` in `RoutingBoard.insert_forced_trace_polyline` that aborts autorouting on boards containing **fixed multi-layer (via) traces**.

**Symptom.** When a board has pre-routed/fixed copper that changes layers through a via, the batch autorouter throws, repeatedly, once it starts shoving traces near that copper:

```
java.lang.NullPointerException: Cannot invoke "Object.equals(Object)" because "from_corner" is null
    at app.freerouting.board.RoutingBoard.insert_forced_trace_polyline(RoutingBoard.java:598)
    at app.freerouting.autoroute.InsertFoundConnectionAlgo.insert_trace(InsertFoundConnectionAlgo.java:143)
    at app.freerouting.autoroute.AutorouteEngine.autoroute_connection(AutorouteEngine.java:241)
    at app.freerouting.autoroute.BatchAutorouter.autoroute_item(BatchAutorouter.java:1104)
    ...
```

`BatchAutorouter` catches it per connection and logs `Error during routing passes`, so the run doesn't hard-crash — but every affected connection is abandoned, leaving nets unrouted (in my case ~29 unrouted vs ~9 after the fix, same board and settings).

**Root cause.** The method reads the polyline's endpoints without a null check:

```java
Point from_corner = p_polyline.first_corner();
Point to_corner   = p_polyline.last_corner();
if (from_corner.equals(to_corner)) { ... }   // NPE when first_corner() == null
```

`first_corner()` / `last_corner()` return `corner(i)`, the intersection of two consecutive lines. That intersection is `null` for a degenerate polyline (consecutive parallel / near-parallel lines) — which the router can produce while shoving a trace against fixed multi-layer copper.

**Fix.** Guard the null corner and return `null`. Both callers already treat a `null` return as "segment not inserted":

- `InsertFoundConnectionAlgo.insert_trace` null-checks `ok_point` before using it, so it simply reroutes the connection.
- `insert_forced_trace_segment` only calls this method with a valid two-point polyline, so it never hits the guard.

With the guard, the autorouter routes *around* the fixed via copper instead of aborting the connection.

**Reproduction.** Freeze/fix a hand-routed bus that uses layer-changing vias (e.g. a microSD SDIO bus), export to DSN, and autoroute — stock throws the NPE above; with the patch it completes and the fixed copper is preserved untouched. I've kept my board out of the fixtures since it's a private design; happy to add a minimal fixture + `Issue###ContributionBoardRoutingTest` if you'd prefer one — just let me know.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible) — reproduction requires a board with fixed via copper; see note above, can add a fixture on request
- [x] All tests passing (`./gradlew test`)
- [ ] Extended the README / documentation, if necessary — N/A (internal null-safety fix)
