### PR TITLE
Fix GUI startup thread confinement

### DIFF
--- a/src/main/java/app/freerouting/gui/GuiManager.java
+++ b/src/main/java/app/freerouting/gui/GuiManager.java
@@ -33,11 +33,15 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 import javax.swing.UIManager;
 import javax.swing.plaf.FontUIResource;
@@ -53,6 +57,28 @@ public class GuiManager {
    */
   // CHECKSTYLE.SUPPRESS: AbbreviationAsWordInName for +1 lines
   public static boolean initializeGUI(GlobalSettings globalSettings) {
+    return invokeOnEdt(() -> initializeGuiOnEdt(globalSettings));
+  }
+
+  /** Runs a GUI initializer synchronously on Swing's event dispatch thread. */
+  static boolean invokeOnEdt(BooleanSupplier initializer) {
+    if (SwingUtilities.isEventDispatchThread()) {
+      return initializer.getAsBoolean();
+    }
+
+    AtomicBoolean initialized = new AtomicBoolean();
+    try {
+      SwingUtilities.invokeAndWait(() -> initialized.set(initializer.getAsBoolean()));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      FRLogger.error("Interrupted while initializing the GUI", e);
+    } catch (InvocationTargetException e) {
+      FRLogger.error("GUI initialization failed", e.getCause());
+    }
+    return initialized.get();
+  }
+
+  private static boolean initializeGuiOnEdt(GlobalSettings globalSettings) {
     // Start a new Freerouting session
     var guiSession =
         SessionManager.getInstance()

--- a/src/test/java/app/freerouting/gui/GuiManagerEdtTest.java
+++ b/src/test/java/app/freerouting/gui/GuiManagerEdtTest.java
@@ -1,0 +1,43 @@
+package app.freerouting.gui;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.SwingUtilities;
+import org.junit.jupiter.api.Test;
+
+class GuiManagerEdtTest {
+
+  @Test
+  void dispatchesInitializerToEdtWhenCalledOffEdt() {
+    AtomicBoolean ranOnEdt = new AtomicBoolean();
+
+    boolean initialized =
+        GuiManager.invokeOnEdt(
+            () -> {
+              ranOnEdt.set(SwingUtilities.isEventDispatchThread());
+              return true;
+            });
+
+    assertTrue(initialized);
+    assertTrue(ranOnEdt.get());
+  }
+
+  @Test
+  void runsInitializerDirectlyWhenAlreadyOnEdt() throws Exception {
+    AtomicBoolean ranOnEdt = new AtomicBoolean();
+    AtomicBoolean initialized = new AtomicBoolean();
+
+    SwingUtilities.invokeAndWait(
+        () ->
+            initialized.set(
+                GuiManager.invokeOnEdt(
+                    () -> {
+                      ranOnEdt.set(SwingUtilities.isEventDispatchThread());
+                      return true;
+                    })));
+
+    assertTrue(initialized.get());
+    assertTrue(ranOnEdt.get());
+  }
+}


### PR DESCRIPTION
## Summary

- Run GUI initialization synchronously on Swing's event dispatch thread.
- Add regression coverage for initialization from both off-EDT and on-EDT callers.

## Root cause

Application startup called `GuiManager.initializeGUI` from the main thread. When startup opened a design, the GUI board-load path mutated `ScreenMessages` off the EDT, which raised `IllegalStateException` and prevented the main board window from opening.

## Validation

- Focused EDT regression test passed.
- Spotless and Checkstyle passed; Checkstyle reported only existing warnings in `BatchAutorouter.java`.
- The full default suite completed 437 tests with two unrelated long-routing fixture timeouts under shared suite load; both fixtures passed when rerun individually.
- Executable JAR build passed, and the patched packaged application reached its main board window during the GUI smoke test.
