### PR TITLE
:wrench: Update pre-commit workflow cache configuration

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,6 +21,10 @@ jobs:
       # Project specific
       - uses: actions/checkout@v7
       - run: python -m pip install pre-commit
+      - uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/pre-commit/
+          key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit hooks
         env:
           SKIP: no-commit-to-branch
@@ -28,10 +32,6 @@ jobs:
           set -o pipefail
           pre-commit gc
           pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
-      - uses: actions/cache/restore@v6
-        with:
-          path: ~/.cache/pre-commit/
-          key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2026.7.1
         if: ${{ failure() }}


### PR DESCRIPTION
The pre-commit workflow cache configuration has been updated to improve performance. The cache is now restored before running pre-commit hooks and is saved after the hooks have run. This change ensures that the pre-commit cache is reused across workflow runs, reducing the time spent on setup.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)  (N/A)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary (not necessary)