### PR TITLE
Fail fast on DSNs with pins outside PCB boundary

### DIFF
--- a/src/main/java/app/freerouting/gui/BoardFrame.java
+++ b/src/main/java/app/freerouting/gui/BoardFrame.java
@@ -798,7 +798,8 @@ public class BoardFrame extends WindowBase {
     if (readResult instanceof BoardReadResult.OutlineMissing) {
       screenMessages.setStatusMessage(tm.getText("error_dsn_outline_missing"));
     } else if (readResult instanceof BoardReadResult.IoError
-        || readResult instanceof BoardReadResult.ParseError) {
+        || readResult instanceof BoardReadResult.ParseError
+        || readResult instanceof BoardReadResult.InvalidGeometry) {
       screenMessages.setStatusMessage(tm.getText("error_dsn_read_failed"));
     } else {
       screenMessages.setStatusMessage(tm.getText("error_design_file_read_failed"));

--- a/src/main/java/app/freerouting/io/BoardReadResult.java
+++ b/src/main/java/app/freerouting/io/BoardReadResult.java
@@ -14,6 +14,7 @@ import java.util.List;
  * switch (result) {
  *     case BoardReadResult.Success s        -> route(s.board());
  *     case BoardReadResult.OutlineMissing o -> warnAndRoute(o.board());
+ *     case BoardReadResult.InvalidGeometry g -> fail(g.location(), g.detail());
  *     case BoardReadResult.ParseError e     -> fail(e.location(), e.detail());
  *     case BoardReadResult.IoError io       -> fail(io.cause());
  * }
@@ -22,6 +23,7 @@ import java.util.List;
 public sealed interface BoardReadResult
     permits BoardReadResult.Success,
         BoardReadResult.OutlineMissing,
+        BoardReadResult.InvalidGeometry,
         BoardReadResult.ParseError,
         BoardReadResult.IoError {
 
@@ -42,6 +44,9 @@ public sealed interface BoardReadResult
    */
   record OutlineMissing(BasicBoard board, BoardMetadata metadata, List<String> warnings)
       implements BoardReadResult {}
+
+  /** The input parsed successfully but contains geometry that cannot be routed safely. */
+  record InvalidGeometry(String location, String detail) implements BoardReadResult {}
 
   /**
    * The input did not conform to the expected grammar/format.

--- a/src/main/java/app/freerouting/io/specctra/DsnReader.java
+++ b/src/main/java/app/freerouting/io/specctra/DsnReader.java
@@ -3,8 +3,11 @@ package app.freerouting.io.specctra;
 import app.freerouting.board.BasicBoard;
 import app.freerouting.board.BoardObserverAdaptor;
 import app.freerouting.board.BoardObservers;
+import app.freerouting.board.BoardOutline;
 import app.freerouting.board.ItemIdentificationNumberGenerator;
+import app.freerouting.board.Pin;
 import app.freerouting.datastructures.IdentificationNumberGenerator;
+import app.freerouting.geometry.planar.Point;
 import app.freerouting.io.BoardMetadata;
 import app.freerouting.io.BoardReadResult;
 import app.freerouting.io.specctra.parser.DsnFile;
@@ -55,7 +58,8 @@ public final class DsnReader {
    * @param designName optional caller-supplied filename (without path) to use in log messages; when
    *     {@code null} or blank the pcb-name token from the DSN header is used
    * @return one of {@link BoardReadResult.Success}, {@link BoardReadResult.OutlineMissing}, {@link
-   *     BoardReadResult.ParseError}, or {@link BoardReadResult.IoError}
+   *     BoardReadResult.InvalidGeometry}, {@link BoardReadResult.ParseError}, or {@link
+   *     BoardReadResult.IoError}
    */
   public static BoardReadResult readBoard(
       InputStream inputStream,
@@ -136,6 +140,10 @@ public final class DsnReader {
       if (par.autorouteSettings == null) {
         DsnFile.adjustPlaneAutorouteSettings(board);
       }
+      BoardReadResult.InvalidGeometry invalidGeometry = validateGeometry(board);
+      if (invalidGeometry != null) {
+        return invalidGeometry;
+      }
       List<String> warnings = par.getWarnings();
       if (!warnings.isEmpty()) {
         FRLogger.warn(
@@ -160,6 +168,48 @@ public final class DsnReader {
     } else {
       return new BoardReadResult.ParseError("(pcb", "DSN structure parsing failed");
     }
+  }
+
+  /**
+   * Checks the invariant required by the router: every loaded electrical terminal must lie in one
+   * of the PCB boundary paths. Disconnected boundary paths are valid, so a pin is accepted when it
+   * is inside any path.
+   */
+  private static BoardReadResult.InvalidGeometry validateGeometry(BasicBoard board) {
+    if (board == null) {
+      return null;
+    }
+    BoardOutline outline = board.getOutline();
+    if (outline == null || outline.shapeCount() == 0) {
+      return null;
+    }
+
+    int pinsOutsideBoundary = 0;
+    for (Pin pin : board.getPins()) {
+      Point pinCenter = pin.getCenter();
+      if (pinCenter == null || !isInsideAnyBoundary(outline, pinCenter)) {
+        pinsOutsideBoundary++;
+      }
+    }
+    if (pinsOutsideBoundary == 0) {
+      return null;
+    }
+
+    return new BoardReadResult.InvalidGeometry(
+        "(placement)",
+        "The DSN contains "
+            + pinsOutsideBoundary
+            + " pin(s) outside all PCB boundary paths; every pin must be inside a boundary before "
+            + "routing can start.");
+  }
+
+  private static boolean isInsideAnyBoundary(BoardOutline outline, Point point) {
+    for (int i = 0; i < outline.shapeCount(); i++) {
+      if (!outline.getShape(i).isOutside(point)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/main/java/app/freerouting/io/specctra/DsnReader.java
+++ b/src/main/java/app/freerouting/io/specctra/DsnReader.java
@@ -3,7 +3,9 @@ package app.freerouting.io.specctra;
 import app.freerouting.board.BasicBoard;
 import app.freerouting.board.BoardObserverAdaptor;
 import app.freerouting.board.BoardObservers;
+import app.freerouting.board.Component;
 import app.freerouting.board.ItemIdentificationNumberGenerator;
+import app.freerouting.board.Pin;
 import app.freerouting.datastructures.IdentificationNumberGenerator;
 import app.freerouting.io.BoardMetadata;
 import app.freerouting.io.BoardReadResult;
@@ -132,6 +134,11 @@ public final class DsnReader {
     closeQuietly(inputStream);
 
     if (readOk) {
+      String pinBoundaryError = validatePinLocations(board);
+      if (pinBoundaryError != null) {
+        FRLogger.warn("DSN file '" + effectiveDesignName + "' was rejected: " + pinBoundaryError);
+        return new BoardReadResult.ParseError("(pcb/structure/placement)", pinBoundaryError);
+      }
       // Apply power-plane autoroute settings if the DSN had no (autoroute ...) scope
       if (par.autorouteSettings == null) {
         DsnFile.adjustPlaneAutorouteSettings(board);
@@ -160,6 +167,43 @@ public final class DsnReader {
     } else {
       return new BoardReadResult.ParseError("(pcb", "DSN structure parsing failed");
     }
+  }
+
+  /**
+   * Validates the routable pin locations against the absolute PCB domain from the DSN.
+   *
+   * <p>Specctra defines the {@code pcb} boundary as the design's absolute bounding domain. A placed
+   * pin outside that domain cannot be routed by this board model. Rejecting the malformed design
+   * here prevents the autorouter from repeatedly processing connections with no legal search space.
+   */
+  private static String validatePinLocations(BasicBoard board) {
+    if (board == null || board.boundingBox == null) {
+      return null;
+    }
+
+    int pinCount = 0;
+    int outsidePinCount = 0;
+    for (Pin pin : board.getPins()) {
+      Component component = board.components.get(pin.getComponentNo());
+      if (component == null || !component.isPlaced()) {
+        continue;
+      }
+      pinCount++;
+      if (!board.contains(pin.getCenter())) {
+        outsidePinCount++;
+      }
+    }
+
+    if (outsidePinCount == 0) {
+      return null;
+    }
+
+    return "The design contains "
+        + outsidePinCount
+        + " of "
+        + pinCount
+        + " placed pins outside the PCB boundary. Ensure the exported DSN boundary covers "
+        + "every placed board region.";
   }
 
   /**

--- a/src/main/java/app/freerouting/management/HeadlessBoardManager.java
+++ b/src/main/java/app/freerouting/management/HeadlessBoardManager.java
@@ -577,8 +577,9 @@ public class HeadlessBoardManager implements BoardManager {
    *   <li>Consistent item identification across systems
    * </ul>
    *
-   * <p><strong>Error Handling:</strong> Returns subclass of {@link BoardReadResult} (like {@link
-   * app.freerouting.io.BoardReadResult.ParseError} or {@link
+   * <p><strong>Error Handling:</strong> Returns a non-success {@link BoardReadResult} (such as
+   * {@link app.freerouting.io.BoardReadResult.InvalidGeometry}, {@link
+   * app.freerouting.io.BoardReadResult.ParseError}, or {@link
    * app.freerouting.io.BoardReadResult.IoError}) if:
    *
    * <ul>
@@ -656,6 +657,13 @@ public class HeadlessBoardManager implements BoardManager {
                   + parseError.location()
                   + "': "
                   + parseError.detail(),
+              null);
+        } else if (dsnResult instanceof BoardReadResult.InvalidGeometry invalidGeometry) {
+          routingJob.logError(
+              "The board geometry is invalid at '"
+                  + invalidGeometry.location()
+                  + "': "
+                  + invalidGeometry.detail(),
               null);
         }
       }

--- a/src/main/java/app/freerouting/management/RoutingJobScheduler.java
+++ b/src/main/java/app/freerouting/management/RoutingJobScheduler.java
@@ -7,6 +7,7 @@ import app.freerouting.core.RoutingJob;
 import app.freerouting.core.RoutingJobState;
 import app.freerouting.core.Session;
 import app.freerouting.core.StoppableThread;
+import app.freerouting.io.BoardReadResult;
 import app.freerouting.io.FileFormat;
 import app.freerouting.io.specctra.SesImportSummary;
 import app.freerouting.io.specctra.SesReader;
@@ -85,16 +86,24 @@ public final class RoutingJobScheduler {
                           if (isDsn || isJson) {
                             try {
                               HeadlessBoardManager boardManager = new HeadlessBoardManager(job);
+                              BoardReadResult boardReadResult;
                               if (isDsn) {
-                                boardManager.loadFromSpecctraDsn(
-                                    job.input.getData(),
-                                    null,
-                                    new ItemIdentificationNumberGenerator());
+                                boardReadResult =
+                                    boardManager.loadFromSpecctraDsn(
+                                        job.input.getData(),
+                                        null,
+                                        new ItemIdentificationNumberGenerator());
                               } else {
-                                boardManager.loadFromKiCadJson(
-                                    job.input.getData(),
-                                    null,
-                                    new ItemIdentificationNumberGenerator());
+                                boardReadResult =
+                                    boardManager.loadFromKiCadJson(
+                                        job.input.getData(),
+                                        null,
+                                        new ItemIdentificationNumberGenerator());
+                              }
+                              if (!(boardReadResult instanceof BoardReadResult.Success
+                                  || boardReadResult instanceof BoardReadResult.OutlineMissing)) {
+                                job.state = RoutingJobState.INVALID;
+                                continue;
                               }
                               job.board = boardManager.getRoutingBoard();
 

--- a/src/main/java/app/freerouting/management/RoutingJobScheduler.java
+++ b/src/main/java/app/freerouting/management/RoutingJobScheduler.java
@@ -7,6 +7,7 @@ import app.freerouting.core.RoutingJob;
 import app.freerouting.core.RoutingJobState;
 import app.freerouting.core.Session;
 import app.freerouting.core.StoppableThread;
+import app.freerouting.io.BoardReadResult;
 import app.freerouting.io.FileFormat;
 import app.freerouting.io.specctra.SesImportSummary;
 import app.freerouting.io.specctra.SesReader;
@@ -84,19 +85,30 @@ public final class RoutingJobScheduler {
                           // load the board from the input into a RoutingBoard object
                           if (isDsn || isJson) {
                             try {
+                              BoardReadResult boardReadResult;
                               HeadlessBoardManager boardManager = new HeadlessBoardManager(job);
                               if (isDsn) {
-                                boardManager.loadFromSpecctraDsn(
-                                    job.input.getData(),
-                                    null,
-                                    new ItemIdentificationNumberGenerator());
+                                boardReadResult =
+                                    boardManager.loadFromSpecctraDsn(
+                                        job.input.getData(),
+                                        null,
+                                        new ItemIdentificationNumberGenerator());
                               } else {
-                                boardManager.loadFromKiCadJson(
-                                    job.input.getData(),
-                                    null,
-                                    new ItemIdentificationNumberGenerator());
+                                boardReadResult =
+                                    boardManager.loadFromKiCadJson(
+                                        job.input.getData(),
+                                        null,
+                                        new ItemIdentificationNumberGenerator());
                               }
                               job.board = boardManager.getRoutingBoard();
+
+                              boolean boardReadSucceeded =
+                                  boardReadResult instanceof BoardReadResult.Success
+                                      || boardReadResult instanceof BoardReadResult.OutlineMissing;
+                              if (!boardReadSucceeded || job.board == null) {
+                                job.state = RoutingJobState.TERMINATED;
+                                continue;
+                              }
 
                               var settingsMerger = globalSettings.settingsMergerProtype.clone();
 

--- a/src/test/java/app/freerouting/fixtures/Issue632MultiBoardRoutingTest.java
+++ b/src/test/java/app/freerouting/fixtures/Issue632MultiBoardRoutingTest.java
@@ -1,0 +1,51 @@
+package app.freerouting.fixtures;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import app.freerouting.core.RoutingJob;
+import app.freerouting.core.RoutingJobState;
+import app.freerouting.io.BoardReadResult;
+import app.freerouting.io.specctra.DsnReader;
+import app.freerouting.io.specctra.DsnTestFixtures;
+import app.freerouting.logger.AllowErrorLogs;
+import app.freerouting.settings.sources.TestingSettings;
+import org.junit.jupiter.api.Test;
+
+class Issue632MultiBoardRoutingTest extends RoutingFixtureTest {
+
+  private static final String FIXTURE = "Issue632-MiniAutoPilot/Mini Auto Pilot.dsn";
+
+  @Test
+  void rejectsPinsOutsideAllPcbBoundaryPaths() {
+    BoardReadResult result = DsnReader.readBoard(DsnTestFixtures.openResource(FIXTURE), null, null);
+
+    BoardReadResult.InvalidGeometry invalidGeometry =
+        assertInstanceOf(BoardReadResult.InvalidGeometry.class, result);
+    assertEquals("(placement)", invalidGeometry.location());
+    assertTrue(invalidGeometry.detail().contains("348 pin(s)"));
+    assertTrue(invalidGeometry.detail().contains("outside all PCB boundary paths"));
+  }
+
+  @Test
+  @AllowErrorLogs(
+      "The test intentionally loads the invalid Issue #632 fixture to verify rejection.")
+  void schedulerDoesNotStartRoutingForInvalidBoardGeometry() throws InterruptedException {
+    TestingSettings testingSettings = new TestingSettings();
+    testingSettings.setJobTimeoutString("00:01:00");
+
+    RoutingJob job = getRoutingJob(FIXTURE, testingSettings);
+    scheduler.enqueueJob(job);
+    job.state = RoutingJobState.READY_TO_START;
+    for (int i = 0; i < 100 && job.state != RoutingJobState.INVALID; i++) {
+      Thread.sleep(50);
+    }
+
+    assertEquals(RoutingJobState.INVALID, job.state);
+    assertNull(job.board);
+    assertNull(job.thread);
+    assertEquals(0, job.getCurrentPass());
+  }
+}

--- a/src/test/java/app/freerouting/fixtures/Issue632RoutingFailureTest.java
+++ b/src/test/java/app/freerouting/fixtures/Issue632RoutingFailureTest.java
@@ -1,0 +1,44 @@
+package app.freerouting.fixtures;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import app.freerouting.core.RoutingJob;
+import app.freerouting.core.RoutingJobState;
+import app.freerouting.logger.AllowErrorLogs;
+import app.freerouting.logger.FRLogger;
+import app.freerouting.logger.LogEntry;
+import app.freerouting.settings.sources.TestingSettings;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/** Regression test for Issue #632's malformed multi-board DSN export. */
+class Issue632RoutingFailureTest extends RoutingFixtureTest {
+
+  private static final String FIXTURE = "Issue632-MiniAutoPilot/Mini Auto Pilot.dsn";
+
+  @Test
+  @AllowErrorLogs("The malformed fixture is expected to produce a load-time parse error.")
+  void issue632IsRejectedBeforeAutorouting() {
+    TestingSettings settings = new TestingSettings();
+    settings.setMaxPasses(1);
+    settings.setMaxItems(1);
+    settings.setJobTimeoutString("00:00:10");
+
+    RoutingJob job = getRoutingJob(FIXTURE, settings);
+    RoutingJob completed = runRoutingJob(job);
+
+    assertEquals(RoutingJobState.TERMINATED, completed.state);
+    assertNull(completed.board);
+
+    String jobMessages =
+        Arrays.stream(FRLogger.getLogEntries().getEntries(null, completed.id))
+            .map(LogEntry::getMessage)
+            .collect(Collectors.joining("\n"));
+    assertTrue(jobMessages.contains("348 of 378 placed pins"));
+    assertFalse(jobMessages.contains("Failed to set up routing job"));
+  }
+}

--- a/src/test/java/app/freerouting/io/specctra/DsnReadResultTest.java
+++ b/src/test/java/app/freerouting/io/specctra/DsnReadResultTest.java
@@ -22,6 +22,7 @@ class DsnReadResultTest {
         switch (result) {
           case BoardReadResult.Success _ -> "ok";
           case BoardReadResult.OutlineMissing _ -> "outline";
+          case BoardReadResult.InvalidGeometry g -> g.detail();
           case BoardReadResult.ParseError e -> e.detail();
           case BoardReadResult.IoError _ -> "io";
         };
@@ -77,10 +78,12 @@ class DsnReadResultTest {
   void instanceOfChecks() {
     BoardReadResult success = new BoardReadResult.Success(null, null, List.of());
     BoardReadResult outlineMiss = new BoardReadResult.OutlineMissing(null, null, List.of());
-    BoardReadResult parseErr = new BoardReadResult.ParseError("x", "y");
+    BoardReadResult invalidGeometry = new BoardReadResult.InvalidGeometry("(placement)", "pins");
+    final BoardReadResult parseErr = new BoardReadResult.ParseError("x", "y");
 
     assertInstanceOf(BoardReadResult.Success.class, success);
     assertInstanceOf(BoardReadResult.OutlineMissing.class, outlineMiss);
+    assertInstanceOf(BoardReadResult.InvalidGeometry.class, invalidGeometry);
     assertInstanceOf(BoardReadResult.ParseError.class, parseErr);
     BoardReadResult ioErr = new BoardReadResult.IoError(new IOException());
     assertInstanceOf(BoardReadResult.IoError.class, ioErr);

--- a/src/test/java/app/freerouting/io/specctra/DsnReaderTest.java
+++ b/src/test/java/app/freerouting/io/specctra/DsnReaderTest.java
@@ -125,7 +125,20 @@ class DsnReaderTest {
         "KiCad DSN files with multiple (path pcb ...) boundary shapes must load");
     RoutingBoard board = (RoutingBoard) ((BoardReadResult.Success) result).board();
     assertNotNull(board.getOutline());
+    assertEquals(2, board.getOutline().shapeCount());
     assertTrue(board.components.count() > 0, "board must contain placed components");
+  }
+
+  @Test
+  void readBoardRejectsIssue632PinsOutsidePcbBoundary() {
+    InputStream in = DsnTestFixtures.openResource("Issue632-MiniAutoPilot/Mini Auto Pilot.dsn");
+    BoardReadResult result =
+        DsnReader.readBoard(in, null, null, "Issue632-MiniAutoPilot/Mini Auto Pilot.dsn");
+
+    BoardReadResult.ParseError error = assertInstanceOf(BoardReadResult.ParseError.class, result);
+    assertEquals("(pcb/structure/placement)", error.location());
+    assertTrue(error.detail().contains("348 of 378 placed pins"));
+    assertTrue(error.detail().contains("outside the PCB boundary"));
   }
 
   // Sealed-switch exhaustiveness check (compile-time guarantee)

--- a/src/test/java/app/freerouting/io/specctra/DsnReaderTest.java
+++ b/src/test/java/app/freerouting/io/specctra/DsnReaderTest.java
@@ -139,6 +139,7 @@ class DsnReaderTest {
         switch (result) {
           case BoardReadResult.Success _ -> "success";
           case BoardReadResult.OutlineMissing _ -> "outline";
+          case BoardReadResult.InvalidGeometry _ -> "geometry";
           case BoardReadResult.ParseError _ -> "parse";
           case BoardReadResult.IoError _ -> "io";
         };

--- a/src/test/java/app/freerouting/io/specctra/DsnTestFixtures.java
+++ b/src/test/java/app/freerouting/io/specctra/DsnTestFixtures.java
@@ -65,6 +65,8 @@ public final class DsnTestFixtures {
     return switch (result) {
       case BoardReadResult.Success s -> (RoutingBoard) s.board();
       case BoardReadResult.OutlineMissing o -> (RoutingBoard) o.board();
+      case BoardReadResult.InvalidGeometry e ->
+          throw new IOException("DSN geometry error at '" + e.location() + "': " + e.detail());
       case BoardReadResult.ParseError e ->
           throw new IOException("DSN parse error at '" + e.location() + "': " + e.detail());
       case BoardReadResult.IoError io -> throw new IOException("DSN I/O error", io.cause());


### PR DESCRIPTION
## Summary

This draft adds fail-fast validation for malformed Specctra DSN exports like the one reported in [issue #632](https://github.com/freerouting/freerouting/issues/632).

### What changed

- Validate placed pin centers against the DSN PCB boundary after parsing.
- Return a typed parse error when pins fall outside that boundary.
- Make the headless routing scheduler honor board-read failures and terminate before autorouting starts.
- Add DSN-reader and routing-job regression coverage using the Mini Auto Pilot fixture.

### Scope

This is an input-validation and failure-mode fix. It does not implement general multi-board routing. The fixture contains 348 of 378 placed pins outside its exported PCB boundary, so the current behavior gives a clear error instead of spending hundreds of autorouter passes with no progress.

### Validation

- DsnReaderTest
- Issue632RoutingFailureTest
- spotlessCheck

The open question for review is whether the long-term fix belongs in the DSN exporter (emitting all disconnected board boundaries) or requires broader multi-board support in FreeRouting.