### PR TITLE
Fix operator precedence in multi-line string formatting & document MCP deployment

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -386,6 +386,33 @@ Authentication is enabled. Either:
 - Add `--api_server.authentication.enabled=false` for local use, or
 - Include the header `Authorization: Bearer <your-api-key>` in all requests.
 
+### Volume permission denied (`freerouting.log: Permission denied`)
+
+The Docker container runs as non-root user `freerouting` (UID `10001`, GID `10001`). When using external Docker volumes or host mounts, Docker creates the directory owned by `root:root` (UID 0:0), preventing Freerouting from creating logs and saving jobs.
+
+Fix permissions directly inside the running container as root:
+
+```bash
+docker exec -u 0 <container-name> chown -R 10001:10001 /mnt/freerouting
+```
+
+> **Umbrel users:** On Umbrel, Portainer runs in a Docker-in-Docker environment (`portainer_docker_1`). Open the **Console** for the container in the Portainer web UI, select **User: root**, and run `chown -R 10001:10001 /mnt/freerouting`. Alternatively, run from the Umbrel host terminal:
+> ```bash
+> sudo docker exec -it portainer_docker_1 docker exec -u 0 <container-id-or-name> chown -R 10001:10001 /mnt/freerouting
+> ```
+
+### Java restricted native access warning (`Conscrypt`)
+
+If you see:
+```text
+WARNING: A restricted method in java.lang.System has been called
+WARNING: java.lang.System::load has been called by org.conscrypt.NativeLibraryUtil
+```
+Add `--enable-native-access=ALL-UNNAMED` as a JVM flag **before** `-jar` in your launch command:
+```bash
+java --enable-native-access=ALL-UNNAMED -jar /app/freerouting-executable.jar ...
+```
+
 ### Out-of-memory on large boards (Raspberry Pi / ARMv7)
 
 The `linux/arm/v7` image runs a 32-bit JVM, which has a 4 GB address-space ceiling. Large boards with hundreds of nets can approach this. Mitigation options:
@@ -402,3 +429,58 @@ docker run -d -p 37864:37864 \
   --gui.enabled=false \
   --api_server.authentication.enabled=false
 ```
+
+---
+
+## Running the MCP Server with Cloudflare Tunnel or Reverse Proxy
+
+Freerouting includes a dedicated Model Context Protocol (MCP) server alongside the REST API:
+* **REST API server:** port `37864` (`/v1/system/*`, `/v1/jobs/*`)
+* **MCP server:** port `37964` (`/v1/mcp`, `/v1/mcp/events`, `/v1/mcp/ws`)
+
+### Docker Compose Stack Configuration
+
+When hosting both services behind a reverse proxy or Cloudflare Tunnel, ensure both listeners bind to `0.0.0.0` so other containers on the network can reach them:
+
+```yaml
+services:
+  freerouting-api:
+    image: ghcr.io/freerouting/freerouting:latest
+    container_name: freerouting-api
+    restart: unless-stopped
+    command: >
+      java --enable-native-access=ALL-UNNAMED
+      -jar /app/freerouting-executable.jar
+      --gui-enabled=false
+      --feature_flags-save_jobs=1
+      --user_data_path=/mnt/freerouting
+      --api_server-enabled=true
+      --api_server-endpoints=http://0.0.0.0:37864
+      --mcp_server-enabled=true
+      --mcp_server-endpoints=http://0.0.0.0:37964
+    volumes:
+      - freerouting-userdata:/mnt/freerouting
+    networks:
+      - freerouting-network
+
+volumes:
+  freerouting-userdata:
+
+networks:
+  freerouting-network:
+    driver: bridge
+```
+
+### Cloudflare Tunnel / Reverse Proxy Path Routing
+
+Clients using `@freerouting/freerouting-mcp-server` target `https://<your-domain>/v1/mcp`. Because the API and MCP servers run on separate internal ports, configure path-based routing in your reverse proxy:
+
+1. **Rule 1 (Specific route - must be first):**
+   * **Path:** `v1/mcp*`
+   * **Target:** `http://freerouting-api:37964`
+2. **Rule 2 (Catch-all route):**
+   * **Path:** `*` (or empty)
+   * **Target:** `http://freerouting-api:37864`
+
+> **Important (Cloudflare Tunnel):** Cloudflare evaluates published application routes from top to bottom. The `v1/mcp*` route **must be ordered above** the catch-all `*` route, otherwise all MCP requests will hit the REST API port and return `404 Not Found`.
+

--- a/src/main/java/app/freerouting/Freerouting.java
+++ b/src/main/java/app/freerouting/Freerouting.java
@@ -432,8 +432,9 @@ public class Freerouting {
       // Check if the protocol is HTTP or HTTPS
       if (!"http".equals(protocol) && !"https".equals(protocol)) {
         FRLogger.warn(
-            "Can't use the endpoint '%s' for the API server, because its protocol is not HTTP "
-                + "or HTTPS.".formatted(endpointUrl));
+            ("Can't use the endpoint '%s' for the API server, because its protocol is not HTTP "
+                    + "or HTTPS.")
+                .formatted(endpointUrl));
         continue;
       }
 
@@ -578,8 +579,9 @@ public class Freerouting {
 
       if (!"http".equals(protocol) && !"https".equals(protocol)) {
         FRLogger.warn(
-            "Can't use the endpoint '%s' for the MCP server, because its protocol is not HTTP "
-                + "or HTTPS.".formatted(endpointUrl));
+            ("Can't use the endpoint '%s' for the MCP server, because its protocol is not HTTP "
+                    + "or HTTPS.")
+                .formatted(endpointUrl));
         continue;
       }
 

--- a/src/main/java/app/freerouting/api/security/GoogleSheetsApiKeyProvider.java
+++ b/src/main/java/app/freerouting/api/security/GoogleSheetsApiKeyProvider.java
@@ -287,8 +287,9 @@ public class GoogleSheetsApiKeyProvider implements ApiKeyProvider {
 
       if (newCache.size() != previousCacheSize) {
         String message =
-            "Successfully refreshed %d valid API keys from Google Sheets (total entries: %d,"
-                + " skipped: %d)".formatted(validKeysCount, newCache.size(), skippedRows);
+            ("Successfully refreshed %d valid API keys from Google Sheets (total entries: %d,"
+                    + " skipped: %d)")
+                .formatted(validKeysCount, newCache.size(), skippedRows);
         FRLogger.info(message);
       } else {
         FRLogger.debug(


### PR DESCRIPTION
## Summary
- Fixes an operator precedence issue in multi-line string formatting across \GoogleSheetsApiKeyProvider.java\ and \Freerouting.java\ where \.formatted(...)\ bound tighter than \+\, leaving earlier format specifiers unpopulated.
- Documents MCP server dual-port configuration, Cloudflare Tunnel path-based routing rules (\1/mcp*\ vs \*\), and Docker volume permissions (UID 10001:10001 on Umbrel/Portainer) in \docs/self-hosting.md\.