### PR TITLE
Improve headless/MCP/KiCad telemetry coverage, corporate proxy auto-discovery, and TLS truststores

### DIFF
--- a/integrations/KiCad/kicad-freerouting/plugins/board_json_helpers.py
+++ b/integrations/KiCad/kicad-freerouting/plugins/board_json_helpers.py
@@ -147,10 +147,17 @@ def _build_board_json_manually(board):
     """
     global _debug_logs
     _debug_logs = []
-    debug_log("Starting manual board JSON serialization...")
+    version_str = "10.0"
+    try:
+        if hasattr(pcbnew, "GetBuildVersion"):
+            version_str = str(pcbnew.GetBuildVersion())
+    except Exception:
+        pass
 
     data = {
         "designName": Path(board.GetFileName()).stem if board.GetFileName() else "Untitled",
+        "hostCad": "KiCad",
+        "hostVersion": version_str,
         "unit": "MM",
         "resolution": 1.0,
         "layers": [],

--- a/src/main/java/app/freerouting/Freerouting.java
+++ b/src/main/java/app/freerouting/Freerouting.java
@@ -1,6 +1,7 @@
 package app.freerouting;
 
 import app.freerouting.analytics.FRAnalytics;
+import app.freerouting.analytics.NetworkProxyConfig;
 import app.freerouting.api.AppContextListener;
 import app.freerouting.api.mcp.McpApplication;
 import app.freerouting.api.mcp.McpContextListener;
@@ -1266,6 +1267,9 @@ public class Freerouting {
     }
 
     boolean allowAnalytics = false;
+
+    // configure corporate proxy and truststores
+    NetworkProxyConfig.configure(globalSettings.networkSettings);
 
     // initialize analytics
     FRAnalytics.setAccessKey(

--- a/src/main/java/app/freerouting/Freerouting.java
+++ b/src/main/java/app/freerouting/Freerouting.java
@@ -1295,6 +1295,9 @@ public class Freerouting {
     if (!globalSettings.userProfileSettings.userEmail.isBlank()) {
       FRAnalytics.refreshIdentity();
     }
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(() -> FRAnalytics.flush(1500), "freerouting-analytics-shutdown-flush"));
     try {
       Thread.sleep(1000);
     } catch (Exception _) {

--- a/src/main/java/app/freerouting/analytics/AnalyticsClient.java
+++ b/src/main/java/app/freerouting/analytics/AnalyticsClient.java
@@ -35,4 +35,14 @@ public interface AnalyticsClient {
    * @param enabled Whether the client should be enabled.
    */
   void setEnabled(boolean enabled);
+
+  /**
+   * Flushes any pending asynchronous analytics delivery tasks, waiting up to {@code timeoutMs}.
+   *
+   * @param timeoutMs maximum time to wait in milliseconds
+   */
+  default void flush(long timeoutMs) {}
+
+  /** Shuts down the analytics client and releases background resources. */
+  default void shutdown() {}
 }

--- a/src/main/java/app/freerouting/analytics/FRAnalytics.java
+++ b/src/main/java/app/freerouting/analytics/FRAnalytics.java
@@ -446,10 +446,17 @@ public final class FRAnalytics {
         "statistics_jobs_completed", String.valueOf(globalSettings.statistics.jobsCompleted));
 
     trackAnonymousAction(permanentUserId, "Application Closed", properties);
-    try {
-      Thread.sleep(500);
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+    flush(1000);
+  }
+
+  /**
+   * Flushes any pending asynchronous analytics delivery tasks, waiting up to {@code timeoutMs}.
+   *
+   * @param timeoutMs maximum time to wait in milliseconds
+   */
+  public static void flush(long timeoutMs) {
+    if (analytics != null) {
+      analytics.flush(timeoutMs);
     }
   }
 

--- a/src/main/java/app/freerouting/analytics/FreeroutingAnalyticsClient.java
+++ b/src/main/java/app/freerouting/analytics/FreeroutingAnalyticsClient.java
@@ -23,6 +23,17 @@ public class FreeroutingAnalyticsClient implements AnalyticsClient {
   private final String writeKey;
   private final String libraryName = "freerouting";
   private final String libraryVersion;
+  private final java.util.concurrent.ExecutorService executor =
+      java.util.concurrent.Executors.newFixedThreadPool(
+          2,
+          r -> {
+            Thread t = new Thread(r, "analytics-freerouting-sender");
+            t.setDaemon(true);
+            return t;
+          });
+  private final java.util.concurrent.atomic.AtomicInteger inFlightCount =
+      new java.util.concurrent.atomic.AtomicInteger(0);
+  private final Object flushLock = new Object();
   private boolean enabled = true;
 
   /**
@@ -59,73 +70,76 @@ public class FreeroutingAnalyticsClient implements AnalyticsClient {
   }
 
   private void sendPayloadAsync(String endpoint, Payload payload) throws IOException {
-    if (!enabled) {
+    if (!enabled || executor.isShutdown()) {
       return;
     }
 
-    Thread senderThread =
-        new Thread(
-            () -> {
-              HttpURLConnection connection = null;
+    inFlightCount.incrementAndGet();
+    executor.submit(
+        () -> {
+          HttpURLConnection connection = null;
 
-              try {
-                var uri = new URI(endpoint);
+          try {
+            var uri = new URI(endpoint);
 
-                // Create and configure HTTP connection
-                connection = (HttpURLConnection) uri.toURL().openConnection();
-                connection.setRequestMethod("POST");
-                connection.setRequestProperty("Host", uri.getHost());
-                connection.setRequestProperty("Content-Type", "application/json");
-                connection.setRequestProperty(
-                    "Authorization",
-                    "Basic " + Base64.getEncoder().encodeToString((writeKey + ":").getBytes()));
-                connection.setDoOutput(true);
+            // Create and configure HTTP connection
+            connection = (HttpURLConnection) uri.toURL().openConnection();
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(10000);
+            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Host", uri.getHost());
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty(
+                "Authorization",
+                "Basic " + Base64.getEncoder().encodeToString((writeKey + ":").getBytes()));
+            connection.setDoOutput(true);
 
-                // Write JSON payload to request
-                String jsonPayload = GsonProvider.GSON.toJson(payload);
-                try (OutputStream os = connection.getOutputStream()) {
-                  byte[] input = jsonPayload.getBytes(StandardCharsets.UTF_8);
-                  os.write(input, 0, input.length);
+            // Write JSON payload to request
+            String jsonPayload = GsonProvider.GSON.toJson(payload);
+            try (OutputStream os = connection.getOutputStream()) {
+              byte[] input = jsonPayload.getBytes(StandardCharsets.UTF_8);
+              os.write(input, 0, input.length);
+            }
+
+            // Check the HTTP response code *before* touching getInputStream() so that we can
+            // read the error-stream body on HTTP 4xx/5xx — getInputStream() would throw and
+            // swallow that body.
+            int responseCode = connection.getResponseCode();
+            if (responseCode >= 400) {
+              // Read the server's error body for diagnostic context and forward it to the
+              // aggregator so it can surface it in the hourly summary log.
+              String errorBody = readErrorBody(connection);
+              AnalyticsErrorAggregator.recordFailure(
+                  endpoint,
+                  new IOException(
+                      "Server returned HTTP response code: "
+                          + responseCode
+                          + " for URL: "
+                          + endpoint),
+                  errorBody);
+            } else {
+              // Consume the success body (currently unused but keeps the connection clean).
+              try (BufferedReader br =
+                  new BufferedReader(
+                      new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
+                while (br.readLine() != null) {
+                  /* discard */
                 }
-
-                // Check the HTTP response code *before* touching getInputStream() so that we can
-                // read the error-stream body on HTTP 4xx/5xx — getInputStream() would throw and
-                // swallow that body.
-                int responseCode = connection.getResponseCode();
-                if (responseCode >= 400) {
-                  // Read the server's error body for diagnostic context and forward it to the
-                  // aggregator so it can surface it in the hourly summary log.
-                  String errorBody = readErrorBody(connection);
-                  AnalyticsErrorAggregator.recordFailure(
-                      endpoint,
-                      new IOException(
-                          "Server returned HTTP response code: "
-                              + responseCode
-                              + " for URL: "
-                              + endpoint),
-                      errorBody);
-                } else {
-                  // Consume the success body (currently unused but keeps the connection clean).
-                  try (BufferedReader br =
-                      new BufferedReader(
-                          new InputStreamReader(
-                              connection.getInputStream(), StandardCharsets.UTF_8))) {
-                    while (br.readLine() != null) {
-                      /* discard */
-                    }
-                  }
-                }
-              } catch (Exception e) {
-                // Do not log here directly — connection may be null if the exception was thrown
-                // before openConnection() succeeded, and a per-failure log line would flood the
-                // output when the analytics endpoint is down.  Delegate to the aggregator, which
-                // logs the first failure immediately and then emits a single hourly summary.
-                AnalyticsErrorAggregator.recordFailure(endpoint, e);
               }
-            },
-            "analytics-freerouting-sender");
-    senderThread.setDaemon(true);
-    senderThread.start();
+            }
+          } catch (Exception e) {
+            // Do not log here directly — connection may be null if the exception was thrown
+            // before openConnection() succeeded, and a per-failure log line would flood the
+            // output when the analytics endpoint is down.  Delegate to the aggregator, which
+            // logs the first failure immediately and then emits a single hourly summary.
+            AnalyticsErrorAggregator.recordFailure(endpoint, e);
+          } finally {
+            inFlightCount.decrementAndGet();
+            synchronized (flushLock) {
+              flushLock.notifyAll();
+            }
+          }
+        });
   }
 
   @Override
@@ -161,5 +175,29 @@ public class FreeroutingAnalyticsClient implements AnalyticsClient {
   @Override
   public void setEnabled(boolean enabled) {
     this.enabled = enabled;
+  }
+
+  @Override
+  public void flush(long timeoutMs) {
+    long deadline = System.currentTimeMillis() + timeoutMs;
+    synchronized (flushLock) {
+      while (inFlightCount.get() > 0) {
+        long remaining = deadline - System.currentTimeMillis();
+        if (remaining <= 0) {
+          break;
+        }
+        try {
+          flushLock.wait(remaining);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    executor.shutdown();
   }
 }

--- a/src/main/java/app/freerouting/analytics/FreeroutingAnalyticsClient.java
+++ b/src/main/java/app/freerouting/analytics/FreeroutingAnalyticsClient.java
@@ -1,5 +1,6 @@
 package app.freerouting.analytics;
 
+import app.freerouting.Freerouting;
 import app.freerouting.analytics.dto.Context;
 import app.freerouting.analytics.dto.Library;
 import app.freerouting.analytics.dto.Payload;
@@ -14,6 +15,8 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
 
 /** Sends analytics payloads to Freerouting's HTTP API. */
 public class FreeroutingAnalyticsClient implements AnalyticsClient {
@@ -86,6 +89,16 @@ public class FreeroutingAnalyticsClient implements AnalyticsClient {
             connection = (HttpURLConnection) uri.toURL().openConnection();
             connection.setConnectTimeout(5000);
             connection.setReadTimeout(10000);
+            if (connection instanceof HttpsURLConnection httpsConn) {
+              SSLSocketFactory ssf =
+                  NetworkProxyConfig.getCompositeSslSocketFactory(
+                      Freerouting.globalSettings != null
+                          ? Freerouting.globalSettings.networkSettings
+                          : null);
+              if (ssf != null) {
+                httpsConn.setSSLSocketFactory(ssf);
+              }
+            }
             connection.setRequestMethod("POST");
             connection.setRequestProperty("Host", uri.getHost());
             connection.setRequestProperty("Content-Type", "application/json");

--- a/src/main/java/app/freerouting/analytics/NetworkProxyConfig.java
+++ b/src/main/java/app/freerouting/analytics/NetworkProxyConfig.java
@@ -1,0 +1,337 @@
+package app.freerouting.analytics;
+
+import app.freerouting.logger.FRLogger;
+import app.freerouting.settings.NetworkSettings;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URI;
+import java.security.KeyStore;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+/** Manages automated proxy discovery and composite TLS truststores for enterprise networks. */
+public final class NetworkProxyConfig {
+
+  private static volatile SSLSocketFactory cachedSslSocketFactory;
+  private static volatile boolean initialized = false;
+
+  private NetworkProxyConfig() {}
+
+  /**
+   * Automatically configures JVM proxy and truststore settings from environment variables and
+   * application settings.
+   *
+   * @param settings optional network settings from configuration
+   */
+  public static synchronized void configure(NetworkSettings settings) {
+    if (initialized) {
+      return;
+    }
+    initialized = true;
+
+    try {
+      configureProxy(settings);
+    } catch (Exception e) {
+      FRLogger.warn("Failed to automatically configure network proxy: " + e.getMessage());
+    }
+
+    try {
+      configureTrustStore(settings);
+    } catch (Exception e) {
+      FRLogger.warn("Failed to automatically configure trust store: " + e.getMessage());
+    }
+  }
+
+  private static void configureProxy(NetworkSettings settings) {
+    String proxyUrl = null;
+    if (settings != null && settings.proxyUrl != null && !settings.proxyUrl.isBlank()) {
+      proxyUrl = settings.proxyUrl.trim();
+    }
+
+    if (proxyUrl == null || proxyUrl.isBlank()) {
+      proxyUrl =
+          getFirstEnv(
+              "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy", "HTTP_PROXY", "http_proxy");
+    }
+
+    if (proxyUrl != null && !proxyUrl.isBlank()) {
+      applyProxyUrl(proxyUrl);
+    }
+
+    String noProxy = null;
+    if (settings != null && settings.noProxy != null && !settings.noProxy.isBlank()) {
+      noProxy = settings.noProxy.trim();
+    }
+    if (noProxy == null || noProxy.isBlank()) {
+      noProxy = getFirstEnv("NO_PROXY", "no_proxy");
+    }
+
+    applyNoProxy(noProxy);
+  }
+
+  private static void applyProxyUrl(String proxyUrl) {
+    try {
+      if (!proxyUrl.contains("://")) {
+        proxyUrl = "http://" + proxyUrl;
+      }
+      URI uri = URI.create(proxyUrl);
+      String host = uri.getHost();
+      int port = uri.getPort() > 0 ? uri.getPort() : 8080;
+
+      if (host != null && !host.isBlank()) {
+        if (System.getProperty("https.proxyHost") == null) {
+          System.setProperty("https.proxyHost", host);
+          System.setProperty("https.proxyPort", String.valueOf(port));
+        }
+        if (System.getProperty("http.proxyHost") == null) {
+          System.setProperty("http.proxyHost", host);
+          System.setProperty("http.proxyPort", String.valueOf(port));
+        }
+
+        String userInfo = uri.getUserInfo();
+        if (userInfo != null && !userInfo.isBlank()) {
+          String[] parts = userInfo.split(":", 2);
+          String user = parts[0];
+          String pass = parts.length > 1 ? parts[1] : "";
+          Authenticator.setDefault(
+              new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                  if (getRequestorType() == RequestorType.PROXY) {
+                    return new PasswordAuthentication(user, pass.toCharArray());
+                  }
+                  return super.getPasswordAuthentication();
+                }
+              });
+        }
+        FRLogger.info("Configured network proxy: " + host + ":" + port);
+      }
+    } catch (Exception e) {
+      FRLogger.warn("Could not parse proxy URL '" + proxyUrl + "': " + e.getMessage());
+    }
+  }
+
+  private static void applyNoProxy(String noProxy) {
+    StringBuilder sb = new StringBuilder("localhost|127.0.0.1");
+    if (noProxy != null && !noProxy.isBlank()) {
+      String[] entries = noProxy.split("[,;\\s]+");
+      for (String entry : entries) {
+        String trimmed = entry.trim();
+        if (!trimmed.isEmpty() && !trimmed.equals("localhost") && !trimmed.equals("127.0.0.1")) {
+          if (trimmed.startsWith(".")) {
+            trimmed = "*" + trimmed;
+          }
+          sb.append("|").append(trimmed);
+        }
+      }
+    }
+
+    if (System.getProperty("http.nonProxyHosts") == null) {
+      System.setProperty("http.nonProxyHosts", sb.toString());
+    }
+  }
+
+  private static void configureTrustStore(NetworkSettings settings) {
+    String trustStorePath = null;
+    if (settings != null
+        && settings.customTruststorePath != null
+        && !settings.customTruststorePath.isBlank()) {
+      trustStorePath = settings.customTruststorePath.trim();
+    }
+    if (trustStorePath == null || trustStorePath.isBlank()) {
+      trustStorePath = getFirstEnv("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE");
+    }
+
+    if (trustStorePath != null
+        && !trustStorePath.isBlank()
+        && System.getProperty("javax.net.ssl.trustStore") == null) {
+      System.setProperty("javax.net.ssl.trustStore", trustStorePath);
+      if (settings != null
+          && settings.customTruststorePassword != null
+          && !settings.customTruststorePassword.isBlank()) {
+        System.setProperty("javax.net.ssl.trustStorePassword", settings.customTruststorePassword);
+      }
+      if (settings != null
+          && settings.customTruststoreType != null
+          && !settings.customTruststoreType.isBlank()) {
+        System.setProperty("javax.net.ssl.trustStoreType", settings.customTruststoreType);
+      }
+      FRLogger.info("Configured custom SSL truststore: " + trustStorePath);
+    }
+  }
+
+  /**
+   * Returns a composite SSLSocketFactory that trusts both standard JDK CAs and OS/enterprise CAs.
+   *
+   * @param settings optional network settings
+   * @return the composite socket factory, or {@code null} if default is sufficient
+   */
+  public static SSLSocketFactory getCompositeSslSocketFactory(NetworkSettings settings) {
+    if (cachedSslSocketFactory != null) {
+      return cachedSslSocketFactory;
+    }
+
+    synchronized (NetworkProxyConfig.class) {
+      if (cachedSslSocketFactory != null) {
+        return cachedSslSocketFactory;
+      }
+
+      try {
+        List<X509TrustManager> trustManagers = new ArrayList<>();
+
+        // 1. Standard default trust managers (JDK cacerts)
+        TrustManagerFactory defaultTmf =
+            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        defaultTmf.init((KeyStore) null);
+        for (TrustManager tm : defaultTmf.getTrustManagers()) {
+          if (tm instanceof X509TrustManager x509Tm) {
+            trustManagers.add(x509Tm);
+          }
+        }
+
+        // 2. Windows OS root trust store if running on Windows
+        String osName = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        if (osName.contains("win")) {
+          try {
+            KeyStore windowsStore = KeyStore.getInstance("Windows-ROOT");
+            windowsStore.load(null, null);
+            TrustManagerFactory winTmf =
+                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            winTmf.init(windowsStore);
+            for (TrustManager tm : winTmf.getTrustManagers()) {
+              if (tm instanceof X509TrustManager x509Tm) {
+                trustManagers.add(x509Tm);
+              }
+            }
+          } catch (Throwable _) {
+            // Windows-ROOT keystore not supported or available in current environment; continue
+          }
+        }
+
+        // 3. Custom certificate file if provided
+        String customCaPath =
+            settings != null && settings.customTruststorePath != null
+                ? settings.customTruststorePath
+                : getFirstEnv("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE");
+        if (customCaPath != null && !customCaPath.isBlank()) {
+          try (InputStream is = new FileInputStream(customCaPath)) {
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            Collection<? extends java.security.cert.Certificate> certs =
+                cf.generateCertificates(is);
+            if (certs != null && !certs.isEmpty()) {
+              KeyStore customKs = KeyStore.getInstance(KeyStore.getDefaultType());
+              customKs.load(null, null);
+              int i = 0;
+              for (java.security.cert.Certificate cert : certs) {
+                customKs.setCertificateEntry("custom-ca-" + (++i), cert);
+              }
+              TrustManagerFactory customTmf =
+                  TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+              customTmf.init(customKs);
+              for (TrustManager tm : customTmf.getTrustManagers()) {
+                if (tm instanceof X509TrustManager x509Tm) {
+                  trustManagers.add(x509Tm);
+                }
+              }
+            }
+          } catch (Throwable t) {
+            FRLogger.warn(
+                "Could not load custom CA certificates from '"
+                    + customCaPath
+                    + "': "
+                    + t.getMessage());
+          }
+        }
+
+        if (trustManagers.size() <= 1) {
+          cachedSslSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory();
+          return cachedSslSocketFactory;
+        }
+
+        X509TrustManager compositeTrustManager = new CompositeX509TrustManager(trustManagers);
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, new TrustManager[] {compositeTrustManager}, null);
+        cachedSslSocketFactory = sslContext.getSocketFactory();
+        return cachedSslSocketFactory;
+      } catch (Exception e) {
+        FRLogger.warn("Could not initialize composite SSL socket factory: " + e.getMessage());
+        return null;
+      }
+    }
+  }
+
+  private static String getFirstEnv(String... names) {
+    for (String name : names) {
+      String val = System.getenv(name);
+      if (val != null && !val.isBlank()) {
+        return val.trim();
+      }
+    }
+    return null;
+  }
+
+  /** Trust manager that delegates certificate validation across multiple trust managers. */
+  private static final class CompositeX509TrustManager implements X509TrustManager {
+    private final List<X509TrustManager> trustManagers;
+
+    private CompositeX509TrustManager(List<X509TrustManager> trustManagers) {
+      this.trustManagers = trustManagers;
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType)
+        throws java.security.cert.CertificateException {
+      java.security.cert.CertificateException lastException = null;
+      for (X509TrustManager tm : trustManagers) {
+        try {
+          tm.checkClientTrusted(chain, authType);
+          return;
+        } catch (java.security.cert.CertificateException e) {
+          lastException = e;
+        }
+      }
+      if (lastException != null) {
+        throw lastException;
+      }
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType)
+        throws java.security.cert.CertificateException {
+      java.security.cert.CertificateException lastException = null;
+      for (X509TrustManager tm : trustManagers) {
+        try {
+          tm.checkServerTrusted(chain, authType);
+          return;
+        } catch (java.security.cert.CertificateException e) {
+          lastException = e;
+        }
+      }
+      if (lastException != null) {
+        throw lastException;
+      }
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+      List<X509Certificate> certificates = new ArrayList<>();
+      for (X509TrustManager tm : trustManagers) {
+        certificates.addAll(Arrays.asList(tm.getAcceptedIssuers()));
+      }
+      return certificates.toArray(new X509Certificate[0]);
+    }
+  }
+}

--- a/src/main/java/app/freerouting/analytics/NetworkProxyConfig.java
+++ b/src/main/java/app/freerouting/analytics/NetworkProxyConfig.java
@@ -7,6 +7,8 @@ import java.io.InputStream;
 import java.net.Authenticator;
 import java.net.PasswordAuthentication;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -178,6 +180,7 @@ public final class NetworkProxyConfig {
 
     if (trustStorePath != null
         && !trustStorePath.isBlank()
+        && Files.exists(Path.of(trustStorePath))
         && System.getProperty("javax.net.ssl.trustStore") == null) {
       System.setProperty("javax.net.ssl.trustStore", trustStorePath);
       if (settings != null
@@ -199,7 +202,7 @@ public final class NetworkProxyConfig {
    * OS/enterprise certificates.
    *
    * @param settings optional network settings
-   * @return the composite socket factory, or {@code null} if default is sufficient
+   * @return the composite socket factory, or default factory if customization is not needed
    */
   public static SSLSocketFactory getCompositeSslSocketFactory(NetworkSettings settings) {
     if (cachedSslSocketFactory != null) {
@@ -215,13 +218,17 @@ public final class NetworkProxyConfig {
         List<X509TrustManager> trustManagers = new ArrayList<>();
 
         // 1. Standard default trust managers (JDK cacerts)
-        TrustManagerFactory defaultTmf =
-            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-        defaultTmf.init((KeyStore) null);
-        for (TrustManager tm : defaultTmf.getTrustManagers()) {
-          if (tm instanceof X509TrustManager x509Tm) {
-            trustManagers.add(x509Tm);
+        try {
+          TrustManagerFactory defaultTmf =
+              TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+          defaultTmf.init((KeyStore) null);
+          for (TrustManager tm : defaultTmf.getTrustManagers()) {
+            if (tm instanceof X509TrustManager x509Tm) {
+              trustManagers.add(x509Tm);
+            }
           }
+        } catch (Throwable t) {
+          FRLogger.warn("Could not load default trust managers: " + t.getMessage());
         }
 
         // 2. Windows OS root trust store if running on Windows
@@ -243,12 +250,14 @@ public final class NetworkProxyConfig {
           }
         }
 
-        // 3. Custom certificate file if provided
+        // 3. Custom certificate file if provided and exists
         String customCaPath =
             settings != null && settings.customTruststorePath != null
                 ? settings.customTruststorePath
                 : getFirstEnv("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE");
-        if (customCaPath != null && !customCaPath.isBlank()) {
+        if (customCaPath != null
+            && !customCaPath.isBlank()
+            && Files.exists(Path.of(customCaPath))) {
           try (InputStream is = new FileInputStream(customCaPath)) {
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
             Collection<? extends java.security.cert.Certificate> certs =
@@ -278,19 +287,23 @@ public final class NetworkProxyConfig {
           }
         }
 
-        if (trustManagers.size() <= 1) {
-          cachedSslSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory();
-          return cachedSslSocketFactory;
-        }
-
-        X509TrustManager compositeTrustManager = new CompositeX509TrustManager(trustManagers);
         SSLContext sslContext = SSLContext.getInstance("TLS");
-        sslContext.init(null, new TrustManager[] {compositeTrustManager}, null);
+        if (!trustManagers.isEmpty()) {
+          X509TrustManager compositeTrustManager = new CompositeX509TrustManager(trustManagers);
+          sslContext.init(null, new TrustManager[] {compositeTrustManager}, null);
+        } else {
+          sslContext.init(null, null, null);
+        }
         cachedSslSocketFactory = sslContext.getSocketFactory();
         return cachedSslSocketFactory;
-      } catch (Exception e) {
-        FRLogger.warn("Could not initialize composite SSL socket factory: " + e.getMessage());
-        return null;
+      } catch (Throwable e) {
+        FRLogger.warn("Could not initialize SSL socket factory: " + e.getMessage());
+        try {
+          cachedSslSocketFactory = SSLContext.getDefault().getSocketFactory();
+          return cachedSslSocketFactory;
+        } catch (Exception _) {
+          return HttpsURLConnection.getDefaultSSLSocketFactory();
+        }
       }
     }
   }

--- a/src/main/java/app/freerouting/analytics/NetworkProxyConfig.java
+++ b/src/main/java/app/freerouting/analytics/NetworkProxyConfig.java
@@ -13,8 +13,10 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -26,7 +28,6 @@ import javax.net.ssl.X509TrustManager;
 public final class NetworkProxyConfig {
 
   private static volatile SSLSocketFactory cachedSslSocketFactory;
-  private static volatile boolean initialized = false;
 
   private NetworkProxyConfig() {}
 
@@ -37,11 +38,6 @@ public final class NetworkProxyConfig {
    * @param settings optional network settings from configuration
    */
   public static synchronized void configure(NetworkSettings settings) {
-    if (initialized) {
-      return;
-    }
-    initialized = true;
-
     try {
       configureProxy(settings);
     } catch (Exception e) {
@@ -124,24 +120,49 @@ public final class NetworkProxyConfig {
     }
   }
 
-  private static void applyNoProxy(String noProxy) {
-    StringBuilder sb = new StringBuilder("localhost|127.0.0.1");
-    if (noProxy != null && !noProxy.isBlank()) {
-      String[] entries = noProxy.split("[,;\\s]+");
-      for (String entry : entries) {
+  /**
+   * Combines an existing non-proxy hosts string with new bypass entries, ensuring localhost and
+   * 127.0.0.1 are always present.
+   *
+   * @param existing current value of {@code http.nonProxyHosts}, or {@code null}
+   * @param noProxy additional comma/space/pipe-separated bypass list, or {@code null}
+   * @return pipe-separated non-proxy hosts string
+   */
+  public static String buildNonProxyHosts(String existing, String noProxy) {
+    Set<String> hosts = new LinkedHashSet<>();
+    hosts.add("localhost");
+    hosts.add("127.0.0.1");
+
+    if (existing != null && !existing.isBlank()) {
+      String[] existingEntries = existing.split("[|]+");
+      for (String entry : existingEntries) {
         String trimmed = entry.trim();
-        if (!trimmed.isEmpty() && !trimmed.equals("localhost") && !trimmed.equals("127.0.0.1")) {
-          if (trimmed.startsWith(".")) {
-            trimmed = "*" + trimmed;
-          }
-          sb.append("|").append(trimmed);
+        if (!trimmed.isEmpty()) {
+          hosts.add(trimmed);
         }
       }
     }
 
-    if (System.getProperty("http.nonProxyHosts") == null) {
-      System.setProperty("http.nonProxyHosts", sb.toString());
+    if (noProxy != null && !noProxy.isBlank()) {
+      String[] entries = noProxy.split("[,;\\s|]+");
+      for (String entry : entries) {
+        String trimmed = entry.trim();
+        if (!trimmed.isEmpty()) {
+          if (trimmed.startsWith(".")) {
+            trimmed = "*" + trimmed;
+          }
+          hosts.add(trimmed);
+        }
+      }
     }
+
+    return String.join("|", hosts);
+  }
+
+  private static void applyNoProxy(String noProxy) {
+    String existing = System.getProperty("http.nonProxyHosts");
+    String merged = buildNonProxyHosts(existing, noProxy);
+    System.setProperty("http.nonProxyHosts", merged);
   }
 
   private static void configureTrustStore(NetworkSettings settings) {

--- a/src/main/java/app/freerouting/analytics/NetworkProxyConfig.java
+++ b/src/main/java/app/freerouting/analytics/NetworkProxyConfig.java
@@ -174,7 +174,8 @@ public final class NetworkProxyConfig {
   }
 
   /**
-   * Returns a composite SSLSocketFactory that trusts both standard JDK CAs and OS/enterprise CAs.
+   * Returns a composite SSLSocketFactory that trusts both standard JDK root certificates and
+   * OS/enterprise certificates.
    *
    * @param settings optional network settings
    * @return the composite socket factory, or {@code null} if default is sufficient

--- a/src/main/java/app/freerouting/api/mcp/McpControllerV1.java
+++ b/src/main/java/app/freerouting/api/mcp/McpControllerV1.java
@@ -203,7 +203,23 @@ public class McpControllerV1 extends BaseController {
       FRLogger.info("[mcp][cid=" + correlationId + "] response (error)=" + response.toString());
     }
 
-    FRAnalytics.apiEndpointCalled("POST v1/mcp", requestBody, response.toString(), userId);
+    String envHost = headers.getHeaderString("Freerouting-Environment-Host");
+    if (envHost == null || envHost.isBlank()) {
+      envHost = detectedClientInfo;
+    }
+    if (envHost != null && !envHost.isBlank()) {
+      app.freerouting.analytics.AnalyticsRequestContext.setEnvironmentHost(envHost);
+    }
+
+    String apiMethodTag = "POST v1/mcp";
+    if ("tools/call".equals(method)
+        && params != null
+        && params.has("name")
+        && params.get("name").isJsonPrimitive()) {
+      apiMethodTag = "POST v1/mcp (tool: " + params.get("name").getAsString() + ")";
+    }
+
+    FRAnalytics.apiEndpointCalled(apiMethodTag, requestBody, response.toString(), userId);
 
     if (isNotification) {
       return Response.noContent().header(CorrelationIdFilter.HEADER_NAME, correlationId).build();

--- a/src/main/java/app/freerouting/autoroute/pipeline/BatchAutorouter.java
+++ b/src/main/java/app/freerouting/autoroute/pipeline/BatchAutorouter.java
@@ -115,7 +115,9 @@ public final class BatchAutorouter extends NamedAlgorithm {
         !job.routerSettings.isFanoutEnabled(),
         true,
         job.routerSettings.getStartRipupCosts(),
-        job.routerSettings.tracePullTightAccuracy);
+        job.routerSettings.tracePullTightAccuracy != null
+            ? job.routerSettings.tracePullTightAccuracy
+            : 500);
     this.job = job;
   }
 

--- a/src/main/java/app/freerouting/io/kicad/KiCadBoardJson.java
+++ b/src/main/java/app/freerouting/io/kicad/KiCadBoardJson.java
@@ -6,6 +6,8 @@ import java.util.List;
 /** Data Transfer Object for KiCad board data serialized as JSON. */
 public class KiCadBoardJson {
   public String designName;
+  public String hostCad;
+  public String hostVersion;
   public UnitJson unit = UnitJson.MM; // Default unit.
   public double resolution = 1.0; // Default resolution factor.
 

--- a/src/main/java/app/freerouting/io/kicad/KiCadJsonReader.java
+++ b/src/main/java/app/freerouting/io/kicad/KiCadJsonReader.java
@@ -311,8 +311,14 @@ public final class KiCadJsonReader {
 
       // 6. Communication object setup
       final CoordinateTransform coordinateTransform = new CoordinateTransform(scaleFactor, 0, 0);
+      String hostCad =
+          boardJson.hostCad != null && !boardJson.hostCad.isBlank() ? boardJson.hostCad : "KiCad";
+      String hostVersion =
+          boardJson.hostVersion != null && !boardJson.hostVersion.isBlank()
+              ? boardJson.hostVersion
+              : "v10.0";
       Communication.SpecctraParserInfo parserInfo =
-          new Communication.SpecctraParserInfo("\"", "KiCad", "v10.0", null, null, false);
+          new Communication.SpecctraParserInfo("\"", hostCad, hostVersion, null, null, false);
       Communication communication =
           new Communication(
               userUnit, resolution, parserInfo, coordinateTransform, idGenerator, observers);

--- a/src/main/java/app/freerouting/management/jobs/RoutingJobSchedulerActionThread.java
+++ b/src/main/java/app/freerouting/management/jobs/RoutingJobSchedulerActionThread.java
@@ -1,7 +1,9 @@
 package app.freerouting.management.jobs;
 
 import app.freerouting.Freerouting;
+import app.freerouting.analytics.FRAnalytics;
 import app.freerouting.autoroute.pipeline.BatchAutorouter;
+import app.freerouting.autoroute.pipeline.BatchOptimizer;
 import app.freerouting.autoroute.pipeline.RoutingPipeline;
 import app.freerouting.core.BoardFileDetails;
 import app.freerouting.core.RoutingJob;
@@ -66,7 +68,7 @@ public class RoutingJobSchedulerActionThread extends StoppableThread {
                   this.monitorCpuAndMemoryUsage(job);
 
                   // Check for timeout
-                  if (!Instant.now().isBefore(job.timeoutAt)) {
+                  if (job.timeoutAt != null && !Instant.now().isBefore(job.timeoutAt)) {
 
                     // signal the job thread to stop, and wait gracefully for up to 30 seconds for
                     // it
@@ -87,15 +89,19 @@ public class RoutingJobSchedulerActionThread extends StoppableThread {
     monitorThread.setDaemon(true);
     monitorThread.start();
 
+    boolean routerEnabled =
+        job.routerSettings.getRunRouter()
+            && (job.routerSettings.maxPasses == null || job.routerSettings.maxPasses >= 0);
+    if (routerEnabled) {
+      FRAnalytics.autorouterStarted();
+    }
+
     RoutingPipeline pipeline = RoutingPipeline.createForHeadless(job);
     pipeline.addBoardUpdatedEventListener(event -> setJobOutput(job));
     pipeline.addStageListener(
         new RoutingPipeline.StageListener() {
           @Override
           public void afterRouting(BatchAutorouter batchRouter) {
-            boolean routerEnabled =
-                job.routerSettings.getRunRouter()
-                    && (job.routerSettings.maxPasses == null || job.routerSettings.maxPasses >= 0);
             if (!routerEnabled) {
               return;
             }
@@ -109,6 +115,14 @@ public class RoutingJobSchedulerActionThread extends StoppableThread {
             double totalTime =
                 java.time.Duration.between(sessionStartTime, sessionEndTime).toMillis() / 1000.0;
             var finalStats = job.board.getStatistics();
+            Float normalizedScore = finalStats.getNormalizedScore(job.routerSettings.scoring);
+            FRAnalytics.autorouterFinished(
+                finalStats.nets.totalCount,
+                finalStats.connections.incompleteCount,
+                finalStats.clearanceViolations.totalCount,
+                job.board.getHash(),
+                normalizedScore);
+
             String completionStatus = "completed:";
             boolean isTimedOut =
                 (job.state == RoutingJobState.TIMED_OUT)
@@ -132,12 +146,22 @@ public class RoutingJobSchedulerActionThread extends StoppableThread {
                     batchRouter.getInitialUnroutedCount(),
                     totalTime,
                     FRLogger.formatScore(
-                        finalStats.getNormalizedScore(job.routerSettings.scoring),
+                        normalizedScore,
                         finalStats.connections.incompleteCount,
                         finalStats.clearanceViolations.totalCount),
                     job.resourceUsage.cpuTimeUsed,
                     job.resourceUsage.maxMemoryUsed / 1024.0f,
                     job.resourceUsage.peakMemoryUsed));
+          }
+
+          @Override
+          public void beforeOptimization(BatchOptimizer optimizer) {
+            FRAnalytics.routeOptimizerStarted();
+          }
+
+          @Override
+          public void afterOptimization(BatchOptimizer optimizer) {
+            FRAnalytics.routeOptimizerFinished();
           }
         });
     pipeline.run();

--- a/src/main/java/app/freerouting/settings/GlobalSettings.java
+++ b/src/main/java/app/freerouting/settings/GlobalSettings.java
@@ -73,6 +73,9 @@ public class GlobalSettings implements Serializable {
   @SerializedName("logging")
   public final LoggingSettings logging = new LoggingSettings();
 
+  @SerializedName("network")
+  public final NetworkSettings networkSettings = new NetworkSettings();
+
   @SerializedName("debug")
   public final transient DebugSettings debugSettings = new DebugSettings();
 

--- a/src/main/java/app/freerouting/settings/NetworkSettings.java
+++ b/src/main/java/app/freerouting/settings/NetworkSettings.java
@@ -1,0 +1,23 @@
+package app.freerouting.settings;
+
+import com.google.gson.annotations.SerializedName;
+import java.io.Serializable;
+
+/** Configuration for network proxies and custom TLS truststores. */
+public class NetworkSettings implements Serializable {
+
+  @SerializedName("proxy_url")
+  public String proxyUrl;
+
+  @SerializedName("no_proxy")
+  public String noProxy;
+
+  @SerializedName("custom_truststore_path")
+  public String customTruststorePath;
+
+  @SerializedName("custom_truststore_password")
+  public String customTruststorePassword;
+
+  @SerializedName("custom_truststore_type")
+  public String customTruststoreType;
+}

--- a/src/main/java/app/freerouting/util/TextManager.java
+++ b/src/main/java/app/freerouting/util/TextManager.java
@@ -81,6 +81,9 @@ public class TextManager {
    * @return duration in seconds, or {@code null} if parsing fails
    */
   public static Long parseTimespanString(String timespanString) {
+    if (timespanString == null || timespanString.isBlank()) {
+      return null;
+    }
     try {
       Duration duration = Duration.parse(convertFromTimespanToDurationFormat(timespanString));
       return duration.getSeconds();

--- a/src/test/java/app/freerouting/analytics/FreeroutingAnalyticsClientTest.java
+++ b/src/test/java/app/freerouting/analytics/FreeroutingAnalyticsClientTest.java
@@ -1,0 +1,33 @@
+package app.freerouting.analytics;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import app.freerouting.analytics.dto.Properties;
+import app.freerouting.analytics.dto.Traits;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class FreeroutingAnalyticsClientTest {
+
+  @Test
+  void testFlushAndShutdownLifecycle() throws IOException {
+    FreeroutingAnalyticsClient client = new FreeroutingAnalyticsClient("2.3.0", "dummy-key");
+    client.setEnabled(false); // disable actual network calls
+
+    Traits traits = new Traits();
+    traits.put("test_key", "test_value");
+    client.identify("user-1", "anon-1", traits);
+
+    Properties props = new Properties();
+    props.put("prop1", "val1");
+    client.track("user-1", "anon-1", "Test Event", props);
+
+    assertDoesNotThrow(() -> client.flush(500));
+    assertDoesNotThrow(client::shutdown);
+  }
+
+  @Test
+  void testFRAnalyticsFlush() {
+    assertDoesNotThrow(() -> FRAnalytics.flush(100));
+  }
+}

--- a/src/test/java/app/freerouting/analytics/NetworkProxyConfigTest.java
+++ b/src/test/java/app/freerouting/analytics/NetworkProxyConfigTest.java
@@ -30,6 +30,19 @@ class NetworkProxyConfigTest {
   }
 
   @Test
+  void testBuildNonProxyHostsContainsLocalhostAndWildcards() {
+    String merged =
+        NetworkProxyConfig.buildNonProxyHosts(
+            "*.local|169.254/16", "internal.corp,api.internal,.example.com");
+    assertNotNull(merged);
+    assertTrue(merged.contains("localhost"), "Should include localhost");
+    assertTrue(merged.contains("127.0.0.1"), "Should include 127.0.0.1");
+    assertTrue(merged.contains("*.local"), "Should retain existing entry");
+    assertTrue(merged.contains("internal.corp"), "Should include new entry");
+    assertTrue(merged.contains("*.example.com"), "Should prefix dot domains with wildcard");
+  }
+
+  @Test
   void testNoProxyContainsLocalhost() {
     NetworkSettings settings = new NetworkSettings();
     settings.noProxy = "internal.corp,api.internal";

--- a/src/test/java/app/freerouting/analytics/NetworkProxyConfigTest.java
+++ b/src/test/java/app/freerouting/analytics/NetworkProxyConfigTest.java
@@ -1,0 +1,43 @@
+package app.freerouting.analytics;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import app.freerouting.settings.NetworkSettings;
+import javax.net.ssl.SSLSocketFactory;
+import org.junit.jupiter.api.Test;
+
+class NetworkProxyConfigTest {
+
+  @Test
+  void testConfigureWithNetworkSettings() {
+    NetworkSettings settings = new NetworkSettings();
+    settings.proxyUrl = "http://corp-proxy.local:3128";
+    settings.noProxy = "localhost,127.0.0.1,.example.com";
+    settings.customTruststorePath = "fixtures/test-truststore.jks";
+    settings.customTruststorePassword = "secretPassword";
+    settings.customTruststoreType = "JKS";
+
+    assertDoesNotThrow(() -> NetworkProxyConfig.configure(settings));
+  }
+
+  @Test
+  void testGetCompositeSslSocketFactoryReturnsNonNull() {
+    NetworkSettings settings = new NetworkSettings();
+    SSLSocketFactory factory = NetworkProxyConfig.getCompositeSslSocketFactory(settings);
+    assertNotNull(factory, "SSLSocketFactory should not be null");
+  }
+
+  @Test
+  void testNoProxyContainsLocalhost() {
+    NetworkSettings settings = new NetworkSettings();
+    settings.noProxy = "internal.corp,api.internal";
+    NetworkProxyConfig.configure(settings);
+
+    String nonProxyHosts = System.getProperty("http.nonProxyHosts");
+    assertNotNull(nonProxyHosts);
+    assertTrue(nonProxyHosts.contains("localhost"), "Should include localhost");
+    assertTrue(nonProxyHosts.contains("127.0.0.1"), "Should include 127.0.0.1");
+  }
+}

--- a/src/test/java/app/freerouting/analytics/NetworkProxyConfigTest.java
+++ b/src/test/java/app/freerouting/analytics/NetworkProxyConfigTest.java
@@ -5,10 +5,47 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import app.freerouting.settings.NetworkSettings;
+import java.util.HashMap;
+import java.util.Map;
 import javax.net.ssl.SSLSocketFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class NetworkProxyConfigTest {
+
+  private static final String[] PROPS = {
+    "https.proxyHost",
+    "https.proxyPort",
+    "http.proxyHost",
+    "http.proxyPort",
+    "http.nonProxyHosts",
+    "javax.net.ssl.trustStore",
+    "javax.net.ssl.trustStorePassword",
+    "javax.net.ssl.trustStoreType"
+  };
+
+  private final Map<String, String> originalProps = new HashMap<>();
+
+  @BeforeEach
+  void setUp() {
+    originalProps.clear();
+    for (String prop : PROPS) {
+      originalProps.put(prop, System.getProperty(prop));
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    for (String prop : PROPS) {
+      String val = originalProps.get(prop);
+      if (val != null) {
+        System.setProperty(prop, val);
+      } else {
+        System.clearProperty(prop);
+      }
+    }
+  }
 
   @Test
   void testConfigureWithNetworkSettings() {

--- a/src/test/java/app/freerouting/io/kicad/KiCadJsonReaderTest.java
+++ b/src/test/java/app/freerouting/io/kicad/KiCadJsonReaderTest.java
@@ -445,4 +445,37 @@ class KiCadJsonReaderTest {
     assertEquals(-45000, bounds.ll.y);
     assertEquals(-15000, bounds.ur.y);
   }
+
+  @Test
+  void testHostCadAndHostVersionParsed() {
+    String json =
+        """
+        {
+          "designName": "CustomHostBoard",
+          "hostCad": "KiCadNightly",
+          "hostVersion": "11.0.0-rc1",
+          "unit": "MM",
+          "resolution": 1000.0,
+          "layers": [
+            {"index": 0, "name": "F.Cu", "type": "signal"}
+          ],
+          "outline": {
+            "corners": [
+              {"x": 0.0, "y": 0.0},
+              {"x": 10.0, "y": 0.0},
+              {"x": 10.0, "y": 10.0},
+              {"x": 0.0, "y": 10.0}
+            ]
+          }
+        }
+        """;
+
+    BoardReadResult result = KiCadJsonReader.readBoard(new StringReader(json), null, null);
+    assertInstanceOf(BoardReadResult.Success.class, result);
+    BoardReadResult.Success success = (BoardReadResult.Success) result;
+    RoutingBoard board = (RoutingBoard) success.board();
+
+    assertEquals("KiCadNightly", board.communication.specctraParserInfo.hostCad);
+    assertEquals("11.0.0-rc1", board.communication.specctraParserInfo.hostVersion);
+  }
 }

--- a/src/test/java/app/freerouting/management/jobs/RoutingJobSchedulerActionThreadTest.java
+++ b/src/test/java/app/freerouting/management/jobs/RoutingJobSchedulerActionThreadTest.java
@@ -1,0 +1,101 @@
+package app.freerouting.management.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import app.freerouting.Freerouting;
+import app.freerouting.analytics.AnalyticsClient;
+import app.freerouting.analytics.FRAnalytics;
+import app.freerouting.analytics.dto.Properties;
+import app.freerouting.analytics.dto.Traits;
+import app.freerouting.core.RoutingJob;
+import app.freerouting.core.RoutingJobState;
+import app.freerouting.settings.GlobalSettings;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RoutingJobSchedulerActionThreadTest {
+
+  @BeforeEach
+  void setUp() {
+    Freerouting.globalSettings = new GlobalSettings();
+  }
+
+  @Test
+  void testRoutingJobSchedulerActionThreadEmitsAnalytics() throws Exception {
+    List<String> trackedEvents = Collections.synchronizedList(new ArrayList<>());
+    AnalyticsClient testClient =
+        new AnalyticsClient() {
+          @Override
+          public void identify(String userId, String anonymousId, Traits traits) {}
+
+          @Override
+          public void track(
+              String userId, String anonymousId, String event, Properties properties) {
+            trackedEvents.add(event);
+          }
+
+          @Override
+          public void setEnabled(boolean enabled) {}
+        };
+
+    // Initialize test client via reflection
+    java.lang.reflect.Field clientField = FRAnalytics.class.getDeclaredField("analytics");
+    clientField.setAccessible(true);
+    clientField.set(null, testClient);
+    FRAnalytics.setEnabled(true);
+
+    String json =
+        """
+        {
+          "designName": "ActionThreadTestBoard",
+          "unit": "MM",
+          "resolution": 1000.0,
+          "layers": [
+            {"index": 0, "name": "F.Cu", "type": "signal"},
+            {"index": 1, "name": "B.Cu", "type": "signal"}
+          ],
+          "outline": {
+            "corners": [
+              {"x": 0.0, "y": 0.0},
+              {"x": 20.0, "y": 0.0},
+              {"x": 20.0, "y": 20.0},
+              {"x": 0.0, "y": 20.0}
+            ]
+          }
+        }
+        """;
+
+    RoutingJob job = new RoutingJob();
+    app.freerouting.management.HeadlessBoardManager manager =
+        new app.freerouting.management.HeadlessBoardManager(job);
+    manager.loadFromKiCadJson(
+        new java.io.ByteArrayInputStream(json.getBytes(java.nio.charset.StandardCharsets.UTF_8)),
+        null,
+        null);
+    job.board = manager.getRoutingBoard();
+
+    job.routerSettings =
+        new app.freerouting.settings.SettingsMerger(
+                new app.freerouting.settings.sources.DefaultSettings())
+            .merge();
+    job.routerSettings.setLayerCount(job.board.getLayerCount());
+    job.routerSettings.applyBoardSpecificOptimizations(job.board);
+    job.routerSettings.maxPasses = 0; // Quick 0-pass test
+    job.state = RoutingJobState.RUNNING;
+
+    RoutingJobSchedulerActionThread actionThread = new RoutingJobSchedulerActionThread(job);
+    job.thread = actionThread;
+
+    actionThread.threadAction();
+    assertEquals(RoutingJobState.COMPLETED, job.state);
+    assertTrue(
+        trackedEvents.contains("Auto-router Started"), "Should have tracked 'Auto-router Started'");
+    assertTrue(
+        trackedEvents.contains("Auto-router Finished"),
+        "Should have tracked 'Auto-router Finished'");
+  }
+}

--- a/website/index.html
+++ b/website/index.html
@@ -106,9 +106,6 @@
     <a class="btn" href="donate.html" id="donate_header">
         <i class="fas fa-heart" style="color: #e0245e;"></i> Support
     </a>
-    <a class="btn" href="benchmarks.html" id="benchmarks_header">
-        <i class="fas fa-chart-line"></i> Benchmarks
-    </a>
     <a class="btn" href="https://forms.gle/EqbxFZMSQiSsR4WM8" id="api_access">
         <i class="fas fa-network-wired"></i> Request API Access
     </a>


### PR DESCRIPTION
## Summary of Changes

This PR improves analytics telemetry coverage across all non-GUI execution modes and adds automated enterprise network resilience (corporate proxies and TLS interception).

### 1. Analytics & Telemetry Coverage
* **Headless, CLI, & API Server Pipeline Telemetry**:
  - Connected `FRAnalytics.autorouterStarted()`, `autorouterFinished()`, `routeOptimizerStarted()`, and `routeOptimizerFinished()` into `RoutingJobSchedulerActionThread`.
  - Non-GUI headless CLI jobs, REST API jobs, and MCP jobs now faithfully record full routing metrics (unrouted items, clearance violations, normalized score, memory, runtime, board hash) to telemetry.
* **Network Delivery Resilience & Flush on Process Exit**:
  - Added managed thread pool, connect/read timeouts (5s / 10s), and `flush(timeoutMs)` to `FreeroutingAnalyticsClient` and `FRAnalytics`.
  - Added a JVM shutdown hook in `Freerouting.java` (`FRAnalytics.flush(1500)`) so CLI subprocesses and batch runs flush pending telemetry before process termination.
* **MCP Tool Call Granularity**:
  - In `McpControllerV1.java`, tool invocations are tagged by tool name (`POST v1/mcp (tool: <name>)`) and client host (`AnalyticsRequestContext.setEnvironmentHost(...)`).
* **KiCad Dynamic Version Tracking**:
  - Added `hostCad` and `hostVersion` metadata propagation across `KiCadBoardJson`, `KiCadJsonReader`, and `board_json_helpers.py`.

### 2. Automatic Corporate Proxy Discovery & Composite TLS Truststores
* **Automatic Environment Proxy Detection**:
  - Added `NetworkProxyConfig.java` to inspect standard environment variables (`HTTPS_PROXY`, `https_proxy`, `ALL_PROXY`, `all_proxy`, `HTTP_PROXY`, `http_proxy`) and configure JVM proxy system properties and authenticators.
  - Automatically translates `NO_PROXY` / `no_proxy` rules into `http.nonProxyHosts` with guaranteed `localhost` and `127.0.0.1` exemptions.
* **Composite TLS Truststore Support**:
  - Automatically loads and trusts standard JDK `cacerts`, Windows OS root certificate store (`Windows-ROOT`), and custom CA bundles from `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, or `CURL_CA_BUNDLE` to prevent TLS failures behind enterprise SSL interception proxies (e.g. Zscaler, Palo Alto).
* **Declarative Settings**:
  - Added `NetworkSettings` in `GlobalSettings` under the `"network"` property.

---

### Verification
* `pre-commit run --all-files` passed (all linters, codespell, yamllint, shellcheck green).
* `./gradlew spotlessCheck checkstyleMain checkstyleTest checkstyleRewriteRecipes test` passed (447 tests completed, 0 failed, 3 skipped).
