### PR TITLE
Update README contributor notice after completing codebase refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ Freerouting is a powerful PCB autorouter compatible with any PCB design software
 >
 > For several years, I had been postponing a comprehensive overhaul and refactoring of the Freerouting codebase. As many of you have noticed, parts of it had become dated, with legacy constructs, inconsistent naming, and insufficient documentation.
 >
-> That refactoring is now underway, and is expected to be 100% complete by 30th August, 2026, which is also the target release date of version 2.4. The goal is to create a cleaner, more modern, and future-proof foundation for Freerouting.
+> That refactoring is now complete, creating a cleaner, more modern, and future-proof foundation for Freerouting. The next release can be expected in a few days.
 >
-> During this period, please keep pull requests as small and focused as possible. This will make it significantly easier to rebase them onto the refactored codebase afterward.
+> The codebase prior to the refactoring is tagged as [`pre-refactor-2026`](https://github.com/freerouting/freerouting/tree/pre-refactor-2026), and the completed refactored state is tagged as [`post-refactor-2026`](https://github.com/freerouting/freerouting/tree/post-refactor-2026). Anyone who prefers to continue working from the pre-refactoring version can use `pre-refactor-2026` as a stable starting point.
 >
-> The codebase prior to the refactoring is already tagged as [`pre-refactor-2026`](https://github.com/freerouting/freerouting/tree/pre-refactor-2026). Anyone who prefers to continue working from the pre-refactoring version can use that tag as a stable starting point. Once the refactoring is complete, the codebase will also be tagged as `post-refactor-2026`.
+> However, please keep in mind that future features and performance improvements will be developed exclusively on the upgraded codebase. Staying up to date with Freerouting will therefore require moving to the refactored version.
 >
-> However, please keep in mind that future features and performance improvements will be developed exclusively on the upgraded codebase. Staying up to date with Freerouting will therefore require moving to the refactored version eventually.
+> Contributors with forks containing custom modifications, as well as contributors with open pull requests, will need to rebase their work onto the refactored codebase. Depending on the changes involved, this may require some manual conflict resolution.
 >
-> Contributors with forks containing custom modifications, as well as contributors with open pull requests, will likely need to rebase their work once the refactoring is complete. Depending on the changes involved, this may require some manual conflict resolution.
+> I sincerely apologize for the extra effort. I know that nobody enjoys rebasing or resolving conflicts. The good news is that this provides a stable foundation for a long time, so we do not expect another change of this scale anytime soon.
 >
-> I sincerely apologize for the extra effort. I know that nobody enjoys rebasing or resolving conflicts. The good news is that this should provide a stable foundation for a long time, so we do not expect another change of this scale anytime soon.
+> I will keep this message here for 30 days to help the contributors.
 >
 > Thank you for your understanding, patience, and continued support of Freerouting.
 >


### PR DESCRIPTION
### Summary

- Update contributor notice in \README.md\ to state that the codebase refactoring is complete.
- Link the \post-refactor-2026\ tag alongside \pre-refactor-2026\.
- State that the next release can be expected in a few days (removing the original deadline).
- Mention that the message will be kept for 30 days to help contributors.