### PR TITLE
Bug Fix: Net Class Track Width Save

### DIFF
--- a/src/main/java/app/freerouting/gui/WindowNetClasses.java
+++ b/src/main/java/app/freerouting/gui/WindowNetClasses.java
@@ -146,6 +146,50 @@ public class WindowNetClasses extends BoardSavableSubWindow {
     netClass.is_ignored_by_autorouter = ignoredByAutorouter;
   }
 
+  /**
+   * Parses a user-entered trace width (full width in user units) and, if valid, applies it to the
+   * input net class on all layers. Positive values only change the width; an explicit {@code 0}
+   * additionally deactivates routing on all layers (legacy v1.9 semantic). Returns {@code true} if
+   * the value was applied, {@code false} for null, non-numeric, negative or otherwise unusable
+   * input.
+   */
+  static boolean applyTraceWidthValue(
+      NetClass p_net_class, CoordinateTransform p_coordinate_transform, Object p_value) {
+    if (p_net_class == null || p_coordinate_transform == null || p_value == null) {
+      return false;
+    }
+    float curr_value;
+    if (p_value instanceof Float float1) {
+      curr_value = float1;
+    } else if (p_value instanceof String string) {
+      try {
+        curr_value = Float.parseFloat(string.trim());
+      } catch (NumberFormatException _) {
+        FRLogger.warn(
+            "WindowNetClasses.applyTraceWidthValue: invalid trace width input '" + string + "'");
+        return false;
+      }
+    } else {
+      return false;
+    }
+    if (!Float.isFinite(curr_value) || curr_value < 0) {
+      return false;
+    }
+    if (curr_value == 0) {
+      p_net_class.set_trace_half_width(0);
+      p_net_class.set_all_layers_active(false);
+      return true;
+    }
+    int curr_half_width =
+        (int) Math.round(0.5 * p_coordinate_transform.user_to_board(curr_value));
+    if (curr_half_width <= 0) {
+      // value too small to be representable as a board half width (or int overflow wrap)
+      return false;
+    }
+    p_net_class.set_trace_half_width(curr_half_width);
+    return true;
+  }
+
   @Override
   public void refresh() {
     this.cl_class_combo_box.removeAllItems();
@@ -585,7 +629,7 @@ public class WindowNetClasses extends BoardSavableSubWindow {
     public void setValueAt(Object p_value, int p_row, int p_col) {
       RoutingBoard routing_board = board_frame.board_panel.board_handling.get_routing_board();
       BoardRules board_rules = routing_board.rules;
-      if (p_col == ColumnName.ON_LAYER.ordinal() || p_col == ColumnName.TRACE_WIDTH.ordinal()) {
+      if (p_col == ColumnName.ON_LAYER.ordinal()) {
         return;
       }
       Object net_class_name = getValueAt(p_row, ColumnName.NAME.ordinal());
@@ -692,6 +736,16 @@ public class WindowNetClasses extends BoardSavableSubWindow {
           }
         }
         net_rule.set_trace_clearance_class(new_cl_class_index);
+      } else if (p_col == ColumnName.TRACE_WIDTH.ordinal()) {
+        if (applyTraceWidthValue(
+            net_rule,
+            board_frame.board_panel.board_handling.coordinate_transform,
+            p_value)) {
+          this.data[p_row][p_col] =
+              p_value instanceof String s ? s.trim() : String.valueOf(p_value);
+          fireTableRowsUpdated(p_row, p_row);
+        }
+        return;
       }
       this.data[p_row][p_col] = p_value;
       fireTableCellUpdated(p_row, p_col);

--- a/src/test/java/app/freerouting/gui/DialogInteractionHandlersTest.java
+++ b/src/test/java/app/freerouting/gui/DialogInteractionHandlersTest.java
@@ -5,9 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import app.freerouting.board.CoordinateTransform;
 import app.freerouting.interactive.GuiBoardManager;
 import app.freerouting.interactive.InteractiveSettings;
 import app.freerouting.rules.ClearanceMatrix;
@@ -116,6 +122,41 @@ class DialogInteractionHandlersTest {
     assertTrue(fieldNetClass.is_ignored_by_autorouter);
     WindowNetClasses.applyAutorouterIgnoreSelection(fieldNetClass, false);
     assertFalse(fieldNetClass.is_ignored_by_autorouter);
+  }
+
+  @Test
+  void netClasses_traceWidthApplyHandlesValidInvalidAndZeroInputs() {
+    CoordinateTransform transform = mock(CoordinateTransform.class);
+    when(transform.user_to_board(anyDouble()))
+        .thenAnswer(inv -> ((Double) inv.getArgument(0)) * 1000.0);
+
+    NetClass positiveFloat = mock(NetClass.class);
+    assertTrue(WindowNetClasses.applyTraceWidthValue(positiveFloat, transform, 0.2f));
+    verify(positiveFloat).set_trace_half_width(100);
+    verify(positiveFloat, never()).set_all_layers_active(anyBoolean());
+
+    NetClass positiveString = mock(NetClass.class);
+    assertTrue(WindowNetClasses.applyTraceWidthValue(positiveString, transform, "  0.25  "));
+    verify(positiveString).set_trace_half_width(125);
+
+    NetClass zeroValue = mock(NetClass.class);
+    assertTrue(WindowNetClasses.applyTraceWidthValue(zeroValue, transform, 0f));
+    verify(zeroValue).set_trace_half_width(0);
+    verify(zeroValue).set_all_layers_active(false);
+
+    NetClass invalid = mock(NetClass.class);
+    assertFalse(WindowNetClasses.applyTraceWidthValue(invalid, transform, null));
+    assertFalse(WindowNetClasses.applyTraceWidthValue(invalid, transform, "not-a-number"));
+    assertFalse(WindowNetClasses.applyTraceWidthValue(invalid, transform, "width_multiple"));
+    assertFalse(WindowNetClasses.applyTraceWidthValue(invalid, transform, -0.5f));
+    assertFalse(WindowNetClasses.applyTraceWidthValue(invalid, transform, Float.NaN));
+    assertFalse(WindowNetClasses.applyTraceWidthValue(invalid, transform, Float.POSITIVE_INFINITY));
+    assertFalse(WindowNetClasses.applyTraceWidthValue(invalid, transform, 0.0001f));
+    assertFalse(WindowNetClasses.applyTraceWidthValue(invalid, transform, 7));
+    verify(invalid, never()).set_trace_half_width(anyInt());
+
+    assertFalse(WindowNetClasses.applyTraceWidthValue(null, transform, 0.2f));
+    assertFalse(WindowNetClasses.applyTraceWidthValue(mock(NetClass.class), null, 0.2f));
   }
 
   @Test

--- a/src/test/java/app/freerouting/gui/DialogInteractionHandlersTest.java
+++ b/src/test/java/app/freerouting/gui/DialogInteractionHandlersTest.java
@@ -2,6 +2,7 @@ package app.freerouting.gui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -14,8 +15,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import app.freerouting.board.CoordinateTransform;
+import app.freerouting.board.Layer;
+import app.freerouting.board.LayerStructure;
 import app.freerouting.interactive.GuiBoardManager;
 import app.freerouting.interactive.InteractiveSettings;
+import app.freerouting.rules.BoardRules;
 import app.freerouting.rules.ClearanceMatrix;
 import app.freerouting.rules.NetClass;
 import app.freerouting.settings.RouterSettings;
@@ -157,6 +161,47 @@ class DialogInteractionHandlersTest {
 
     assertFalse(WindowNetClasses.applyTraceWidthValue(null, transform, 0.2f));
     assertFalse(WindowNetClasses.applyTraceWidthValue(mock(NetClass.class), null, 0.2f));
+  }
+
+  @Test
+  void netClasses_traceWidthEditActuallyMutatesTheBoardModel() {
+    // Build a real adjacency between NetClass and its model as used by the GUI table.
+    LayerStructure layerStructure =
+        new LayerStructure(
+            new Layer[] {new Layer("Top", true), new Layer("In1", false), new Layer("Bottom", true)});
+    ClearanceMatrix clearanceMatrix = ClearanceMatrix.get_default_instance(layerStructure, 10);
+    BoardRules boardRules = new BoardRules(layerStructure, clearanceMatrix);
+    boardRules.create_default_net_class();
+    NetClass netClass = boardRules.get_default_net_class();
+
+    CoordinateTransform transform = mock(CoordinateTransform.class);
+    when(transform.user_to_board(anyDouble()))
+        .thenAnswer(inv -> ((Double) inv.getArgument(0)) * 1000.0);
+
+    int originalHalfWidth = netClass.get_trace_half_width(0);
+    assertTrue(originalHalfWidth > 0);
+
+    // Editing the "track width" from the GUI cell persists into the real model.
+    assertTrue(WindowNetClasses.applyTraceWidthValue(netClass, transform, "0.25"));
+    assertEquals(125, netClass.get_trace_half_width(0));
+    assertNotEquals(originalHalfWidth, netClass.get_trace_half_width(0));
+    for (int i = 0; i < layerStructure.arr.length; i++) {
+      assertEquals(125, netClass.get_trace_half_width(i));
+      if (layerStructure.arr[i].is_signal) {
+        // a positive edit must never silently re-activate or deactivate layers
+        assertTrue(netClass.is_active_routing_layer(i));
+      }
+    }
+
+    // Explicit 0 keeps the legacy semantic: routing disabled on this class.
+    assertTrue(WindowNetClasses.applyTraceWidthValue(netClass, transform, 0f));
+    assertEquals(0, netClass.get_trace_half_width(0));
+    for (int i = 0; i < layerStructure.arr.length; i++) {
+      assertEquals(0, netClass.get_trace_half_width(i));
+      if (layerStructure.arr[i].is_signal) {
+        assertFalse(netClass.is_active_routing_layer(i));
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
### Description

Fix issue: #796 - Trace width not saving in netclass when modifed

Issue: 
if (p_col == ColumnName.ON_LAYER.ordinal() || p_col == ColumnName.TRACE_WIDTH.ordinal()) { return; }

which had been silently implemented in previous commit causing the an early return for the JTextField

## Files changed

WindowNetClasses.java
DialogInteractionHandlersTest.java