### PR TITLE
Fix optimizer worker trace metric baseline

### DIFF
--- a/src/main/java/app/freerouting/autoroute/BatchOptimizer.java
+++ b/src/main/java/app/freerouting/autoroute/BatchOptimizer.java
@@ -307,10 +307,11 @@ public class BatchOptimizer extends NamedAlgorithm {
         routeImproved =
             (float)
                 (boardStatisticsBefore.items.viaCount != 0
-                        && boardStatisticsBefore.traces.totalLength != 0
+                        && boardStatisticsBefore.traces.totalWeightedLength != 0
                     ? 1.0
                         - ((((float) result.viaCount() / boardStatisticsBefore.items.viaCount)
-                                + (result.traceLength() / boardStatisticsBefore.traces.totalLength))
+                                + (result.traceLength()
+                                    / boardStatisticsBefore.traces.totalWeightedLength))
                             / 2)
                     : 0);
       } else {
@@ -455,7 +456,7 @@ public class BatchOptimizer extends NamedAlgorithm {
             boardStatisticsBefore.items.viaCount,
             boardStatisticsAfter.items.viaCount,
             this.minCumulativeTraceLength,
-            boardStatisticsAfter.traces.totalLength,
+            boardStatisticsAfter.traces.totalWeightedLength,
             routerCountersBefore.incompleteCount,
             routerCountersAfter.incompleteCount);
     boolean routeImproved = !this.thread.isStopRequested() && result.improved();

--- a/src/main/java/app/freerouting/autoroute/BatchOptimizerMultiThreaded.java
+++ b/src/main/java/app/freerouting/autoroute/BatchOptimizerMultiThreaded.java
@@ -344,11 +344,12 @@ public class BatchOptimizerMultiThreaded extends BatchOptimizer {
             + ", via count: "
             + bestRouteResult.viaCount()
             + ", trace length: "
-            + boardStatisticsAfter.traces.totalLength
+            + boardStatisticsAfter.traces.totalWeightedLength
             + ", via count delta: "
             + (boardStatisticsBefore.items.viaCount - bestRouteResult.viaCount())
             + ", trace length delta: "
-            + (boardStatisticsBefore.traces.totalLength - boardStatisticsAfter.traces.totalLength)
+            + (boardStatisticsBefore.traces.totalWeightedLength
+                - boardStatisticsAfter.traces.totalWeightedLength)
             + ".");
 
     FRLogger.traceExit(optimizationPassId);

--- a/src/main/java/app/freerouting/autoroute/OptimizeRouteTask.java
+++ b/src/main/java/app/freerouting/autoroute/OptimizeRouteTask.java
@@ -3,6 +3,7 @@ package app.freerouting.autoroute;
 import app.freerouting.board.Item;
 import app.freerouting.board.RoutingBoard;
 import app.freerouting.core.RoutingJob;
+import app.freerouting.core.scoring.BoardStatistics;
 import app.freerouting.logger.FRLogger;
 
 /** Task for optimizing a single route item in a multi-threaded routing pass. */
@@ -41,8 +42,11 @@ public class OptimizeRouteTask implements Runnable {
       return;
     }
 
+    BatchOptimizer workerOptimizer = new BatchOptimizer(this.job);
+    workerOptimizer.minCumulativeTraceLength =
+        new BoardStatistics(this.board, null, false).traces.totalWeightedLength;
     optimizationResult =
-        new BatchOptimizer(this.job).optRouteItem(itemToOptimize, withPreferredDirections, true);
+        workerOptimizer.optRouteItem(itemToOptimize, withPreferredDirections, true);
 
     boolean winningCandidate = optimizer.isWinningCandidate(this);
 

--- a/src/test/java/app/freerouting/autoroute/BatchOptimizerTraceMetricTest.java
+++ b/src/test/java/app/freerouting/autoroute/BatchOptimizerTraceMetricTest.java
@@ -1,0 +1,100 @@
+package app.freerouting.autoroute;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import app.freerouting.board.RoutingBoard;
+import app.freerouting.board.Trace;
+import app.freerouting.core.RoutingJob;
+import app.freerouting.core.StoppableThread;
+import app.freerouting.core.scoring.BoardStatistics;
+import app.freerouting.io.specctra.DsnTestFixtures;
+import app.freerouting.settings.RouterSettings;
+import app.freerouting.settings.sources.DefaultSettings;
+import java.util.Comparator;
+import org.junit.jupiter.api.Test;
+
+/** Regression tests for the optimizer's worker trace-length comparison. */
+class BatchOptimizerTraceMetricTest {
+
+  private static final String FIXTURE = "Issue026-J2_reference.dsn";
+
+  @Test
+  void workerUsesTheWeightedTraceMetricFromItsBoardSnapshot() throws Exception {
+    RoutingJob job = routedFixtureJob();
+    BatchOptimizerMultiThreaded optimizer = new BatchOptimizerMultiThreaded(job);
+    Trace trace =
+        job.board.getTraces().stream()
+            .filter(item -> !item.isUserFixed())
+            .min(Comparator.comparingInt(Trace::getIdNo))
+            .orElseThrow(() -> new AssertionError("Fixture must contain an unfixed trace"));
+
+    OptimizeRouteTask task = new OptimizeRouteTask(optimizer, job, trace.getIdNo(), 1, false);
+    double snapshotWeightedTraceLength = weightedTraceLength(task.board);
+    assertTrue(snapshotWeightedTraceLength > 0, "Worker snapshot must contain existing traces");
+
+    task.run();
+
+    ItemRouteResult result = task.getRouteResult();
+    assertTrue(result != null, "Worker must produce a route result");
+
+    double reconstructedBefore = result.lengthReduced() + result.traceLength();
+    double workerAfter = weightedTraceLength(task.board);
+    System.out.printf(
+        "Worker trace metrics: snapshotWeighted=%.3f, before=%.3f, after=%.3f, "
+            + "workerBoardAfter=%.3f%n",
+        snapshotWeightedTraceLength, reconstructedBefore, result.traceLength(), workerAfter);
+    assertEquals(
+        snapshotWeightedTraceLength,
+        reconstructedBefore,
+        0.001,
+        "Worker before metric must come from its own board snapshot");
+    assertEquals(
+        workerAfter,
+        result.traceLength(),
+        0.001,
+        "Worker before/after values must use the same weighted metric");
+  }
+
+  @Test
+  void traceOnlyImprovementIsAcceptedWhenCanonicalMetricDecreases() {
+    ItemRouteResult result = new ItemRouteResult(1, 2, 2, 100.0, 90.0, 0, 0);
+
+    assertTrue(result.improved(), "A trace-only reduction must be treated as an improvement");
+    assertEquals(10.0, result.lengthReduced(), 0.001);
+  }
+
+  private static double weightedTraceLength(RoutingBoard board) {
+    return new BoardStatistics(board, null, false).traces.totalWeightedLength;
+  }
+
+  private static RoutingJob routedFixtureJob() throws Exception {
+    RoutingBoard board = DsnTestFixtures.loadBoard(FIXTURE);
+    RoutingJob job = new RoutingJob();
+    job.board = board;
+    job.thread = new TestStoppableThread();
+
+    RouterSettings settings = new DefaultSettings().getSettings();
+    settings.setLayerCount(board.getLayerCount());
+    settings.applyBoardSpecificOptimizations(board);
+    settings.maxPasses = 1;
+    settings.maxItems = Integer.MAX_VALUE;
+    settings.fanout.enabled = false;
+    settings.optimizer.enabled = true;
+    settings.optimizer.maxThreads = 1;
+    settings.optimizer.boardUpdateStrategy = BoardUpdateStrategy.GLOBAL_OPTIMAL;
+    settings.optimizer.maxAutoroutePasses = 1;
+    job.routerSettings = settings;
+
+    new BatchAutorouter(job).runBatchLoop();
+    return job;
+  }
+
+  private static final class TestStoppableThread extends StoppableThread {
+
+    @Override
+    protected void threadAction() {
+      // The test invokes the algorithm directly; no thread body is required.
+    }
+  }
+}


### PR DESCRIPTION
Addresses part of #811.

## Problem

- `OptimizeRouteTask` used a fresh `BatchOptimizer` whose worker trace baseline began at `0.0`.
- Before/after trace metrics used inconsistent weighted/raw units.
- Legitimate trace-length-only improvements could therefore be rejected.

## Fix

- Derive the worker baseline from its own deep-copied board.
- Use weighted cumulative trace length consistently for before/after comparison.
- Preserve the existing incomplete-connection and via-count priorities.

## Regression

- Added `BatchOptimizerTraceMetricTest` using the public `Issue026-J2_reference.dsn` fixture.
- The pre-fix worker baseline was `0.0` instead of `8,897,641.0`.
- Post-fix probe: before `8,897,641.0`, after `8,015,181.5`; both values are from the same weighted metric.

## Validation

- New regression tests: passed.
- Relevant optimizer tests, including `MaxFanoutOptimizerSettingsTest`: passed.
- `Dac2020Bm01RoutingTest`: passed in isolation.
- Required slow optimizer/OOM/DRC test: passed.
- Full serial suite: passed, 437 tests, 3 skipped.
- Spotless and Checkstyle: passed.
- i18n context check: passed.
- `git diff --check`: passed.
- The default parallel suite had two resource-contention timeouts; both passed in isolation.

## Scope

This PR does not fix the other #811 findings:

- MT winner handback
- stale task snapshots/compounding
- CLI parsing
- algorithm dispatch
- optimizer outcomes
- broader performance/determinism work

Development assisted by OpenAI Codex.
