### PR TITLE
feat: Reimplemented trace-width editing for net classes in GUI

### DIFF
--- a/src/main/java/app/freerouting/gui/WindowNetClasses.java
+++ b/src/main/java/app/freerouting/gui/WindowNetClasses.java
@@ -163,6 +163,53 @@ public class WindowNetClasses extends BoardSavableSubWindow {
     netClass.isIgnoredByAutorouter = ignoredByAutorouter;
   }
 
+  /**
+   * Parses and applies a trace-width edit for the given net class.
+   *
+   * <p>The {@code value} is a user-unit trace width (the full width, not a half width). It is
+   * converted to board units, rounded to the nearest integer half-width, and written to every
+   * signal layer of {@code netClass}. A value of {@code 0} stores a zero width (traces disallowed
+   * on the class's active layers) without altering the active-layer selection, which remains owned
+   * by the "on layer" dialog.
+   *
+   * @return {@code true} if the value was applied, {@code false} if it was rejected (null, non
+   *     numeric, or negative input).
+   */
+  static boolean applyTraceWidthValue(
+      NetClass netClass,
+      LayerStructure layerStructure,
+      CoordinateTransform coordinateTransform,
+      Object value) {
+    if (netClass == null || layerStructure == null || coordinateTransform == null) {
+      return false;
+    }
+
+    double widthValue;
+    if (value instanceof Number number) {
+      widthValue = number.doubleValue();
+    } else if (value instanceof String text) {
+      try {
+        widthValue = Double.parseDouble(text.trim());
+      } catch (NumberFormatException ex) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+
+    if (widthValue < 0) {
+      return false;
+    }
+
+    int halfWidth = (int) Math.round(coordinateTransform.userToBoard(0.5 * widthValue));
+    for (int i = 0; i < layerStructure.arr.length; i++) {
+      if (layerStructure.arr[i].isSignal) {
+        netClass.setTraceHalfWidth(i, halfWidth);
+      }
+    }
+    return true;
+  }
+
   @Override
   public void refresh() {
     this.clClassComboBox.removeAllItems();
@@ -629,7 +676,9 @@ public class WindowNetClasses extends BoardSavableSubWindow {
     public void setValueAt(Object value, int row, int col) {
       RoutingBoard routingBoard = boardFrame.boardPanel.boardHandling.getRoutingBoard();
       BoardRules boardRules = routingBoard.rules;
-      if (col == ColumnName.ON_LAYER.ordinal() || col == ColumnName.TRACE_WIDTH.ordinal()) {
+      if (col == ColumnName.ON_LAYER.ordinal()) {
+        // Layer selection is owned by the LayerRules dialog (LayerRulesCellEditor); its edits must
+        // not be applied through the model.
         return;
       }
       Object netClassName = getValueAt(row, ColumnName.NAME.ordinal());
@@ -640,6 +689,24 @@ public class WindowNetClasses extends BoardSavableSubWindow {
       NetClass netRule = boardRules.netClasses.get((String) netClassName);
       if (netRule == null) {
         FRLogger.warn("EditNetRuLesVindow.setValueAt: netRule not found");
+        return;
+      }
+
+      if (col == ColumnName.TRACE_WIDTH.ordinal()) {
+        boolean applied =
+            applyTraceWidthValue(
+                netRule,
+                routingBoard.layerStructure,
+                boardFrame.boardPanel.boardHandling.coordinateTransform,
+                value);
+        if (!applied) {
+          // Rejected edit (null, non-numeric, or negative input): refresh the cell so the stored
+          // value is re-displayed instead of leaving the rejected text visible.
+          fireTableCellUpdated(row, col);
+          return;
+        }
+        this.data[row][col] = value;
+        fireTableCellUpdated(row, col);
         return;
       }
 

--- a/src/test/java/app/freerouting/gui/DialogInteractionHandlersTest.java
+++ b/src/test/java/app/freerouting/gui/DialogInteractionHandlersTest.java
@@ -8,11 +8,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import app.freerouting.board.CoordinateTransform;
+import app.freerouting.board.Layer;
+import app.freerouting.board.LayerStructure;
+import app.freerouting.board.Unit;
 import app.freerouting.interactive.GuiBoardManager;
 import app.freerouting.interactive.InteractiveSettings;
 import app.freerouting.rules.ClearanceMatrix;
 import app.freerouting.rules.NetClass;
 import app.freerouting.settings.RouterSettings;
+import java.util.Locale;
 import org.junit.jupiter.api.Test;
 
 class DialogInteractionHandlersTest {
@@ -122,5 +127,56 @@ class DialogInteractionHandlersTest {
     assertNotNull(parsedDouble);
     assertEquals(7.0f, parsedInteger);
     assertEquals(3.75f, parsedDouble);
+  }
+
+  @Test
+  void traceWidthEditParsesAndAppliesToSignalLayers() {
+    Layer[] layers =
+        new Layer[] {
+          new Layer("Top", true),
+          new Layer("Inner", true),
+          new Layer("Edge", false),
+          new Layer("Bottom", true)
+        };
+    LayerStructure layerStructure = new LayerStructure(layers);
+    ClearanceMatrix clearanceMatrix =
+        new ClearanceMatrix(1, layerStructure, new String[] {"default"});
+    NetClass netClass = new NetClass("default", layerStructure, clearanceMatrix, false);
+    CoordinateTransform coordinateTransform = new CoordinateTransform(1.0, Unit.UM, 1.0, Unit.UM);
+
+    // A 400 um full width must map to a 200 um half width on every signal layer.
+    assertTrue(
+        WindowNetClasses.applyTraceWidthValue(
+            netClass, layerStructure, coordinateTransform, "400.0000"));
+    assertEquals(200, netClass.getTraceHalfWidth(0));
+    assertEquals(200, netClass.getTraceHalfWidth(1));
+    assertEquals(200, netClass.getTraceHalfWidth(3));
+    // Non-signal layers must be left untouched.
+    assertEquals(0, netClass.getTraceHalfWidth(2));
+
+    // Numeric (non-String) input is accepted as well.
+    assertTrue(
+        WindowNetClasses.applyTraceWidthValue(
+            netClass, layerStructure, coordinateTransform, 200.0));
+    assertEquals(100, netClass.getTraceHalfWidth(0));
+
+    // Rejected inputs must not modify the stored width.
+    assertFalse(
+        WindowNetClasses.applyTraceWidthValue(
+            netClass, layerStructure, coordinateTransform, "not-a-number"));
+    assertFalse(
+        WindowNetClasses.applyTraceWidthValue(netClass, layerStructure, coordinateTransform, ""));
+    assertFalse(
+        WindowNetClasses.applyTraceWidthValue(netClass, layerStructure, coordinateTransform, -5));
+    assertFalse(
+        WindowNetClasses.applyTraceWidthValue(netClass, layerStructure, coordinateTransform, null));
+    assertFalse(
+        WindowNetClasses.applyTraceWidthValue(null, layerStructure, coordinateTransform, 100.0));
+    // The width set by the numeric input above (100) must be unchanged.
+    assertEquals(100, netClass.getTraceHalfWidth(0));
+
+    // The on-screen width is rendered to four decimal places and rounds half-up.
+    assertEquals("0.2001", String.format(Locale.ENGLISH, "%.4f", 0.20005));
+    assertEquals("0.2000", String.format(Locale.ENGLISH, "%.4f", 0.20004));
   }
 }


### PR DESCRIPTION
Implement functionality to parse and apply user-specified trace-width values for net classes in the net class table editor. Includes a new `applyTraceWidthValue` method and updates the cell editor to handle width input with proper validation and rounding to board units.

This PR is related to #796 