### PR TITLE
Make the scheduler's maximum parallel jobs configurable (api_server.max_parallel_jobs)

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -67,7 +67,8 @@ The primary way to configure Freerouting is through a JSON settings file. This f
       "enabled": false,
       "requests_per_window": 120,
       "window_seconds": 60
-    }
+    },
+    "max_parallel_jobs": 5
   },
   "mcp_server": {
     "enabled": false,
@@ -194,6 +195,8 @@ Configures the SMD-pin fanout pre-pass stage.
   - `enabled`: Enable/disable API-side rate limiting.
   - `requests_per_window`: Maximum accepted requests per identity in each window.
   - `window_seconds`: Window duration in seconds.
+- **`max_parallel_jobs`**: Maximum number of routing jobs the scheduler runs concurrently (default: `5`). Useful for self-hosted instances that size job concurrency to their hardware.
+  - Env var: `FREEROUTING__API_SERVER__MAX_PARALLEL_JOBS=10`
 
 #### **`mcp_server` Section**
 

--- a/src/main/java/app/freerouting/management/jobs/RoutingJobScheduler.java
+++ b/src/main/java/app/freerouting/management/jobs/RoutingJobScheduler.java
@@ -37,8 +37,8 @@ import java.util.UUID;
 public final class RoutingJobScheduler {
 
   private static final RoutingJobScheduler instance = new RoutingJobScheduler();
+  private static final int DEFAULT_MAX_PARALLEL_JOBS = 5;
   public final LinkedList<RoutingJob> jobs = new LinkedList<>();
-  private final int maxParallelJobs = 5;
 
   // Private constructor to prevent instantiation
   private RoutingJobScheduler() {
@@ -73,7 +73,7 @@ public final class RoutingJobScheduler {
                                     .filter(j -> j.state == RoutingJobState.RUNNING)
                                     .count();
 
-                        if (parallelJobs < maxParallelJobs) {
+                        if (parallelJobs < getMaxParallelJobs()) {
                           if ((job.input == null) || (job.input.getData() == null)) {
                             FRLogger.warn("RoutingJob input is null, it is skipped.");
                             job.state = RoutingJobState.INVALID;
@@ -220,6 +220,23 @@ public final class RoutingJobScheduler {
    */
   public static RoutingJobScheduler getInstance() {
     return instance;
+  }
+
+  /**
+   * Returns the maximum number of routing jobs that may run concurrently, taken from the
+   * api_server.max_parallel_jobs setting. Falls back to the built-in default when the settings are
+   * not loaded yet or the configured value is not positive.
+   *
+   * @return The maximum number of parallel jobs.
+   */
+  private int getMaxParallelJobs() {
+    if ((globalSettings != null)
+        && (globalSettings.apiServerSettings != null)
+        && (globalSettings.apiServerSettings.maxParallelJobs != null)
+        && (globalSettings.apiServerSettings.maxParallelJobs > 0)) {
+      return globalSettings.apiServerSettings.maxParallelJobs;
+    }
+    return DEFAULT_MAX_PARALLEL_JOBS;
   }
 
   private String uuidToShortCode(UUID uuid) {

--- a/src/main/java/app/freerouting/settings/ApiServerSettings.java
+++ b/src/main/java/app/freerouting/settings/ApiServerSettings.java
@@ -35,4 +35,8 @@ public class ApiServerSettings implements Serializable {
   /** Fixed-window request-rate limiting configuration. */
   @SerializedName("rate_limit")
   public RateLimitSettings rateLimit = new RateLimitSettings();
+
+  /** Maximum number of routing jobs the scheduler runs concurrently. */
+  @SerializedName("max_parallel_jobs")
+  public Integer maxParallelJobs = 5;
 }


### PR DESCRIPTION
human tldr, make concurrent jobs configurable and not 5 limit

ai slop:
## Problem

`RoutingJobScheduler` caps concurrently running jobs at a hardcoded `5`. Self-hosted instances sized for more (or fewer) concurrent routing jobs currently have no way to change this without patching the source.

## Solution

Adds `api_server.max_parallel_jobs` (default `5`, so out-of-the-box behavior is unchanged). It participates in the normal settings pipeline, so it can be set via the JSON settings file, CLI, or environment variable:

```
FREEROUTING__API_SERVER__MAX_PARALLEL_JOBS=10
```

The scheduler reads the value each loop iteration and falls back to the previous default when settings are not loaded yet or the configured value is not positive. Documented in `docs/settings.md`.

## Context

We run Freerouting as a self-hosted routing service (thanks for the great project!) on hosts sized for higher job concurrency, and this was the one knob we could not reach through configuration.