### PR TITLE
Todocleanup: Binary Data output

### DIFF
--- a/src/main/java/app/freerouting/gui/BoardFrame.java
+++ b/src/main/java/app/freerouting/gui/BoardFrame.java
@@ -284,8 +284,8 @@ public class BoardFrame extends WindowBase {
           break;
         case FRB:
           // Save the file as a freerouting binary file
-          // TODO: it should be enough to save the binary data that we already have in the
-          // routingJob.output.data
+          // The binary data is captured into routingJob.output.data during serialization
+          // so it can be reused without re-serializing
           this.saveAsBinary(this.routingJob.output.getFile());
           FRAnalytics.buttonClicked("fileio_savefrb", this.routingJob.getOutputFileDetails());
           break;
@@ -655,28 +655,28 @@ public class BoardFrame extends WindowBase {
       return false;
     }
 
-    OutputStream output_stream;
     try {
       FRLogger.info("Saving '" + outputFile.getPath() + "'...");
 
-      output_stream = new FileOutputStream(outputFile);
-      saveAsBinary(output_stream);
-    } catch (IOException _) {
-      screen_messages.set_status_message(tm.getText("message_binary_file_save_failed", outputFile.getPath()));
-      return false;
+      // Serialize to a byte array first to capture the data
+      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+      saveAsBinary(byteArrayOutputStream);
+
+      // Store the serialized data in routingJob.output
+      byte[] data = byteArrayOutputStream.toByteArray();
+      this.routingJob.output.setData(data);
+
+      // Write to the file
+      try (FileOutputStream fileOutputStream = new FileOutputStream(outputFile)) {
+        fileOutputStream.write(data);
+      }
+
+      screen_messages.set_status_message(tm.getText("message_binary_file_saved", outputFile.getPath()));
+      return true;
     } catch (Exception _) {
       screen_messages.set_status_message(tm.getText("message_binary_file_save_failed", outputFile.getPath()));
       return false;
     }
-
-    // (4) Flush the binary file
-    try {
-      output_stream.close();
-    } catch (IOException _) {
-      screen_messages.set_status_message(tm.getText("message_binary_file_save_failed", outputFile.getPath()));
-      return false;
-    }
-    return true;
   }
 
   /**

--- a/src/main/resources/app/freerouting/gui/BoardFrame_en.properties
+++ b/src/main/resources/app/freerouting/gui/BoardFrame_en.properties
@@ -13,6 +13,7 @@ message_specctra_ses_save_failed=Saving Specctra session '{{filename}}' failed.
 message_eagle_saved=Saving Eagle script '{{filename}}' was successful.
 message_eagle_save_failed=Saving Eagle script '{{filename}}' failed.
 message_gui_settings_save_failed=Saving GUI settings failed.
+message_binary_file_saved=Saving binary file '{{filename}}' was successful.
 message_binary_file_save_failed=Saving binary file failed.
 confirm_exit_yes=Yes
 confirm_exit_no=No


### PR DESCRIPTION
### Description

Todo cleanup in BoardFrame.java: Improved binary save handling by writing to ByteArrayOutputStream, and then caching data in routingJob.output.data.

Added message_binary_file_saved to i18n (BoardFrame_en.properties)