### PR TITLE
Support parsing autoroute_settings in .rules files and API rules upload

### DIFF
--- a/docs/API/API_v1.md
+++ b/docs/API/API_v1.md
@@ -296,6 +296,26 @@ If `Freerouting-Environment-Host` is absent or does not match the `<ToolName>/<V
   }
   ```
 
+- **Submit Design Rules for a Job**
+
+  ```http
+  POST /jobs/{jobId}/rules
+  ```
+
+  **Parameters:**
+    - `jobId` *(required)*: The unique identifier of the job.
+
+  **Description:** Submits optional Specctra design rules (`.rules`) data for a routing job. The rules file can define net classes, clearances, via definitions, as well as `(autoroute_settings ...)` and `(layer_rule ...)` parameters. The job must still be in `QUEUED` state.
+
+  **Request body:** Contains the filename and the [Base64-encoded](https://en.wikipedia.org/wiki/Base64) Specctra RULES data.
+
+  ```json
+  {
+    "filename": "BBD-Mars-64-revE.rules",
+    "data": "KHJ1bGVzIFBD...AgICAgKQogICkKKQ=="
+  }
+  ```
+
 - **Get Output for a Job**
 
   ```http

--- a/docs/API/MCP.md
+++ b/docs/API/MCP.md
@@ -137,8 +137,9 @@ graph TD
 - **Encode**: It is recommended to use the local `encode_base64` tool to convert your plain-text board file (typically a `.dsn` Specctra file) into a Base64-encoded string. Prefer this over running external shell commands (like PowerShell or `base64`).
 - **Upload**: Call `upload_job_input_file` with the `jobId` and the generated Base64 string under `body.data`.
 
-#### Step 3.5 (Optional): Update Settings (`update_job_settings`)
-- Call `update_job_settings` with the `jobId` if you need to override default clearance classes, passes, optimizer settings, or rules.
+#### Step 3.5 (Optional): Update Settings or Rules (`update_job_settings` or `.rules` upload)
+- Call `update_job_settings` with the `jobId` if you need to override default clearance classes, passes, or optimizer settings.
+- If a `.rules` file is available, it can also be submitted via the API (`POST /v1/jobs/{jobId}/rules`) to supply custom design rules, net classes, clearances, and layer routing costs.
 
 #### Step 4: Start and Poll the Job (`start_job` & `get_job_details`)
 - **Start**: Call `start_job` with the `jobId`.

--- a/docs/command_line_arguments.md
+++ b/docs/command_line_arguments.md
@@ -29,7 +29,7 @@ Below is a comprehensive list of command-line options available in Freerouting, 
     - Freerouting design rules file (`.rules` - optional)
 
   The DSN file is mandatory, while the SES and RULES files are optional.
-  They can be provided in any order, separately or appended by the `+` sign (e.g. `-de myboard.dsn+myboard.ses+myboard.rules`).
+  They can be provided in any order, separately or combined with the `+` delimiter (e.g. `-de myboard.dsn+myboard.ses+myboard.rules` or `-de myboard.dsn+myboard.rules`). When a `.rules` file is loaded, its design rules, net classes, clearances, via definitions, and `(autoroute_settings ...)` / `(layer_rule ...)` parameters are applied to the board and autorouter configuration. If no rules file is explicitly specified, Freerouting will automatically look for an adjacent `<boardname>.rules` file in the same directory as the DSN file.
 
 - **`-do [design output file]`**
   Saves the routing results when the routing is finished. The output can be:
@@ -43,7 +43,7 @@ Below is a comprehensive list of command-line options available in Freerouting, 
   Sets the default folder for the open design dialogs when using the GUI.
 
 - **`-dr [design rules file]`**
-  Reads design rules from a previously saved `.rules` file.
+  Reads design rules from an explicit `.rules` file. Supports design rules, net classes, clearances, via definitions, and `(autoroute_settings ...)` / `(layer_rule ...)` blocks.
 
 - **`-drc [design rules check json file]`**
   Writes the design rules check report in KiCad JSON DRC schema format.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -287,6 +287,17 @@ Settings are resolved by the `SettingsMerger` class, which collects all active `
 
 If a setting is not defined in any source, the hardcoded default from `DefaultSettings` is used.
 
+### Specctra `.rules` File Settings (Priority 40)
+
+When a `.rules` file is provided (via CLI `-dr`, `-de board.dsn+board.rules`, API `POST /v1/jobs/{jobId}/rules`, or an adjacent `<designName>.rules` file), `RulesFileSettings` parses both general routing rules and the `(autoroute_settings ...)` block. Supported parameters include:
+- `(autoroute on|off)` / `(postroute on|off)` / `(vias on|off)`
+- `(via_costs <int>)`, `(plane_via_costs <int>)`, `(start_ripup_costs <int>)`
+- Per-layer settings via `(layer_rule <layer_name> ...)`:
+  - `(active on|off)`
+  - `(preferred_direction horizontal|vertical)`
+  - `(preferred_direction_trace_costs <float>)`
+  - `(against_preferred_direction_trace_costs <float>)`
+
 ## Storage Locations
 
 Freerouting stores configuration (`freerouting.json`), user data (`data/`), and logs (`freerouting.log`) in dedicated, platform-standard operating system directories:

--- a/src/main/java/app/freerouting/Freerouting.java
+++ b/src/main/java/app/freerouting/Freerouting.java
@@ -126,6 +126,23 @@ public class Freerouting {
     settingsMerger.addOrReplaceSources(
         new DsnFileSettings(routingJob.input.getData(), routingJob.input.getFilename()));
 
+    if (globalSettings.initialRulesFile != null) {
+      try {
+        routingJob.setRules(globalSettings.initialRulesFile);
+        if (routingJob.rules != null && routingJob.rules.getData() != null) {
+          settingsMerger.addOrReplaceSources(
+              new app.freerouting.settings.sources.RulesFileSettings(
+                  routingJob.rules.getData(), routingJob.rules.getFilename()));
+        }
+      } catch (Exception e) {
+        FRLogger.warn(
+            "Couldn't load rules file '"
+                + globalSettings.initialRulesFile
+                + "': "
+                + e.getMessage());
+      }
+    }
+
     routingJob.routerSettings = settingsMerger.merge();
     routingJob.drcSettings = Freerouting.globalSettings.drcSettings.clone();
     routingJob.state = RoutingJobState.READY_TO_START;
@@ -254,6 +271,26 @@ public class Freerouting {
     if (!BoardLoader.loadBoardIfNeeded(drcJob)) {
       FRLogger.error("Failed to load board for DRC check", null);
       System.exit(1);
+    }
+
+    // Load rules file if specified for DRC
+    if (globalSettings.initialRulesFile != null) {
+      try {
+        java.io.File rulesFile = new java.io.File(globalSettings.initialRulesFile);
+        if (rulesFile.exists()) {
+          FRLogger.info("Loading RULES file for DRC: " + globalSettings.initialRulesFile);
+          try (java.io.FileInputStream rulesStream = new java.io.FileInputStream(rulesFile)) {
+            String designName = drcJob.name != null ? drcJob.name : "board";
+            app.freerouting.io.specctra.RulesReader.read(
+                rulesStream, designName, drcJob.board, drcJob.routerSettings);
+            FRLogger.info("RULES file loaded for DRC successfully");
+          }
+        } else {
+          FRLogger.warn("RULES file for DRC not found: " + globalSettings.initialRulesFile);
+        }
+      } catch (Exception e) {
+        FRLogger.error("Failed to load RULES file for DRC", e);
+      }
     }
 
     // Load session file if specified for DRC

--- a/src/main/java/app/freerouting/api/v1/JobControllerV1.java
+++ b/src/main/java/app/freerouting/api/v1/JobControllerV1.java
@@ -305,6 +305,46 @@ public class JobControllerV1 extends BaseController {
     return new JobInputResource().uploadInput(jobId, requestBody);
   }
 
+  /** Upload design rules for the job in Specctra RULES format (.rules). */
+  @Operation(
+      summary = "Upload job design rules file",
+      description =
+          "Uploads a Specctra design rules (.rules) file for a routing job. The file must be"
+              + " Base64-encoded. For MCP/LLM clients, it is recommended to use the local"
+              + " 'encode_base64' tool to perform this conversion rather than running terminal"
+              + " commands.")
+  @RequestBody(
+      description = "Board file payload with Base64-encoded rules data",
+      required = true,
+      content =
+          @Content(
+              mediaType = MediaType.APPLICATION_JSON,
+              schema = @Schema(implementation = BoardFilePayload.class)))
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Rules uploaded successfully",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = RoutingJob.class))),
+        @ApiResponse(responseCode = "404", description = "Job not found"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid rules data or job already started")
+      })
+  @Path("/{jobId}/rules")
+  public Response uploadRules(
+      @Parameter(
+              description = "Unique identifier of the job",
+              example = "550e8400-e29b-41d4-a716-446655440000")
+          @PathParam("jobId")
+          String jobId,
+      String requestBody) {
+    return new JobInputResource().uploadRules(jobId, requestBody);
+  }
+
   /**
    * Upload the input of the job in KiCad JSON format. The JSON payload is sent as the raw request
    * body (not Base64-encoded), which is more efficient for the IPC bridge workflow where the Python

--- a/src/main/java/app/freerouting/api/v1/JobInputResource.java
+++ b/src/main/java/app/freerouting/api/v1/JobInputResource.java
@@ -347,6 +347,110 @@ public class JobInputResource extends BaseController {
     }
   }
 
+  /** Upload design rules for the job in Specctra RULES format (.rules). */
+  @Operation(
+      summary = "Upload job design rules file",
+      description =
+          "Uploads a Specctra design rules (.rules) file for a routing job. The file must be"
+              + " Base64-encoded. For MCP/LLM clients, it is recommended to use the local"
+              + " 'encode_base64' tool to perform this conversion rather than running terminal"
+              + " commands.")
+  @RequestBody(
+      description = "Board file payload with Base64-encoded rules data",
+      required = true,
+      content =
+          @Content(
+              mediaType = MediaType.APPLICATION_JSON,
+              schema = @Schema(implementation = BoardFilePayload.class)))
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Rules uploaded successfully",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = RoutingJob.class))),
+        @ApiResponse(responseCode = "404", description = "Job not found"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid rules data or job already started")
+      })
+  @POST
+  @Path("/{jobId}/rules")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Response uploadRules(
+      @Parameter(
+              description = "Unique identifier of the job",
+              example = "550e8400-e29b-41d4-a716-446655440000")
+          @PathParam("jobId")
+          String jobId,
+      String requestBody) {
+    UUID userId = authenticateUser();
+
+    var job = RoutingJobScheduler.getInstance().getJob(jobId);
+    if (job == null) {
+      return Response.status(Response.Status.NOT_FOUND).entity("{}").build();
+    }
+
+    Session session = SessionManager.getInstance().getSession(job.sessionId.toString(), userId);
+    if (session == null) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity("{\"error\":\"The session ID '" + job.sessionId + "' is invalid.\"}")
+          .build();
+    }
+
+    if (job.state != RoutingJobState.QUEUED) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity("{\"error\":\"The job is already started and cannot be changed.\"}")
+          .build();
+    }
+
+    BoardFilePayload payload = GSON.fromJson(requestBody, BoardFilePayload.class);
+    if (payload == null || payload.dataBase64 == null || payload.dataBase64.isEmpty()) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity(
+              "{\"error\":\"The rules data must be base-64 encoded and put into the \\\"data\\\""
+                  + " field.\"}")
+          .build();
+    }
+
+    byte[] rulesByteArray;
+    try {
+      rulesByteArray = Base64.getDecoder().decode(payload.dataBase64);
+    } catch (IllegalArgumentException e) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity("{\"error\":\"Invalid base64 encoding for rules file.\"}")
+          .build();
+    }
+
+    if (rulesByteArray.length > MAX_INPUT_PAYLOAD_BYTES) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity("{\"error\":\"Rules file exceeds maximum allowed size of 100MB.\"}")
+          .build();
+    }
+
+    if (!job.setRules(rulesByteArray)) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity("{\"error\":\"The rules data is invalid.\"}")
+          .build();
+    }
+
+    if (payload.getFilename() != null && !payload.getFilename().isEmpty()) {
+      job.rules.setFilename(payload.getFilename());
+    } else {
+      job.rules.setFilename(job.name != null ? job.name + ".rules" : "design.rules");
+    }
+
+    var request =
+        GSON.toJson(payload)
+            .replace(payload.dataBase64, TextManager.shortenString(payload.dataBase64, 4));
+    var response = GSON.toJson(job);
+    FRAnalytics.apiEndpointCalled("POST v1/jobs/" + jobId + "/rules", request, response, userId);
+    return Response.ok(response).build();
+  }
+
   /**
    * Upload the input of the job in KiCad JSON format. The JSON payload is sent as the raw request
    * body (not Base64-encoded), which is more efficient for the IPC bridge workflow where the Python

--- a/src/main/java/app/freerouting/core/RoutingJob.java
+++ b/src/main/java/app/freerouting/core/RoutingJob.java
@@ -92,6 +92,10 @@ public class RoutingJob implements Serializable, Comparable<RoutingJob> {
   @Schema(description = "Details of the routed output design file")
   public BoardFileDetails output;
 
+  @SerializedName("rules")
+  @Schema(description = "Details of the uploaded design rules (.rules) file")
+  public BoardFileDetails rules;
+
   @SerializedName("drc")
   @Schema(description = "Details of the design rules check output")
   public BoardFileDetails drc;
@@ -205,6 +209,14 @@ public class RoutingJob implements Serializable, Comparable<RoutingJob> {
                 && buffer[3] == (byte) 0x53)) {
           return FileFormat.SES;
         }
+
+        // Check if the file is a RULES file (it starts with "(rules" or "(RULES")
+        if (buffer[0] == (byte) 0x28
+            && (buffer[1] == (byte) 0x72 || buffer[1] == (byte) 0x52)
+            && (buffer[2] == (byte) 0x75 || buffer[2] == (byte) 0x55)
+            && (buffer[3] == (byte) 0x6C || buffer[3] == (byte) 0x4C)) {
+          return FileFormat.RULES;
+        }
       }
     } catch (IOException _) {
       // Ignore the exception, it can happen with the built-in template or if the user
@@ -224,6 +236,7 @@ public class RoutingJob implements Serializable, Comparable<RoutingJob> {
         case DSN_FILE_EXTENSION -> FileFormat.DSN;
         case BINARY_FILE_EXTENSION -> FileFormat.FRB;
         case "ses" -> FileFormat.SES;
+        case RULES_FILE_EXTENSION -> FileFormat.RULES;
         case "scr" -> FileFormat.SCR;
         case "json" -> FileFormat.KICAD_DESIGN_JSON;
         default -> FileFormat.UNKNOWN;
@@ -269,6 +282,31 @@ public class RoutingJob implements Serializable, Comparable<RoutingJob> {
   /** Loads the input file from the specified file. */
   public void setInput(File inputFile) throws IOException {
     setInputFromFile(inputFile);
+  }
+
+  /** Sets the rules from file content. */
+  public boolean setRules(byte[] rulesFileContent) {
+    this.rules = new BoardFileDetails();
+    this.rules.format = FileFormat.RULES;
+    this.rules.setData(rulesFileContent);
+    return true;
+  }
+
+  /** Loads the rules file from the specified path. */
+  public void setRules(String rulesFilePath) throws IOException {
+    setRules(new File(rulesFilePath));
+  }
+
+  /** Loads the rules file from the specified file. */
+  public void setRules(File rulesFile) throws IOException {
+    if (rulesFile != null && rulesFile.exists()) {
+      try (InputStream in = new FileInputStream(rulesFile)) {
+        this.rules = new BoardFileDetails();
+        this.rules.format = FileFormat.RULES;
+        this.rules.setFilename(rulesFile.getName());
+        this.rules.setData(in.readAllBytes());
+      }
+    }
   }
 
   /** Returns the rules file associated with the output file. */

