### PR TITLE
chore: bump version to 2.4.2-SNAPSHOT

### DIFF
--- a/gradle/project-info.gradle
+++ b/gradle/project-info.gradle
@@ -3,7 +3,7 @@
 // -----------------------------------------------------------------------------
 ext.publishInfo.artifactId = project.name.toLowerCase()
 ext.publishInfo.groupId = 'app.freerouting'
-ext.publishInfo.versionId = '2.4.1'
+ext.publishInfo.versionId = '2.4.2-SNAPSHOT'
 ext.publishInfo.isReleaseVersion = !ext.publishInfo.versionId.endsWith("SNAPSHOT")
 
 ext.publishInfo.developerName = 'Andras Fuchs, Michael Hoffer, Andrey Belomutskiy, Alfons Wirtz'


### PR DESCRIPTION
Bump xt.publishInfo.versionId to 2.4.2-SNAPSHOT in gradle/project-info.gradle for the next development cycle.