### PR TITLE
fix(gui): persist Net Class track width edits and commit changes on blur (#796)

### DIFF
--- a/src/main/java/app/freerouting/gui/controls/ColorManager.java
+++ b/src/main/java/app/freerouting/gui/controls/ColorManager.java
@@ -45,12 +45,14 @@ public class ColorManager extends BoardSavableSubWindow {
     panel.setPreferredSize(new Dimension(10 + tableWidth, 90 + itemColorTableHeight));
 
     layersColorTable = new JTable(graphicsContext.itemColorTable);
+    layersColorTable.putClientProperty("terminateEditOnFocusLost", Boolean.TRUE);
     layersColorTable.setPreferredScrollableViewportSize(
         new Dimension(tableWidth, itemColorTableHeight));
     JScrollPane itemScrollPane = initColorTable(layersColorTable, boardFrame.getLocale());
     panel.add(itemScrollPane, BorderLayout.NORTH);
 
     generalColorTable = new JTable(graphicsContext.otherColorTable);
+    generalColorTable.putClientProperty("terminateEditOnFocusLost", Boolean.TRUE);
     generalColorTable.setPreferredScrollableViewportSize(
         new Dimension(tableWidth, textfieldHeight));
     JScrollPane otherScrollPane = initColorTable(generalColorTable, boardFrame.getLocale());

--- a/src/main/java/app/freerouting/gui/windows/routing/WindowAssignNetClass.java
+++ b/src/main/java/app/freerouting/gui/windows/routing/WindowAssignNetClass.java
@@ -47,6 +47,7 @@ public class WindowAssignNetClass extends BoardSavableSubWindow {
 
     this.tableModel = new AssignRuleTableModel();
     this.table = new AssignRuleTable(this.tableModel);
+    this.table.putClientProperty("terminateEditOnFocusLost", Boolean.TRUE);
     this.table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
     this.scrollPane = new JScrollPane(this.table);
     int tableHeight = TEXTFIELD_HEIGHT * Math.min(this.tableModel.getRowCount(), 20);

--- a/src/main/java/app/freerouting/gui/windows/routing/WindowClearanceMatrix.java
+++ b/src/main/java/app/freerouting/gui/windows/routing/WindowClearanceMatrix.java
@@ -168,6 +168,7 @@ public class WindowClearanceMatrix extends BoardSavableSubWindow {
   private JPanel addClearanceTable(BoardFrame boardFrame) {
     this.clearanceTableModel = new ClearanceTableModel(boardFrame.boardPanel.boardHandling);
     this.clearanceTable = new JTable(clearanceTableModel);
+    this.clearanceTable.putClientProperty("terminateEditOnFocusLost", Boolean.TRUE);
 
     // Put the clearance table into a scroll pane.
     final int textfieldHeight = 16;

--- a/src/main/java/app/freerouting/gui/windows/routing/WindowEditVias.java
+++ b/src/main/java/app/freerouting/gui/windows/routing/WindowEditVias.java
@@ -91,6 +91,7 @@ public class WindowEditVias extends BoardSavableSubWindow {
   private void addTable() {
     this.tableModel = new ViaTableModel();
     this.table = new JTable(this.tableModel);
+    this.table.putClientProperty("terminateEditOnFocusLost", Boolean.TRUE);
     this.scrollPane = new JScrollPane(this.table);
     int tableHeight = TEXTFIELD_HEIGHT * this.tableModel.getRowCount();
     int tableWidth = TEXTFIELD_WIDTH * this.tableModel.getColumnCount();

--- a/src/main/java/app/freerouting/gui/windows/routing/WindowManualRules.java
+++ b/src/main/java/app/freerouting/gui/windows/routing/WindowManualRules.java
@@ -245,25 +245,33 @@ public class WindowManualRules extends BoardSavableSubWindow {
     }
   }
 
+  private void applyTraceWidthFromField() {
+    try {
+      traceWidthField.commitEdit();
+    } catch (java.text.ParseException _) {
+      setSelectedLayer(settingsRoutingManualRuleSelectionLayerComboBox.getSelectedLayer());
+      return;
+    }
+    Object input = traceWidthField.getValue();
+    if (input instanceof Number number && number.doubleValue() > 0) {
+      double inputValue = number.doubleValue();
+      double boardValue = boardHandling.coordinateTransform.userToBoard(inputValue);
+      int newHalfWidth = (int) Math.round(0.5 * boardValue);
+      boardHandling.setManualTraceHalfWidth(
+          settingsRoutingManualRuleSelectionLayerComboBox.getSelectedLayer().index, newHalfWidth);
+      setTraceWidthField(newHalfWidth);
+    } else {
+      setSelectedLayer(settingsRoutingManualRuleSelectionLayerComboBox.getSelectedLayer());
+    }
+  }
+
   private class TraceWidthFieldKeyListener extends KeyAdapter {
 
     @Override
     public void keyTyped(KeyEvent evt) {
       if (evt.getKeyChar() == '\n') {
+        applyTraceWidthFromField();
         keyInputCompleted = true;
-        Object input = traceWidthField.getValue();
-        if (!(input instanceof Number)) {
-          return;
-        }
-        double inputValue = ((Number) input).doubleValue();
-        if (inputValue <= 0) {
-          return;
-        }
-        double boardValue = boardHandling.coordinateTransform.userToBoard(inputValue);
-        int newHalfWidth = (int) Math.round(0.5 * boardValue);
-        boardHandling.setManualTraceHalfWidth(
-            settingsRoutingManualRuleSelectionLayerComboBox.getSelectedLayer().index, newHalfWidth);
-        setTraceWidthField(newHalfWidth);
       } else {
         keyInputCompleted = false;
       }
@@ -275,8 +283,7 @@ public class WindowManualRules extends BoardSavableSubWindow {
     @Override
     public void focusLost(FocusEvent evt) {
       if (!keyInputCompleted) {
-        // restore the text field.
-        setSelectedLayer(settingsRoutingManualRuleSelectionLayerComboBox.getSelectedLayer());
+        applyTraceWidthFromField();
         keyInputCompleted = true;
       }
     }

--- a/src/main/java/app/freerouting/gui/windows/routing/WindowMoveParameter.java
+++ b/src/main/java/app/freerouting/gui/windows/routing/WindowMoveParameter.java
@@ -183,7 +183,21 @@ public class WindowMoveParameter extends BoardSavableSubWindow {
     @Override
     public void focusLost(FocusEvent evt) {
       if (!keyInputCompleted) {
-        // restore the text field.
+        double oldValue =
+            boardHandling.coordinateTransform.boardToUser(
+                boardHandling.getWorkspaceSettings().getHorizontalComponentGrid());
+        try {
+          horizontalGridField.commitEdit();
+        } catch (java.text.ParseException _) {
+          horizontalGridField.setValue(oldValue);
+        }
+        Object input = horizontalGridField.getValue();
+        double inputValue =
+            (input instanceof Number number) ? Math.max(0, number.doubleValue()) : 0;
+        boardHandling
+            .getWorkspaceSettings()
+            .setHorizontalComponentGrid(
+                (int) Math.round(boardHandling.coordinateTransform.userToBoard(inputValue)));
         setHorizontalGridField(boardHandling.getWorkspaceSettings().getHorizontalComponentGrid());
         keyInputCompleted = true;
       }
@@ -224,7 +238,21 @@ public class WindowMoveParameter extends BoardSavableSubWindow {
     @Override
     public void focusLost(FocusEvent evt) {
       if (!keyInputCompleted) {
-        // restore the text field.
+        double oldValue =
+            boardHandling.coordinateTransform.boardToUser(
+                boardHandling.getWorkspaceSettings().getVerticalComponentGrid());
+        try {
+          verticalGridField.commitEdit();
+        } catch (java.text.ParseException _) {
+          verticalGridField.setValue(oldValue);
+        }
+        Object input = verticalGridField.getValue();
+        double inputValue =
+            (input instanceof Number number) ? Math.max(0, number.doubleValue()) : 0;
+        boardHandling
+            .getWorkspaceSettings()
+            .setVerticalComponentGrid(
+                (int) Math.round(boardHandling.coordinateTransform.userToBoard(inputValue)));
         setVerticalGridField(boardHandling.getWorkspaceSettings().getVerticalComponentGrid());
         keyInputCompleted = true;
       }

--- a/src/main/java/app/freerouting/gui/windows/routing/WindowNetClasses.java
+++ b/src/main/java/app/freerouting/gui/windows/routing/WindowNetClasses.java
@@ -167,6 +167,34 @@ public class WindowNetClasses extends BoardSavableSubWindow {
     netClass.isIgnoredByAutorouter = ignoredByAutorouter;
   }
 
+  public static Double parseTraceWidthValue(Object value) {
+    if (value instanceof Number number) {
+      return number.doubleValue();
+    }
+    if (value instanceof String stringValue) {
+      try {
+        return Double.parseDouble(stringValue.replace(',', '.').trim());
+      } catch (Exception _) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  public static boolean applyTraceWidth(
+      NetClass netClass, Object value, CoordinateTransform coordinateTransform) {
+    Double parsedValue = parseTraceWidthValue(value);
+    if (parsedValue == null || parsedValue <= 0 || coordinateTransform == null) {
+      return false;
+    }
+    int traceHalfWidth = (int) Math.round(coordinateTransform.userToBoard(0.5 * parsedValue));
+    if (traceHalfWidth <= 0) {
+      return false;
+    }
+    netClass.setTraceHalfWidth(traceHalfWidth);
+    return true;
+  }
+
   @Override
   public void refresh() {
     this.clClassComboBox.removeAllItems();
@@ -206,6 +234,7 @@ public class WindowNetClasses extends BoardSavableSubWindow {
   private void addTable() {
     this.tableModel = new NetClassTableModel();
     this.table = new NetClassTable(this.tableModel);
+    this.table.putClientProperty("terminateEditOnFocusLost", Boolean.TRUE);
     final JScrollPane scrollPane = new JScrollPane(this.table);
     int tableHeight = TEXTFIELD_HEIGHT * this.tableModel.getRowCount();
     int tableWidth = TEXTFIELD_WIDTH * this.tableModel.getColumnCount();
@@ -633,7 +662,7 @@ public class WindowNetClasses extends BoardSavableSubWindow {
     public void setValueAt(Object value, int row, int col) {
       RoutingBoard routingBoard = boardFrame.boardPanel.boardHandling.getRoutingBoard();
       BoardRules boardRules = routingBoard.rules;
-      if (col == ColumnName.ON_LAYER.ordinal() || col == ColumnName.TRACE_WIDTH.ordinal()) {
+      if (col == ColumnName.ON_LAYER.ordinal()) {
         return;
       }
       Object netClassName = getValueAt(row, ColumnName.NAME.ordinal());
@@ -744,6 +773,13 @@ public class WindowNetClasses extends BoardSavableSubWindow {
           }
         }
         netRule.setTraceClearanceClass(newClClassIndex);
+      } else if (col == ColumnName.TRACE_WIDTH.ordinal()) {
+        CoordinateTransform coordinateTransform =
+            boardFrame.boardPanel.boardHandling.coordinateTransform;
+        if (!applyTraceWidth(netRule, value, coordinateTransform)) {
+          return;
+        }
+        boardFrame.boardPanel.repaint();
       }
       this.data[row][col] = value;
       fireTableCellUpdated(row, col);

--- a/src/main/java/app/freerouting/gui/windows/routing/WindowRouteParameter.java
+++ b/src/main/java/app/freerouting/gui/windows/routing/WindowRouteParameter.java
@@ -1024,8 +1024,21 @@ public class WindowRouteParameter extends BoardSavableSubWindow {
     public void focusLost(FocusEvent evt) {
       if (!keyInputCompleted) {
         double edgeToTurnDist = guiBoardManager.getRoutingBoard().rules.getPinEdgeToTurnDist();
-        edgeToTurnDist = guiBoardManager.coordinateTransform.boardToUser(edgeToTurnDist);
-        edgeToTurnDistField.setValue(edgeToTurnDist);
+        double oldValue = guiBoardManager.coordinateTransform.boardToUser(edgeToTurnDist);
+        try {
+          edgeToTurnDistField.commitEdit();
+        } catch (java.text.ParseException _) {
+          edgeToTurnDistField.setValue(oldValue);
+        }
+        Object input = edgeToTurnDistField.getValue();
+        if (input instanceof Number number) {
+          float inputValue = number.floatValue();
+          guiBoardManager.setPinEdgeToTurnDist(inputValue);
+          settingsRoutingRestrictPinExitDirectionsCheckBox.setSelected(inputValue > 0);
+          refresh();
+        } else {
+          edgeToTurnDistField.setValue(oldValue);
+        }
         keyInputCompleted = true;
       }
     }
@@ -1059,9 +1072,23 @@ public class WindowRouteParameter extends BoardSavableSubWindow {
     @Override
     public void focusLost(FocusEvent evt) {
       if (!keyInputCompleted) {
-        regionWidthField.setValue(
+        double oldValue =
             WindowRouteParameter.this.guiBoardManager.coordinateTransform.boardToUser(
-                regionSlider.getValue() * c_region_scale_factor));
+                regionSlider.getValue() * c_region_scale_factor);
+        try {
+          regionWidthField.commitEdit();
+        } catch (java.text.ParseException _) {
+          regionWidthField.setValue(oldValue);
+        }
+        Object input = regionWidthField.getValue();
+        if (input instanceof Number number) {
+          double userValue = Math.max(0.0, number.doubleValue());
+          double boardValue = guiBoardManager.coordinateTransform.userToBoard(userValue);
+          int sliderValue = (int) Math.round(boardValue / c_region_scale_factor);
+          setPullTightRegionWidth(sliderValue);
+        } else {
+          regionWidthField.setValue(oldValue);
+        }
         keyInputCompleted = true;
       }
     }
@@ -1101,8 +1128,25 @@ public class WindowRouteParameter extends BoardSavableSubWindow {
       if (!keyInputCompleted) {
         int accuracyBoardValue =
             (c_accuracy_max_slider_value - accuracySlider.getValue() + 1) * c_accuracy_scale_factor;
-        accuracyValueField.setValue(
-            guiBoardManager.coordinateTransform.boardToUser(accuracyBoardValue));
+        double oldValue = guiBoardManager.coordinateTransform.boardToUser(accuracyBoardValue);
+        try {
+          accuracyValueField.commitEdit();
+        } catch (java.text.ParseException _) {
+          accuracyValueField.setValue(oldValue);
+        }
+        Object input = accuracyValueField.getValue();
+        if (input instanceof Number number) {
+          double userValue = Math.max(0.0, number.doubleValue());
+          double boardValue = guiBoardManager.coordinateTransform.userToBoard(userValue);
+          int sliderValue =
+              c_accuracy_max_slider_value
+                  - (int) Math.round(boardValue / c_accuracy_scale_factor)
+                  + 1;
+          sliderValue = Math.max(0, Math.min(c_accuracy_max_slider_value, sliderValue));
+          accuracySlider.setValue(sliderValue);
+        } else {
+          accuracyValueField.setValue(oldValue);
+        }
         keyInputCompleted = true;
       }
     }

--- a/src/test/java/app/freerouting/gui/WindowNetClassesTest.java
+++ b/src/test/java/app/freerouting/gui/WindowNetClassesTest.java
@@ -1,0 +1,62 @@
+package app.freerouting.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import app.freerouting.board.state.CoordinateTransform;
+import app.freerouting.gui.windows.routing.WindowNetClasses;
+import app.freerouting.rules.NetClass;
+import org.junit.jupiter.api.Test;
+
+class WindowNetClassesTest {
+
+  @Test
+  void parseTraceWidthValueHandlesVariousNumericAndStringInputs() {
+    assertEquals(200.0, WindowNetClasses.parseTraceWidthValue(200));
+    assertEquals(150.5, WindowNetClasses.parseTraceWidthValue(150.5f));
+    assertEquals(300.25, WindowNetClasses.parseTraceWidthValue(300.25d));
+
+    assertEquals(200.0, WindowNetClasses.parseTraceWidthValue("200.0000"));
+    assertEquals(0.35, WindowNetClasses.parseTraceWidthValue("0.35"));
+    assertEquals(0.35, WindowNetClasses.parseTraceWidthValue("0,35"));
+    assertEquals(120.0, WindowNetClasses.parseTraceWidthValue("  120.0  "));
+
+    assertNull(WindowNetClasses.parseTraceWidthValue("invalid"));
+    assertNull(WindowNetClasses.parseTraceWidthValue(""));
+    assertNull(WindowNetClasses.parseTraceWidthValue(null));
+    assertNull(WindowNetClasses.parseTraceWidthValue(new Object()));
+  }
+
+  @Test
+  void applyTraceWidthAppliesCorrectHalfWidthToNetClass() {
+    NetClass netClass = mock(NetClass.class);
+    CoordinateTransform ct = mock(CoordinateTransform.class);
+
+    when(ct.userToBoard(100.0)).thenReturn(10000.0);
+
+    boolean success = WindowNetClasses.applyTraceWidth(netClass, 200.0, ct);
+
+    assertTrue(success);
+    verify(ct).userToBoard(100.0);
+    verify(netClass).setTraceHalfWidth(10000);
+  }
+
+  @Test
+  void applyTraceWidthFailsOnInvalidOrNonPositiveInputs() {
+    NetClass netClass = mock(NetClass.class);
+    CoordinateTransform ct = mock(CoordinateTransform.class);
+
+    assertFalse(WindowNetClasses.applyTraceWidth(netClass, 0.0, ct));
+    assertFalse(WindowNetClasses.applyTraceWidth(netClass, -50.0, ct));
+    assertFalse(WindowNetClasses.applyTraceWidth(netClass, "bad_input", ct));
+    assertFalse(WindowNetClasses.applyTraceWidth(netClass, 100.0, null));
+
+    verifyNoInteractions(netClass);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #796.

This PR addresses an issue where editing track widths in the **Rules → Net Classes** table editor was silently discarded. Additionally, it modernizes input and cell edit persistence across all Freerouting GUI tables and parameter dialogs by supporting **commit-on-blur** (focus loss) alongside <kbd>Enter</kbd> key confirmation.

---

### Root Cause Analysis (Issue #796)

In `WindowNetClasses.java`, `NetClassTableModel.setValueAt` contained an early return:
```java
if (col == ColumnName.ON_LAYER.ordinal() || col == ColumnName.TRACE_WIDTH.ordinal()) {
  return;
}
```
This bypassed and discarded any user modifications made to the `TRACE_WIDTH` column.

---

### Key Changes

1. **Net Class Track Width Persistence ([#796](https://github.com/freerouting/freerouting/issues/796))**:
   - Removed `TRACE_WIDTH` from the early exit guard in `WindowNetClasses.java`.
   - Added `parseTraceWidthValue(Object)` and `applyTraceWidth(NetClass, Object, CoordinateTransform)` static helpers to parse numeric and string inputs (handling both `.` and `,` decimal separators, as well as whitespace).
   - Applied converted half-width board units into `NetClass.setTraceHalfWidth(...)` across active signal layers.

2. **Commit-on-Blur Across All Table Editors (`JTable`)**:
   - Enabled `putClientProperty("terminateEditOnFocusLost", Boolean.TRUE)` across all table components so in-progress cell edits commit automatically when clicking outside or switching focus:
     - `WindowNetClasses`
     - `WindowClearanceMatrix`
     - `WindowEditVias`
     - `WindowAssignNetClass`
     - `ColorManager` (`layersColorTable`, `generalColorTable`)

3. **Commit-on-Blur for Form Text Fields (`JFormattedTextField`)**:
   - Modernized `focusLost` listeners to parse, validate, and commit user inputs when clicking away (with safe fallback to previous valid value if invalid) in:
     - `WindowManualRules`: `traceWidthField`
     - `WindowRouteParameter`: `edgeToTurnDistField`, `regionWidthField`, `accuracyValueField`
     - `WindowMoveParameter`: `horizontalGridField`, `verticalGridField`

4. **Testing**:
   - Added `WindowNetClassesTest` covering input parsing (`Integer`, `Float`, `Double`, formatted strings with `.` and `,`), coordinate conversions, and invalid/non-positive edge cases.
   - Verified that all unit tests (`./gradlew test`) and quality gates (`./gradlew spotlessCheck checkstyleMain checkstyleTest checkstyleRewriteRecipes`) pass.