--- a/src/main/java/app/freerouting/gui/board/GuiManager.java
+++ b/src/main/java/app/freerouting/gui/board/GuiManager.java
@@ -511,7 +511,11 @@ public class GuiManager {
       FRLogger.info("Opening '" + rulesFileName + "'...");
       try (InputStream inputStream = new FileInputStream(rulesFile)) {
         if (dsnFileGeneratedByHost && WindowMessage.confirm(confirmMessage)) {
-          return RulesReader.read(inputStream, designName, boardHandling.getRoutingBoard());
+          return RulesReader.read(
+              inputStream,
+              designName,
+              boardHandling.getRoutingBoard(),
+              boardHandling.getCurrentRoutingJob().routerSettings);
         }
       }
     } catch (IOException e) {

--- a/src/main/java/app/freerouting/io/specctra/RulesReader.java
+++ b/src/main/java/app/freerouting/io/specctra/RulesReader.java
@@ -3,6 +3,7 @@ package app.freerouting.io.specctra;
 import app.freerouting.board.facade.BasicBoard;
 import app.freerouting.board.model.structure.AngleRestriction;
 import app.freerouting.io.CoordinateTransform;
+import app.freerouting.io.specctra.parser.AutorouteSettings;
 import app.freerouting.io.specctra.parser.IJFlexScanner;
 import app.freerouting.io.specctra.parser.Keyword;
 import app.freerouting.io.specctra.parser.LayerStructure;
@@ -15,6 +16,8 @@ import app.freerouting.io.specctra.parser.SpecctraDsnStreamReader;
 import app.freerouting.io.specctra.parser.Structure;
 import app.freerouting.logger.FRLogger;
 import app.freerouting.rules.ViaInfo;
+import app.freerouting.settings.RouterSettings;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
@@ -42,6 +45,25 @@ public final class RulesReader {
    *     parse or I/O error
    */
   public static boolean read(InputStream in, String designName, BasicBoard board) {
+    return read(in, designName, board, null);
+  }
+
+  /**
+   * Reads the rules from {@code in} and applies them to {@code board} and optional {@code
+   * targetSettings}.
+   *
+   * <p>The stream is closed by this method on return (success or failure).
+   *
+   * @param in source — closed by this method on completion
+   * @param designName expected PCB design name in the rules header (mismatch is logged but does not
+   *     abort the read)
+   * @param board the board to which parsed rules are applied
+   * @param targetSettings optional router settings to update with parsed autoroute_settings
+   * @return {@code true} if the rules were parsed and applied successfully; {@code false} on any
+   *     parse or I/O error
+   */
+  public static boolean read(
+      InputStream in, String designName, BasicBoard board, RouterSettings targetSettings) {
     if (in == null) {
       FRLogger.warn("RulesReader.read: input stream is null");
       return false;
@@ -128,6 +150,11 @@ public final class RulesReader {
             if (snapAngle != null) {
               board.rules.setTraceAngleRestriction(snapAngle);
             }
+          } else if (nextToken == Keyword.AUTOROUTE_SETTINGS) {
+            RouterSettings parsedSettings = AutorouteSettings.readScope(scanner, layerStructure);
+            if (targetSettings != null && parsedSettings != null) {
+              targetSettings.applyNewValuesFrom(parsedSettings);
+            }
           } else {
             ScopeKeyword.skipScope(scanner);
           }
@@ -140,6 +167,110 @@ public final class RulesReader {
     } finally {
       closeQuietly(in);
     }
+  }
+
+  /**
+   * Reads only the {@link RouterSettings} from a rules file stream.
+   *
+   * <p>The stream is closed by this method on return.
+   *
+   * @param in source stream
+   * @return extracted {@link RouterSettings}, or {@code null} if not found or on error
+   */
+  public static RouterSettings readRouterSettings(InputStream in) {
+    if (in == null) {
+      return null;
+    }
+    byte[] data;
+    try {
+      data = in.readAllBytes();
+    } catch (IOException e) {
+      FRLogger.error("RulesReader.readRouterSettings: error reading stream", e);
+      return null;
+    } finally {
+      closeQuietly(in);
+    }
+
+    if (data.length == 0) {
+      return null;
+    }
+
+    LayerStructure layerStructure = discoverLayerStructure(data);
+    IJFlexScanner scanner = new SpecctraDsnStreamReader(new ByteArrayInputStream(data));
+    try {
+      // Validate header
+      Object currentToken = scanner.nextToken();
+      if (currentToken != Keyword.OPEN_BRACKET) {
+        return null;
+      }
+      currentToken = scanner.nextToken();
+      if (currentToken != Keyword.RULES) {
+        return null;
+      }
+      currentToken = scanner.nextToken();
+      if (currentToken != Keyword.PCB_SCOPE) {
+        return null;
+      }
+      scanner.yybegin(SpecctraDsnStreamReader.NAME);
+      scanner.nextToken(); // designName
+
+      Object nextToken = null;
+      for (; ; ) {
+        final Object prevToken = nextToken;
+        nextToken = scanner.nextToken();
+        if (nextToken == null || nextToken == Keyword.CLOSED_BRACKET) {
+          break;
+        }
+        if (prevToken == Keyword.OPEN_BRACKET) {
+          if (nextToken == Keyword.AUTOROUTE_SETTINGS) {
+            return AutorouteSettings.readScope(scanner, layerStructure);
+          } else {
+            ScopeKeyword.skipScope(scanner);
+          }
+        }
+      }
+    } catch (IOException e) {
+      FRLogger.error("RulesReader.readRouterSettings: IO error scanning file", e);
+    }
+    return null;
+  }
+
+  private static LayerStructure discoverLayerStructure(byte[] data) {
+    java.util.LinkedHashSet<String> layerNames = new java.util.LinkedHashSet<>();
+    IJFlexScanner scanner = new SpecctraDsnStreamReader(new java.io.ByteArrayInputStream(data));
+    try {
+      Object token = null;
+      for (; ; ) {
+        Object prev = token;
+        token = scanner.nextToken();
+        if (token == null) {
+          break;
+        }
+        if (prev == Keyword.OPEN_BRACKET) {
+          if (token == Keyword.LAYER_RULE || token == Keyword.LAYER) {
+            scanner.yybegin(SpecctraDsnStreamReader.NAME);
+            Object nameToken = scanner.nextToken();
+            if (nameToken instanceof String s && !s.isBlank()) {
+              layerNames.add(s);
+            }
+          }
+        }
+      }
+    } catch (IOException _) {
+      // ignore
+    }
+
+    if (layerNames.isEmpty()) {
+      layerNames.add("F.Cu");
+      layerNames.add("B.Cu");
+    }
+
+    java.util.List<app.freerouting.io.specctra.parser.Layer> list = new java.util.ArrayList<>();
+    int idx = 0;
+    for (String name : layerNames) {
+      list.add(new app.freerouting.io.specctra.parser.Layer(name, idx++, true));
+    }
+    return new LayerStructure(list);
   }
 
   // -------------------------------------------------------------------------

--- a/src/main/java/app/freerouting/io/specctra/RulesWriter.java
+++ b/src/main/java/app/freerouting/io/specctra/RulesWriter.java
@@ -9,6 +9,7 @@ import app.freerouting.io.specctra.parser.Network;
 import app.freerouting.io.specctra.parser.Rule;
 import app.freerouting.io.specctra.parser.Structure;
 import app.freerouting.io.specctra.parser.WriteScopeParameter;
+import app.freerouting.settings.RouterSettings;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -34,11 +35,30 @@ public final class RulesWriter {
    */
   public static void write(BasicBoard board, OutputStream out, String designName)
       throws IOException {
+    write(board, null, out, designName);
+  }
+
+  /**
+   * Writes the design rules of {@code board} and optional {@code settings} to {@code out} in
+   * Specctra rules format.
+   *
+   * <p>The stream is <em>not</em> closed by this method — the caller is responsible.
+   *
+   * @param board the board whose rules are written
+   * @param settings optional router settings to serialize into the {@code (autoroute_settings ...)}
+   *     scope
+   * @param out destination stream
+   * @param designName the PCB design name written into the {@code (rules PCB ...)} header
+   * @throws IOException if writing fails
+   */
+  public static void write(
+      BasicBoard board, RouterSettings settings, OutputStream out, String designName)
+      throws IOException {
     IndentFileWriter outputFile = new IndentFileWriter(out);
     WriteScopeParameter scopeParameter =
         new WriteScopeParameter(
             board,
-            null,
+            settings,
             outputFile,
             board.communication.specctraParserInfo.stringQuote,
             board.communication.coordinateTransform,

--- a/src/main/java/app/freerouting/io/specctra/parser/AutorouteSettings.java
+++ b/src/main/java/app/freerouting/io/specctra/parser/AutorouteSettings.java
@@ -15,7 +15,7 @@ public final class AutorouteSettings {
 
   private AutorouteSettings() {}
 
-  static RouterSettings readScope(IJFlexScanner scanner, LayerStructure layerStructure) {
+  public static RouterSettings readScope(IJFlexScanner scanner, LayerStructure layerStructure) {
     RouterSettings result = new RouterSettings();
     result.setLayerCount(layerStructure.layers.length);
     boolean withAutoroute = true;
@@ -163,7 +163,7 @@ public final class AutorouteSettings {
       IdentifierType identifierType)
       throws IOException {
     file.startScope();
-    file.write("autorouteSettings");
+    file.write("autoroute_settings");
     file.newLine();
     file.write("(autoroute ");
     if (settings.getRunRouter()) {
@@ -186,7 +186,7 @@ public final class AutorouteSettings {
       file.write("off)");
     }
     file.newLine();
-    file.write("(viaCosts ");
+    file.write("(via_costs ");
     {
       int viaCosts = settings.getViaCosts();
       file.write(String.valueOf(viaCosts));
@@ -200,7 +200,7 @@ public final class AutorouteSettings {
     }
     file.write(")");
     file.newLine();
-    file.write("(startRipupCosts ");
+    file.write("(start_ripup_costs ");
     {
       int ripupCosts = settings.getStartRipupCosts();
       file.write(String.valueOf(ripupCosts));

--- a/src/main/java/app/freerouting/management/jobs/RoutingJobScheduler.java
+++ b/src/main/java/app/freerouting/management/jobs/RoutingJobScheduler.java
@@ -8,6 +8,7 @@ import app.freerouting.core.RoutingJobState;
 import app.freerouting.core.Session;
 import app.freerouting.core.StoppableThread;
 import app.freerouting.io.FileFormat;
+import app.freerouting.io.specctra.RulesReader;
 import app.freerouting.io.specctra.SesImportSummary;
 import app.freerouting.io.specctra.SesReader;
 import app.freerouting.logger.FRLogger;
@@ -16,8 +17,10 @@ import app.freerouting.management.sessions.SessionManager;
 import app.freerouting.settings.GlobalSettings;
 import app.freerouting.settings.sources.ApiSettings;
 import app.freerouting.settings.sources.DsnFileSettings;
+import app.freerouting.settings.sources.RulesFileSettings;
 import app.freerouting.util.TextManager;
 import app.freerouting.util.gson.GsonProvider;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -105,6 +108,55 @@ public final class RoutingJobScheduler {
                                         job.input.getData(), job.input.getFilename()));
                               }
 
+                              // Rules file from job.rules, CLI initialRulesFile, or adjacent
+                              // <designName>.rules
+                              byte[] rulesData = null;
+                              String rulesFilename = null;
+                              if (job.rules != null && job.rules.getData() != null) {
+                                rulesData = job.rules.getData().readAllBytes();
+                                rulesFilename = job.rules.getFilename();
+                              } else if (globalSettings.initialRulesFile != null) {
+                                java.io.File rf = new java.io.File(globalSettings.initialRulesFile);
+                                if (rf.exists()) {
+                                  try {
+                                    rulesData = Files.readAllBytes(rf.toPath());
+                                    rulesFilename = rf.getName();
+                                  } catch (IOException e) {
+                                    FRLogger.warn(
+                                        "Failed to read rules file: "
+                                            + rf.getPath()
+                                            + ": "
+                                            + e.getMessage());
+                                  }
+                                }
+                              } else if (isDsn && job.input.getDirectoryPath() != null) {
+                                String baseName = job.input.getFilename();
+                                if (baseName.lastIndexOf('.') > 0) {
+                                  baseName = baseName.substring(0, baseName.lastIndexOf('.'));
+                                }
+                                java.io.File autoRules =
+                                    new java.io.File(
+                                        job.input.getDirectoryPath(), baseName + ".rules");
+                                if (autoRules.exists()) {
+                                  try {
+                                    rulesData = Files.readAllBytes(autoRules.toPath());
+                                    rulesFilename = autoRules.getName();
+                                  } catch (IOException e) {
+                                    FRLogger.warn(
+                                        "Failed to read adjacent rules file: "
+                                            + autoRules.getPath()
+                                            + ": "
+                                            + e.getMessage());
+                                  }
+                                }
+                              }
+
+                              if (rulesData != null) {
+                                settingsMerger.addOrReplaceSources(
+                                    new RulesFileSettings(
+                                        new ByteArrayInputStream(rulesData), rulesFilename));
+                              }
+
                               // Keep per-job overrides (e.g. tests toggling fanout/optimizer) by
                               // applying the job's current settings as highest-priority API
                               // settings.
@@ -116,6 +168,21 @@ public final class RoutingJobScheduler {
                               // Apply the final merged settings to the job and optimize them for
                               // the board
                               job.routerSettings = settingsMerger.merge();
+
+                              // Apply rules from rules file onto the board and routerSettings
+                              if (rulesData != null && job.board != null) {
+                                try {
+                                  String designName = job.name != null ? job.name : "board";
+                                  RulesReader.read(
+                                      new ByteArrayInputStream(rulesData),
+                                      designName,
+                                      job.board,
+                                      job.routerSettings);
+                                } catch (Exception e) {
+                                  FRLogger.error("Failed to apply rules from rules file", e);
+                                }
+                              }
+
                               job.routerSettings.applyBoardSpecificOptimizations(job.board);
 
                               // Load session file if specified

--- a/src/main/java/app/freerouting/settings/sources/RulesFileSettings.java
+++ b/src/main/java/app/freerouting/settings/sources/RulesFileSettings.java
@@ -1,8 +1,13 @@
 package app.freerouting.settings.sources;
 
+import app.freerouting.io.specctra.RulesReader;
 import app.freerouting.logger.FRLogger;
 import app.freerouting.settings.RouterSettings;
 import app.freerouting.settings.SettingsSource;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.file.Path;
 
 /**
  * Extracts router settings from RULES files. Only the settings present in the RULES file will be
@@ -15,19 +20,71 @@ public class RulesFileSettings implements SettingsSource {
   private final String fileName;
 
   /**
-   * Creates a RulesFileSettings source from a RULES file.
+   * Creates a RulesFileSettings source from an input stream.
    *
+   * @param in Input stream of the RULES file
    * @param fileName Name of the RULES file (for logging)
+   */
+  public RulesFileSettings(InputStream in, String fileName) {
+    this.fileName = fileName;
+    this.settings = loadSettings(in);
+  }
+
+  /**
+   * Creates a RulesFileSettings source from a File.
+   *
+   * @param file the RULES file
+   */
+  public RulesFileSettings(File file) {
+    this.fileName = file != null ? file.getName() : "unknown.rules";
+    this.settings = file != null && file.exists() ? loadFromFile(file) : new RouterSettings();
+  }
+
+  /**
+   * Creates a RulesFileSettings source from a Path.
+   *
+   * @param path Path to the RULES file
+   */
+  public RulesFileSettings(Path path) {
+    this(path != null ? path.toFile() : null);
+  }
+
+  /**
+   * Creates a RulesFileSettings source from a RULES file path/name.
+   *
+   * @param fileName Name or path of the RULES file (for logging)
    */
   public RulesFileSettings(String fileName) {
     this.fileName = fileName;
-    this.settings = loadSettings();
+    if (fileName != null) {
+      File f = new File(fileName);
+      if (f.exists()) {
+        this.settings = loadFromFile(f);
+      } else {
+        this.settings = new RouterSettings();
+      }
+    } else {
+      this.settings = new RouterSettings();
+    }
   }
 
-  private RouterSettings loadSettings() {
+  private RouterSettings loadFromFile(File file) {
+    try (InputStream in = new FileInputStream(file)) {
+      return loadSettings(in);
+    } catch (Exception e) {
+      FRLogger.warn(
+          "Failed to load settings from RULES file: " + file.getName() + ": " + e.getMessage());
+      return new RouterSettings();
+    }
+  }
+
+  private RouterSettings loadSettings(InputStream in) {
     try {
-      // Design rules from .rules files are applied to the board via RulesReader;
-      // this source is a structural placeholder for behavioral RouterSettings.
+      RouterSettings extracted = RulesReader.readRouterSettings(in);
+      if (extracted != null) {
+        FRLogger.debug("Loaded router settings from RULES file: " + fileName);
+        return extracted;
+      }
       return new RouterSettings();
     } catch (Exception e) {
       FRLogger.warn("Failed to load settings from RULES file: " + fileName + ": " + e.getMessage());

--- a/src/test/java/app/freerouting/api/v1/JobInputResourceTest.java
+++ b/src/test/java/app/freerouting/api/v1/JobInputResourceTest.java
@@ -49,4 +49,26 @@ class JobInputResourceTest {
     Response response = resource.uploadInputJson(jobId, "");
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
   }
+
+  @Test
+  void uploadRulesRejectsMalformedBase64() {
+    String malformedPayload = "{\"data\":\"%%%not-valid-base64%%%\"}";
+    Response response = resource.uploadRules(jobId, malformedPayload);
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  void uploadRulesAcceptsValidBase64() {
+    String rulesContent = "(rules PCB test (snap_angle fortyfive_degree))";
+    String base64 =
+        java.util.Base64.getEncoder()
+            .encodeToString(rulesContent.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    String payload = "{\"data\":\"" + base64 + "\",\"filename\":\"test.rules\"}";
+    Response response = resource.uploadRules(jobId, payload);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    RoutingJob job = RoutingJobScheduler.getInstance().getJob(jobId);
+    org.junit.jupiter.api.Assertions.assertNotNull(job.rules);
+    assertEquals("test.rules", job.rules.getFilename());
+  }
 }

--- a/src/test/java/app/freerouting/api/v1/JobResourceContractTest.java
+++ b/src/test/java/app/freerouting/api/v1/JobResourceContractTest.java
@@ -56,6 +56,7 @@ class JobResourceContractTest {
             "POST /v1/jobs/{jobId}/settings",
             "POST /v1/jobs/{jobId}/input",
             "POST /v1/jobs/{jobId}/input/json",
+            "POST /v1/jobs/{jobId}/rules",
             "GET /v1/jobs/{jobId}/output",
             "GET /v1/jobs/{jobId}/output/json",
             "GET /v1/jobs/{jobId}/output/stream",

--- a/src/test/java/app/freerouting/io/specctra/RulesRoundTripTest.java
+++ b/src/test/java/app/freerouting/io/specctra/RulesRoundTripTest.java
@@ -1,5 +1,6 @@
 package app.freerouting.io.specctra;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -9,6 +10,7 @@ import app.freerouting.Freerouting;
 import app.freerouting.board.facade.RoutingBoard;
 import app.freerouting.io.BoardReadResult;
 import app.freerouting.settings.GlobalSettings;
+import app.freerouting.settings.RouterSettings;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -40,6 +42,51 @@ class RulesRoundTripTest {
     InputStream in = new ByteArrayInputStream(out.toByteArray());
     boolean ok = RulesReader.read(in, "Issue029-hw48na", board);
     assertTrue(ok, "RulesReader.read must return true on valid input");
+  }
+
+  @Test
+  void rulesRoundTripWithAutorouteSettings() throws Exception {
+    RoutingBoard board = DsnTestFixtures.loadBoard("Issue029-hw48na.dsn");
+
+    RouterSettings settings = new RouterSettings();
+    settings.setLayerCount(board.getLayerCount());
+    settings.setViaCosts(75);
+    settings.setPlaneViaCosts(8);
+    settings.setStartRipupCosts(120);
+    settings.setLayerActive(0, true);
+    settings.setLayerActive(1, true);
+    settings.setPreferredDirectionIsHorizontal(0, true);
+    settings.setPreferredDirectionIsHorizontal(1, false);
+    settings.setPreferredDirectionTraceCosts(0, 1.2);
+    settings.setAgainstPreferredDirectionTraceCosts(0, 2.8);
+    settings.setPreferredDirectionTraceCosts(1, 1.0);
+    settings.setAgainstPreferredDirectionTraceCosts(1, 3.1);
+
+    // Write rules with autoroute settings
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    RulesWriter.write(board, settings, out, "Issue029-hw48na");
+
+    String content = out.toString(StandardCharsets.UTF_8);
+    assertTrue(
+        content.contains("(autoroute_settings"),
+        "Rules file must contain autoroute_settings scope");
+    assertTrue(content.contains("(layer_rule"), "Rules file must contain layer_rule scopes");
+
+    // Read back rules and verify settings are populated
+    RouterSettings targetSettings = new RouterSettings();
+    InputStream in = new ByteArrayInputStream(out.toByteArray());
+    boolean ok = RulesReader.read(in, "Issue029-hw48na", board, targetSettings);
+    assertTrue(ok, "RulesReader.read must return true on valid input");
+
+    assertEquals(75, targetSettings.getViaCosts());
+    assertEquals(8, targetSettings.getPlaneViaCosts());
+    assertEquals(120, targetSettings.getStartRipupCosts());
+    assertTrue(targetSettings.getPreferredDirectionIsHorizontal(0));
+    assertFalse(targetSettings.getPreferredDirectionIsHorizontal(1));
+    assertEquals(1.2, targetSettings.getPreferredDirectionTraceCosts(0));
+    assertEquals(2.8, targetSettings.getAgainstPreferredDirectionTraceCosts(0));
+    assertEquals(1.0, targetSettings.getPreferredDirectionTraceCosts(1));
+    assertEquals(3.1, targetSettings.getAgainstPreferredDirectionTraceCosts(1));
   }
 
   @Test

--- a/src/test/java/app/freerouting/settings/sources/RulesFileSettingsTest.java
+++ b/src/test/java/app/freerouting/settings/sources/RulesFileSettingsTest.java
@@ -1,0 +1,81 @@
+package app.freerouting.settings.sources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import app.freerouting.settings.RouterSettings;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+
+class RulesFileSettingsTest {
+
+  @Test
+  void priorityIs40() {
+    RulesFileSettings source = new RulesFileSettings("dummy.rules");
+    assertEquals(40, source.getPriority());
+    assertEquals("RULES file: dummy.rules", source.getSourceName());
+  }
+
+  @Test
+  void parsesAutorouteSettingsFromProcessorRules() throws Exception {
+    File rulesFile = new File("fixtures/Issue191-processor.Z80/processor.rules");
+    assertTrue(rulesFile.exists(), "processor.rules must exist");
+
+    try (InputStream in = new FileInputStream(rulesFile)) {
+      RulesFileSettings source = new RulesFileSettings(in, "processor.rules");
+      RouterSettings settings = source.getSettings();
+      assertNotNull(settings);
+
+      assertEquals(true, settings.getViasAllowed());
+      assertEquals(50, settings.getViaCosts());
+      assertEquals(5, settings.getPlaneViaCosts());
+      assertEquals(100, settings.getStartRipupCosts());
+      assertEquals(true, settings.getRunRouter());
+      assertEquals(true, settings.getRunOptimizer());
+      assertEquals(2, settings.getLayerCount());
+
+      assertTrue(settings.getLayerActive(0));
+      assertTrue(settings.getLayerActive(1));
+
+      // Layer 0: F.Cu horizontal, cost 1.0 / 2.5
+      assertTrue(settings.getPreferredDirectionIsHorizontal(0));
+      assertEquals(1.0, settings.getPreferredDirectionTraceCosts(0));
+      assertEquals(2.5, settings.getAgainstPreferredDirectionTraceCosts(0));
+
+      // Layer 1: B.Cu vertical, cost 1.0 / 1.7
+      assertFalse(settings.getPreferredDirectionIsHorizontal(1));
+      assertEquals(1.0, settings.getPreferredDirectionTraceCosts(1));
+      assertEquals(1.7, settings.getAgainstPreferredDirectionTraceCosts(1));
+    }
+  }
+
+  @Test
+  void parsesAutorouteSettingsFromHw48naRules() throws Exception {
+    File rulesFile = new File("fixtures/Issue029-hw48na_valid.rules");
+    assertTrue(rulesFile.exists(), "hw48na_valid.rules must exist");
+
+    RulesFileSettings source = new RulesFileSettings(rulesFile);
+    RouterSettings settings = source.getSettings();
+    assertNotNull(settings);
+
+    assertEquals(true, settings.getViasAllowed());
+    assertEquals(50, settings.getViaCosts());
+    assertEquals(5, settings.getPlaneViaCosts());
+    assertEquals(100, settings.getStartRipupCosts());
+    assertEquals(2, settings.getLayerCount());
+
+    // Layer 0: F.Cu vertical, cost 1.0 / 2.0
+    assertFalse(settings.getPreferredDirectionIsHorizontal(0));
+    assertEquals(1.0, settings.getPreferredDirectionTraceCosts(0));
+    assertEquals(2.0, settings.getAgainstPreferredDirectionTraceCosts(0));
+
+    // Layer 1: B.Cu horizontal, cost 1.0 / 2.0
+    assertTrue(settings.getPreferredDirectionIsHorizontal(1));
+    assertEquals(1.0, settings.getPreferredDirectionTraceCosts(1));
+    assertEquals(2.0, settings.getAgainstPreferredDirectionTraceCosts(1));
+  }
+}


### PR DESCRIPTION
## Description

This PR resolves #848 by implementing complete ingestion, parsing, and serialization of Specctra `.rules` files, including `(autoroute_settings ...)` and `(layer_rule ...)` scopes, along with CLI multi-input (`+`) and REST API integration.

### Summary of Changes

1. **Specctra `.rules` Parser & Serializer (`io.specctra`)**:
   - `RulesReader`: Added handling for `Keyword.AUTOROUTE_SETTINGS`, overloaded `read(..., RouterSettings targetSettings)` to update settings, and implemented `readRouterSettings(InputStream in)` with dynamic layer structure discovery.
   - `RulesWriter`: Added overloaded `write(BasicBoard board, RouterSettings settings, OutputStream out, String designName)` writing standard snake_case tokens (`autoroute_settings`, `via_costs`, `start_ripup_costs`, `layer_rule`).
   - `AutorouteSettings`: Exposed `readScope(IJFlexScanner, LayerStructure)` publicly and ensured snake_case token serialization in `writeScope`.

2. **Settings Priority Hierarchy (`settings.sources`)**:
   - `RulesFileSettings`: Implemented at priority 40 in `SettingsMerger` to provide configuration from `.rules` files.
   - `RoutingJobScheduler`: Automatically loads rules from `job.rules` (API mode), `globalSettings.initialRulesFile` (CLI `-dr` or `-de name.dsn+name.rules`), or adjacent `<designName>.rules` files, merges settings via `RulesFileSettings`, and applies rules to the board.
   - `Freerouting`: Integrated `RulesFileSettings` into CLI single-job setup and DRC check paths.

3. **REST API & Job Model (`core`, `api.v1`)**:
   - `RoutingJob`: Added `rules` field, `setRules(...)`, and updated `getFileFormat` to detect `FileFormat.RULES` from byte streams and `.rules` extensions.
   - `JobInputResource` / `JobControllerV1`: Added `POST /v1/jobs/{jobId}/rules` endpoint for Base64 `.rules` file uploads.

4. **Documentation**:
   - Updated `docs/API/API_v1.md` with `POST /v1/jobs/{jobId}/rules` endpoint specifications.
   - Updated `docs/command_line_arguments.md` for `-de` / `-dr` `.rules` loading and `+` concatenation.
   - Updated `docs/settings.md` detailing priority 40 and parsed `.rules` settings.
   - Updated `docs/API/MCP.md` with rules file workflows.

5. **Testing**:
   - Added `RulesFileSettingsTest` covering layer direction, active status, trace costs, and via costs parsing.
   - Added `rulesRoundTripWithAutorouteSettings` in `RulesRoundTripTest`.
   - Added `uploadRules` tests in `JobInputResourceTest` and updated `JobResourceContractTest`.
   - Verified that `./gradlew test` (474 unit tests) and `./gradlew spotlessCheck checkstyleMain checkstyleTest checkstyleRewriteRecipes` pass cleanly.

Fixes #848.
