### PR TITLE
feat(analytics): Dual-user attribution (Human & AI Agents) and lifecycle observability

### DIFF
--- a/src/main/java/app/freerouting/Freerouting.java
+++ b/src/main/java/app/freerouting/Freerouting.java
@@ -2,6 +2,10 @@ package app.freerouting;
 
 import app.freerouting.analytics.FRAnalytics;
 import app.freerouting.analytics.NetworkProxyConfig;
+import app.freerouting.analytics.ProcessEnvironmentDetector;
+import app.freerouting.analytics.model.ActorType;
+import app.freerouting.analytics.model.JobLifecycleStatus;
+import app.freerouting.analytics.model.PipelineType;
 import app.freerouting.api.AppContextListener;
 import app.freerouting.api.mcp.McpApplication;
 import app.freerouting.api.mcp.McpContextListener;
@@ -181,6 +185,66 @@ public class Freerouting {
               + "║  Every contribution helps keep this project open and active!     ║"
               + nl
               + "╚══════════════════════════════════════════════════════════════════╝");
+    }
+
+    // Emit consolidated batch job summary telemetry for CLI batch execution
+    try {
+      JobLifecycleStatus status =
+          switch (routingJob.state) {
+            case COMPLETED ->
+                (cliExitCode == 0 ? JobLifecycleStatus.SUCCEEDED : JobLifecycleStatus.FAILED);
+            case TIMED_OUT -> JobLifecycleStatus.TIMED_OUT;
+            case CANCELLED -> JobLifecycleStatus.CANCELLED;
+            default -> JobLifecycleStatus.FAILED;
+          };
+      String failureReason =
+          cliExitCode != 0 ? "CLI exit code " + cliExitCode + " (" + routingJob.state + ")" : null;
+      var stats = routingJob.board != null ? routingJob.board.getStatistics() : null;
+      Integer netsTotal = stats != null && stats.nets != null ? stats.nets.totalCount : null;
+      Integer netsIncomplete =
+          stats != null && stats.connections != null ? stats.connections.incompleteCount : null;
+      Integer clearanceViolations =
+          stats != null && stats.clearanceViolations != null
+              ? stats.clearanceViolations.totalCount
+              : null;
+      Float normalizedScore =
+          stats != null && routingJob.routerSettings != null
+              ? stats.getNormalizedScore(routingJob.routerSettings.scoring)
+              : null;
+      int totalPasses =
+          routingJob.routerSettings != null && routingJob.routerSettings.maxPasses != null
+              ? routingJob.routerSettings.maxPasses
+              : 0;
+      double runtimeSeconds =
+          routingJob.startedAt != null
+              ? java.time.Duration.between(routingJob.startedAt, java.time.Instant.now()).toMillis()
+                  / 1000.0
+              : 0.0;
+      String inputBasename =
+          globalSettings.initialInputFile != null
+              ? java.nio.file.Path.of(globalSettings.initialInputFile).getFileName().toString()
+              : "unknown.dsn";
+
+      FRAnalytics.recordBatchJobSummary(
+          routingJob.id.toString(),
+          cliSession.id.toString(),
+          inputBasename,
+          cliExitCode,
+          status,
+          failureReason,
+          netsTotal,
+          netsIncomplete,
+          clearanceViolations,
+          normalizedScore,
+          totalPasses,
+          runtimeSeconds,
+          routingJob.resourceUsage.cpuTimeUsed,
+          routingJob.resourceUsage.peakMemoryUsed,
+          routingJob.getDetectedHost(),
+          null);
+      FRAnalytics.flush(1500);
+    } catch (Throwable ex) {
+      FRLogger.warn("Failed to record batch job summary: " + ex.getMessage());
     }
 
     globalSettings.cliExitCode = cliExitCode;
@@ -1381,6 +1445,33 @@ public class Freerouting {
     FRAnalytics.setEnabled(allowAnalytics);
     FRAnalytics.setUserId(
         globalSettings.userProfileSettings.userId, globalSettings.userProfileSettings.userEmail);
+
+    boolean isMcpEnabled = globalSettings.mcpServerSettings.isEnabled;
+    boolean isMcpStdio = Boolean.TRUE.equals(globalSettings.mcpServerSettings.isStdioMode);
+    boolean isApiEnabled = globalSettings.apiServerSettings.isEnabled;
+    boolean isGuiEnabled = globalSettings.guiSettings.isEnabled;
+    boolean hasInitialInput = globalSettings.initialInputFile != null;
+
+    PipelineType detectedPipeline =
+        ProcessEnvironmentDetector.detectPipelineType(
+            isMcpEnabled, isMcpStdio, isApiEnabled, isGuiEnabled, hasInitialInput);
+
+    ActorType detectedActor =
+        ProcessEnvironmentDetector.detectActorType(
+            detectedPipeline, isGuiEnabled, width == 0 && height == 0, String.join(" ", args));
+
+    String detectedHost =
+        (globalSettings.runtimeEnvironment.host != null
+                && !globalSettings.runtimeEnvironment.host.isBlank()
+                && !"N/A".equals(globalSettings.runtimeEnvironment.host))
+            ? globalSettings.runtimeEnvironment.host
+            : "Freerouting";
+
+    globalSettings.runtimeEnvironment.pipelineType = detectedPipeline.name();
+    globalSettings.runtimeEnvironment.actorType = detectedActor.name();
+
+    FRAnalytics.setExecutionContext(detectedPipeline, detectedActor, detectedHost, "");
+
     FRAnalytics.identify();
     if (!globalSettings.userProfileSettings.userEmail.isBlank()) {
       FRAnalytics.refreshIdentity();

--- a/src/main/java/app/freerouting/analytics/FRAnalytics.java
+++ b/src/main/java/app/freerouting/analytics/FRAnalytics.java
@@ -4,6 +4,10 @@ import static app.freerouting.Freerouting.globalSettings;
 
 import app.freerouting.analytics.dto.Properties;
 import app.freerouting.analytics.dto.Traits;
+import app.freerouting.analytics.model.ActorType;
+import app.freerouting.analytics.model.JobLifecycleStatus;
+import app.freerouting.analytics.model.PipelineType;
+import app.freerouting.constants.Constants;
 import app.freerouting.logger.FRLogger;
 import app.freerouting.util.gson.GsonProvider;
 import java.time.Instant;
@@ -31,6 +35,11 @@ public final class FRAnalytics {
   private static long autorouterStartedAt;
   private static long routeOptimizerStartedAt;
   private static String sessionId;
+
+  private static PipelineType currentPipeline = PipelineType.CLI;
+  private static ActorType currentActorType = ActorType.AUTOMATED_BATCH;
+  private static String currentIntegrationTool = "Freerouting";
+  private static String currentIntegrationVersion = "";
 
   static {
     appLocationTable = new HashMap<String, String>();
@@ -204,6 +213,54 @@ public final class FRAnalytics {
     }
   }
 
+  /**
+   * Configures the execution context (pipeline, actor classification, and host integration tool)
+   * used to annotate all outgoing analytics events.
+   *
+   * @param pipeline the active execution pipeline
+   * @param actorType the active actor classification
+   * @param integrationTool the EDA or AI host tool name
+   * @param integrationVersion the EDA or AI host tool version
+   */
+  public static void setExecutionContext(
+      PipelineType pipeline,
+      ActorType actorType,
+      String integrationTool,
+      String integrationVersion) {
+    if (pipeline != null) {
+      currentPipeline = pipeline;
+    }
+    if (actorType != null) {
+      currentActorType = actorType;
+    }
+    if (integrationTool != null && !integrationTool.isBlank()) {
+      currentIntegrationTool = integrationTool;
+    }
+    if (integrationVersion != null) {
+      currentIntegrationVersion = integrationVersion;
+    }
+  }
+
+  /** Gets the active pipeline type. */
+  public static PipelineType getCurrentPipeline() {
+    return currentPipeline;
+  }
+
+  /** Gets the active actor type. */
+  public static ActorType getCurrentActorType() {
+    return currentActorType;
+  }
+
+  /** Gets the active integration tool name. */
+  public static String getCurrentIntegrationTool() {
+    return currentIntegrationTool;
+  }
+
+  /** Gets the active integration tool version. */
+  public static String getCurrentIntegrationVersion() {
+    return currentIntegrationVersion;
+  }
+
   private static void identifyAnonymous(String anonymousId, Map<String, String> traits) {
     if (analytics == null) {
       return;
@@ -237,6 +294,12 @@ public final class FRAnalytics {
       p.put("app_current_location", appCurrentLocation);
       p.put("app_previous_location", appPreviousLocation);
       p.put("app_window_title", appWindowTitle);
+      p.put("pipeline", currentPipeline.name());
+      p.put("actor_type", currentActorType.name());
+      p.put("integration_tool", currentIntegrationTool);
+      if (currentIntegrationVersion != null && !currentIntegrationVersion.isBlank()) {
+        p.put("integration_version", currentIntegrationVersion);
+      }
       if (sessionId != null) {
         p.put("session_id", sessionId);
       }
@@ -286,6 +349,9 @@ public final class FRAnalytics {
     traits.put("os_version", System.getProperty("os.version"));
     traits.put("system_language", Locale.getDefault().toString());
     traits.put("gui_language", globalSettings.currentLocale.toString());
+    traits.put("pipeline", currentPipeline.name());
+    traits.put("actor_type", currentActorType.name());
+    traits.put("integration_tool", currentIntegrationTool);
     traits.put(
         "allow_telemetry", Boolean.toString(globalSettings.userProfileSettings.isTelemetryAllowed));
     traits.put(
@@ -713,5 +779,235 @@ public final class FRAnalytics {
     }
 
     trackAnonymousAction(effectiveUserId, "API Usage", properties);
+  }
+
+  /**
+   * Records a consolidated batch routing job summary upon CLI termination.
+   *
+   * @param jobId the routing job identifier
+   * @param sessionId the routing session identifier
+   * @param inputFileName the basename of the design file
+   * @param exitCode the process exit code
+   * @param status the terminal job status
+   * @param failureReason explanation when failed, or {@code null}
+   * @param netsTotal total net count, or {@code null}
+   * @param netsIncomplete incomplete net count, or {@code null}
+   * @param clearanceViolations clearance violations count, or {@code null}
+   * @param normalizedScore normalized score, or {@code null}
+   * @param totalPasses total autoroute passes completed
+   * @param runtimeSeconds elapsed wall clock runtime in seconds
+   * @param cpuSeconds CPU time consumed in seconds
+   * @param peakHeapMb peak JVM heap memory allocated in MB
+   * @param integrationTool originating EDA tool name, or {@code null}
+   * @param integrationVersion originating EDA tool version, or {@code null}
+   */
+  public static void recordBatchJobSummary(
+      String jobId,
+      String sessionId,
+      String inputFileName,
+      int exitCode,
+      JobLifecycleStatus status,
+      String failureReason,
+      Integer netsTotal,
+      Integer netsIncomplete,
+      Integer clearanceViolations,
+      Float normalizedScore,
+      int totalPasses,
+      double runtimeSeconds,
+      double cpuSeconds,
+      double peakHeapMb,
+      String integrationTool,
+      String integrationVersion) {
+    Map<String, String> properties = new HashMap<>();
+    if (jobId != null) {
+      properties.put("job_id", jobId);
+    }
+    if (sessionId != null) {
+      properties.put("session_id", sessionId);
+    }
+    if (inputFileName != null) {
+      properties.put("input_file_name", inputFileName);
+    }
+    properties.put("exit_code", Integer.toString(exitCode));
+    properties.put("status", status != null ? status.name() : "UNKNOWN");
+    if (failureReason != null && !failureReason.isBlank()) {
+      properties.put("failure_reason", failureReason);
+    }
+    if (netsTotal != null) {
+      properties.put("nets_total", Integer.toString(netsTotal));
+    }
+    if (netsIncomplete != null) {
+      properties.put("nets_incomplete", Integer.toString(netsIncomplete));
+    }
+    if (clearanceViolations != null) {
+      properties.put("clearance_violations", Integer.toString(clearanceViolations));
+    }
+    if (normalizedScore != null) {
+      properties.put("normalized_score", Float.toString(normalizedScore));
+    }
+    properties.put("total_passes", Integer.toString(totalPasses));
+    properties.put("runtime_seconds", String.format(Locale.US, "%.2f", runtimeSeconds));
+    properties.put("cpu_seconds", String.format(Locale.US, "%.2f", cpuSeconds));
+    properties.put("peak_heap_mb", String.format(Locale.US, "%.1f", peakHeapMb));
+    properties.put("pipeline", currentPipeline.name());
+    properties.put("actor_type", currentActorType.name());
+    properties.put(
+        "integration_tool", integrationTool != null ? integrationTool : currentIntegrationTool);
+    if (integrationVersion != null && !integrationVersion.isBlank()) {
+      properties.put("integration_version", integrationVersion);
+    }
+    properties.put("app_version", Constants.FREEROUTING_VERSION);
+
+    trackAnonymousAction(permanentUserId, "Batch Job Summary", properties);
+  }
+
+  /**
+   * Emits a normalized job lifecycle event across GUI, CLI, API, and MCP pipelines.
+   *
+   * @param jobId the routing job identifier
+   * @param sessionId the routing session identifier
+   * @param status current lifecycle status
+   * @param pipeline execution pipeline, or {@code null} to use default
+   * @param actorType actor classification, or {@code null} to use default
+   * @param failureReason failure explanation if failed, or {@code null}
+   * @param netsTotal total net count, or {@code null}
+   * @param netsIncomplete incomplete net count, or {@code null}
+   * @param clearanceViolations clearance violations count, or {@code null}
+   * @param normalizedScore normalized score, or {@code null}
+   * @param runtimeSeconds runtime duration in seconds, or {@code null}
+   * @param cpuSeconds CPU seconds used, or {@code null}
+   * @param peakHeapMb peak heap memory in MB, or {@code null}
+   * @param integrationTool originating EDA tool, or {@code null}
+   * @param integrationVersion originating EDA tool version, or {@code null}
+   * @param userId caller user identifier, or {@code null}
+   */
+  public static void recordJobLifecycle(
+      String jobId,
+      String sessionId,
+      JobLifecycleStatus status,
+      PipelineType pipeline,
+      ActorType actorType,
+      String failureReason,
+      Integer netsTotal,
+      Integer netsIncomplete,
+      Integer clearanceViolations,
+      Float normalizedScore,
+      Double runtimeSeconds,
+      Double cpuSeconds,
+      Double peakHeapMb,
+      String integrationTool,
+      String integrationVersion,
+      UUID userId) {
+    Map<String, String> properties = new HashMap<>();
+    if (jobId != null) {
+      properties.put("job_id", jobId);
+    }
+    if (sessionId != null) {
+      properties.put("session_id", sessionId);
+    }
+    properties.put("status", status != null ? status.name() : "UNKNOWN");
+    properties.put("pipeline", pipeline != null ? pipeline.name() : currentPipeline.name());
+    properties.put("actor_type", actorType != null ? actorType.name() : currentActorType.name());
+    if (failureReason != null && !failureReason.isBlank()) {
+      properties.put("failure_reason", failureReason);
+    }
+    if (netsTotal != null) {
+      properties.put("nets_total", Integer.toString(netsTotal));
+    }
+    if (netsIncomplete != null) {
+      properties.put("nets_incomplete", Integer.toString(netsIncomplete));
+    }
+    if (clearanceViolations != null) {
+      properties.put("clearance_violations", Integer.toString(clearanceViolations));
+    }
+    if (normalizedScore != null) {
+      properties.put("normalized_score", Float.toString(normalizedScore));
+    }
+    if (runtimeSeconds != null) {
+      properties.put("runtime_seconds", String.format(Locale.US, "%.2f", runtimeSeconds));
+    }
+    if (cpuSeconds != null) {
+      properties.put("cpu_seconds", String.format(Locale.US, "%.2f", cpuSeconds));
+    }
+    if (peakHeapMb != null) {
+      properties.put("peak_heap_mb", String.format(Locale.US, "%.1f", peakHeapMb));
+    }
+    properties.put(
+        "integration_tool", integrationTool != null ? integrationTool : currentIntegrationTool);
+    if (integrationVersion != null && !integrationVersion.isBlank()) {
+      properties.put("integration_version", integrationVersion);
+    }
+    properties.put("app_version", Constants.FREEROUTING_VERSION);
+
+    String effectiveUserId = userId != null ? userId.toString() : permanentUserId;
+    trackAnonymousAction(effectiveUserId, "Job Lifecycle", properties);
+  }
+
+  /**
+   * Emits a session lifecycle event across GUI, CLI, API, and MCP pipelines.
+   *
+   * @param sessionId the session identifier
+   * @param eventType the lifecycle action (e.g. {@code "SESSION_CREATED"}, {@code
+   *     "SESSION_CLOSED"})
+   * @param pipeline execution pipeline, or {@code null} to use default
+   * @param actorType actor classification, or {@code null} to use default
+   * @param integrationTool originating EDA tool or client
+   * @param userId caller user identifier, or {@code null}
+   */
+  public static void recordSessionLifecycle(
+      String sessionId,
+      String eventType,
+      PipelineType pipeline,
+      ActorType actorType,
+      String integrationTool,
+      UUID userId) {
+    Map<String, String> properties = new HashMap<>();
+    if (sessionId != null) {
+      properties.put("session_id", sessionId);
+    }
+    properties.put("event_type", eventType != null ? eventType : "SESSION_CREATED");
+    properties.put("pipeline", pipeline != null ? pipeline.name() : currentPipeline.name());
+    properties.put("actor_type", actorType != null ? actorType.name() : currentActorType.name());
+    properties.put(
+        "integration_tool", integrationTool != null ? integrationTool : currentIntegrationTool);
+    properties.put("app_version", Constants.FREEROUTING_VERSION);
+
+    String effectiveUserId = userId != null ? userId.toString() : permanentUserId;
+    trackAnonymousAction(effectiveUserId, "Session Lifecycle", properties);
+  }
+
+  /**
+   * Emits a categorized, structured error event for automated alerting and diagnostics.
+   *
+   * @param category high-level category (e.g. {@code "PARSER"}, {@code "ROUTING"}, {@code "MCP"})
+   * @param errorCode machine-readable error code (e.g. {@code "SPECCTRA_SYNTAX_ERROR"})
+   * @param message concise error summary
+   * @param ex the associated exception, or {@code null}
+   * @param correlationId correlation ID if available, or {@code null}
+   */
+  public static void recordStructuredError(
+      String category, String errorCode, String message, Throwable ex, String correlationId) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("error_category", category != null ? category : "SYSTEM");
+    properties.put("error_code", errorCode != null ? errorCode : "UNKNOWN_ERROR");
+    properties.put(
+        "error_message", message != null ? message : (ex != null ? ex.getMessage() : ""));
+    if (ex != null) {
+      properties.put("exception_class", ex.getClass().getName());
+      StringBuilder sb = new StringBuilder();
+      for (StackTraceElement ste : ex.getStackTrace()) {
+        sb.append(ste.toString()).append("\n");
+      }
+      properties.put("exception_stacktrace", sb.toString());
+    }
+    if (correlationId != null && !correlationId.isBlank()) {
+      properties.put("correlation_id", correlationId);
+    }
+    properties.put("pipeline", currentPipeline.name());
+    properties.put("actor_type", currentActorType.name());
+    properties.put("integration_tool", currentIntegrationTool);
+    properties.put("app_version", Constants.FREEROUTING_VERSION);
+
+    trackAnonymousAction(permanentUserId, "Error Event", properties);
   }
 }

--- a/src/main/java/app/freerouting/analytics/ProcessEnvironmentDetector.java
+++ b/src/main/java/app/freerouting/analytics/ProcessEnvironmentDetector.java
@@ -107,8 +107,28 @@ public final class ProcessEnvironmentDetector {
       boolean isGuiEnabled,
       boolean hasHeadlessDisplay,
       String commandLineArgs) {
+    return detectActorType(
+        pipeline, isGuiEnabled, hasHeadlessDisplay, commandLineArgs, isCiEnvironment());
+  }
+
+  /**
+   * Resolves the {@link ActorType} driving this Freerouting process with explicit CI determination.
+   *
+   * @param pipeline the resolved pipeline type
+   * @param isGuiEnabled whether GUI is enabled
+   * @param hasHeadlessDisplay whether display is headless or has zero dimension
+   * @param commandLineArgs the raw command-line argument string
+   * @param isCi whether executing within a CI environment
+   * @return the resolved {@link ActorType}
+   */
+  public static ActorType detectActorType(
+      PipelineType pipeline,
+      boolean isGuiEnabled,
+      boolean hasHeadlessDisplay,
+      String commandLineArgs,
+      boolean isCi) {
     // 1. CI/CD environment takes priority when detected
-    if (isCiEnvironment()) {
+    if (isCi) {
       return ActorType.CI_CD;
     }
 

--- a/src/main/java/app/freerouting/analytics/ProcessEnvironmentDetector.java
+++ b/src/main/java/app/freerouting/analytics/ProcessEnvironmentDetector.java
@@ -1,0 +1,170 @@
+package app.freerouting.analytics;
+
+import app.freerouting.analytics.model.ActorType;
+import app.freerouting.analytics.model.PipelineType;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Inspects runtime environment characteristics, environment variables, and OS process hierarchy to
+ * classify the active {@link PipelineType} and {@link ActorType}.
+ */
+public final class ProcessEnvironmentDetector {
+
+  private ProcessEnvironmentDetector() {}
+
+  /**
+   * Identifies whether the current process is executing within a known CI/CD environment.
+   *
+   * @return {@code true} if a CI environment is detected, {@code false} otherwise
+   */
+  public static boolean isCiEnvironment() {
+    String[] ciEnvVars = {
+      "CI",
+      "CONTINUOUS_INTEGRATION",
+      "GITHUB_ACTIONS",
+      "GITLAB_CI",
+      "BITBUCKET_BUILD_NUMBER",
+      "JENKINS_URL",
+      "TRAVIS",
+      "CIRCLECI",
+      "BUILDKITE",
+      "TF_BUILD"
+    };
+
+    for (String varName : ciEnvVars) {
+      String val = System.getenv(varName);
+      if (val != null && !val.isBlank() && !"false".equalsIgnoreCase(val) && !"0".equals(val)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Retrieves the parent process command line or executable name if available.
+   *
+   * @return lowercased parent command name or empty string if unavailable
+   */
+  public static String getParentProcessCommand() {
+    try {
+      Optional<ProcessHandle> parentOpt = ProcessHandle.current().parent();
+      if (parentOpt.isPresent()) {
+        ProcessHandle.Info info = parentOpt.get().info();
+        String cmd = info.command().orElse(info.commandLine().orElse(""));
+        if (!cmd.isBlank()) {
+          return cmd.toLowerCase(Locale.ROOT);
+        }
+      }
+    } catch (Throwable _) {
+      // Ignored: OS permissions or security manager may prohibit process inspection
+    }
+    return "";
+  }
+
+  /**
+   * Detects the {@link PipelineType} based on startup configuration and arguments.
+   *
+   * @param isMcpEnabled whether MCP server is enabled
+   * @param isMcpStdio whether MCP runs in stdio bridge mode
+   * @param isApiEnabled whether REST API server is enabled
+   * @param isGuiEnabled whether GUI is enabled
+   * @param hasInitialInputFile whether an initial input board file is passed
+   * @return the resolved {@link PipelineType}
+   */
+  public static PipelineType detectPipelineType(
+      boolean isMcpEnabled,
+      boolean isMcpStdio,
+      boolean isApiEnabled,
+      boolean isGuiEnabled,
+      boolean hasInitialInputFile) {
+    if (isMcpEnabled && isMcpStdio) {
+      return PipelineType.MCP;
+    }
+    if (isGuiEnabled) {
+      return PipelineType.GUI;
+    }
+    if (isApiEnabled && !hasInitialInputFile) {
+      return PipelineType.API;
+    }
+    if (isMcpEnabled && !hasInitialInputFile) {
+      return PipelineType.MCP;
+    }
+    return PipelineType.CLI;
+  }
+
+  /**
+   * Resolves the {@link ActorType} driving this Freerouting process.
+   *
+   * @param pipeline the resolved pipeline type
+   * @param isGuiEnabled whether GUI is enabled
+   * @param hasHeadlessDisplay whether display is headless or has zero dimension
+   * @param commandLineArgs the raw command-line argument string
+   * @return the resolved {@link ActorType}
+   */
+  public static ActorType detectActorType(
+      PipelineType pipeline,
+      boolean isGuiEnabled,
+      boolean hasHeadlessDisplay,
+      String commandLineArgs) {
+    // 1. CI/CD environment takes priority when detected
+    if (isCiEnvironment()) {
+      return ActorType.CI_CD;
+    }
+
+    // 2. Explicit MCP pipeline is driven by an AI agent
+    if (pipeline == PipelineType.MCP) {
+      return ActorType.AGENT;
+    }
+
+    // 3. Inspect parent process binary/command if accessible
+    String parentCmd = getParentProcessCommand();
+    if (!parentCmd.isEmpty()) {
+      // Agent frameworks and IDE MCP hosts
+      if (parentCmd.contains("node")
+          || parentCmd.contains("electron")
+          || parentCmd.contains("claude")
+          || parentCmd.contains("cursor")
+          || parentCmd.contains("cline")
+          || parentCmd.contains("windsurf")
+          || parentCmd.contains("code")
+          || parentCmd.contains("copilot")) {
+        return ActorType.AGENT;
+      }
+
+      // Automated scripting runners and container runtimes
+      if (parentCmd.contains("python")
+          || parentCmd.contains("pytest")
+          || parentCmd.contains("bash")
+          || parentCmd.contains("sh")
+          || parentCmd.contains("zsh")
+          || parentCmd.contains("pwsh")
+          || parentCmd.contains("powershell")
+          || parentCmd.contains("docker")
+          || parentCmd.contains("containerd")
+          || parentCmd.contains("podman")
+          || parentCmd.contains("perl")
+          || parentCmd.contains("ruby")) {
+        return ActorType.AUTOMATED_BATCH;
+      }
+    }
+
+    // 4. Check for headless automation CLI flags
+    String argsLower = commandLineArgs == null ? "" : commandLineArgs.toLowerCase(Locale.ROOT);
+    if (argsLower.contains("-dct 0")
+        || argsLower.contains("--gui.enabled=false")
+        || argsLower.contains("--gui-enabled=false")
+        || argsLower.contains("/data/")) {
+      return ActorType.AUTOMATED_BATCH;
+    }
+
+    // 5. Check display capability
+    boolean isHeadless =
+        hasHeadlessDisplay || Boolean.getBoolean("java.awt.headless") || !isGuiEnabled;
+    if (isHeadless) {
+      return ActorType.AUTOMATED_BATCH;
+    }
+
+    return ActorType.HUMAN;
+  }
+}

--- a/src/main/java/app/freerouting/analytics/model/ActorType.java
+++ b/src/main/java/app/freerouting/analytics/model/ActorType.java
@@ -1,0 +1,16 @@
+package app.freerouting.analytics.model;
+
+/** Represents the actor or execution context driving the Freerouting process. */
+public enum ActorType {
+  /** Interactive human engineer operating the visual display. */
+  HUMAN,
+
+  /** Autonomous AI or LLM agent operating via MCP or agent orchestration. */
+  AGENT,
+
+  /** Automated batch script, training cluster, container worker, or parametric loop. */
+  AUTOMATED_BATCH,
+
+  /** Continuous integration or continuous delivery build runner. */
+  CI_CD
+}

--- a/src/main/java/app/freerouting/analytics/model/JobLifecycleStatus.java
+++ b/src/main/java/app/freerouting/analytics/model/JobLifecycleStatus.java
@@ -1,0 +1,19 @@
+package app.freerouting.analytics.model;
+
+/** Represents the lifecycle progress or terminal status of a routing job. */
+public enum JobLifecycleStatus {
+  /** Job was enqueued and started execution. */
+  STARTED,
+
+  /** Job completed successfully with routing finished. */
+  SUCCEEDED,
+
+  /** Job failed due to parsing, DRC, algorithmic error, or unrouted incompletes. */
+  FAILED,
+
+  /** Job timed out before completing all passes. */
+  TIMED_OUT,
+
+  /** Job was cancelled by user or client request. */
+  CANCELLED
+}

--- a/src/main/java/app/freerouting/analytics/model/PipelineType.java
+++ b/src/main/java/app/freerouting/analytics/model/PipelineType.java
@@ -1,0 +1,16 @@
+package app.freerouting.analytics.model;
+
+/** Represents the execution pipeline or interface through which Freerouting is invoked. */
+public enum PipelineType {
+  /** Interactive graphical desktop user interface. */
+  GUI,
+
+  /** Headless command-line batch execution. */
+  CLI,
+
+  /** Headless REST API server execution. */
+  API,
+
+  /** Model Context Protocol (MCP) tool execution. */
+  MCP
+}

--- a/src/main/java/app/freerouting/api/mcp/McpControllerV1.java
+++ b/src/main/java/app/freerouting/api/mcp/McpControllerV1.java
@@ -2,6 +2,8 @@ package app.freerouting.api.mcp;
 
 import app.freerouting.Freerouting;
 import app.freerouting.analytics.FRAnalytics;
+import app.freerouting.analytics.model.ActorType;
+import app.freerouting.analytics.model.PipelineType;
 import app.freerouting.api.BaseController;
 import app.freerouting.api.CorrelationIdFilter;
 import app.freerouting.constants.Constants;
@@ -201,6 +203,8 @@ public class McpControllerV1 extends BaseController {
       FRLogger.error("MCP RPC execution failed", e);
       response = error(id, -32603, "Internal error");
       FRLogger.info("[mcp][cid=" + correlationId + "] response (error)=" + response.toString());
+      FRAnalytics.recordStructuredError(
+          "MCP", "INTERNAL_RPC_ERROR", e.getMessage(), e, correlationId);
     }
 
     String envHost = headers.getHeaderString("Freerouting-Environment-Host");
@@ -269,6 +273,7 @@ public class McpControllerV1 extends BaseController {
         String version =
             clientInfo.has("version") ? clientInfo.get("version").getAsString() : "1.0";
         detectedClientInfo = name + "/" + version;
+        FRAnalytics.setExecutionContext(PipelineType.MCP, ActorType.AGENT, name, version);
       } catch (Exception e) {
         FRLogger.warn("Failed to parse clientInfo from initialize params: " + e.getMessage());
       }
@@ -316,6 +321,8 @@ public class McpControllerV1 extends BaseController {
     OpenApiMcpToolRegistry.ToolOperation tool = registry.get(toolName);
 
     if (tool == null) {
+      FRAnalytics.recordStructuredError(
+          "MCP", "UNKNOWN_TOOL", "Unknown tool: " + toolName, null, correlationId);
       return error(id, -32601, "Unknown tool: " + toolName);
     }
 
@@ -327,6 +334,8 @@ public class McpControllerV1 extends BaseController {
     try {
       response = invokeTool(tool, arguments, correlationId);
     } catch (IllegalArgumentException ex) {
+      FRAnalytics.recordStructuredError(
+          "MCP", "INVALID_TOOL_ARGUMENTS", ex.getMessage(), ex, correlationId);
       return error(id, -32602, ex.getMessage());
     }
 
@@ -349,9 +358,19 @@ public class McpControllerV1 extends BaseController {
     text.addProperty("text", GsonProvider.GSON.toJson(payload));
     content.add(text);
 
+    boolean isError = response.statusCode() >= 400;
     JsonObject result = new JsonObject();
     result.add("content", content);
-    result.addProperty("isError", response.statusCode() >= 400);
+    result.addProperty("isError", isError);
+
+    if (isError) {
+      FRAnalytics.recordStructuredError(
+          "MCP",
+          "TOOL_EXECUTION_FAILED",
+          "Tool '" + toolName + "' returned HTTP " + response.statusCode(),
+          null,
+          correlationId);
+    }
 
     return success(id, result);
   }

--- a/src/main/java/app/freerouting/core/RoutingJob.java
+++ b/src/main/java/app/freerouting/core/RoutingJob.java
@@ -96,6 +96,16 @@ public class RoutingJob implements Serializable, Comparable<RoutingJob> {
   @Schema(description = "Details of the uploaded design rules (.rules) file")
   public BoardFileDetails rules;
 
+  @SerializedName("host_cad")
+  @Schema(name = "host_cad", description = "The CAD system that generated the board")
+  public String hostCad;
+
+  @SerializedName("host_version")
+  @Schema(
+      name = "host_version",
+      description = "The version of the CAD system that generated the board")
+  public String hostVersion;
+
   @SerializedName("drc")
   @Schema(description = "Details of the design rules check output")
   public BoardFileDetails drc;
@@ -565,5 +575,26 @@ public class RoutingJob implements Serializable, Comparable<RoutingJob> {
   public void logDebug(String message) {
     LogEntry logEntry = FRLogger.debug("[" + this.shortName + "] " + message, this.id);
     fireLogEntryAddedEvent(logEntry);
+  }
+
+  /**
+   * Resolves the detected host CAD name and version from parsed board communication if available.
+   */
+  public String getDetectedHost() {
+    if (hostCad != null && !hostCad.isBlank()) {
+      return (hostVersion != null && !hostVersion.isBlank())
+          ? hostCad + "/" + hostVersion
+          : hostCad;
+    }
+    if (board != null
+        && board.communication != null
+        && board.communication.specctraParserInfo != null) {
+      String cad = board.communication.specctraParserInfo.hostCad;
+      String ver = board.communication.specctraParserInfo.hostVersion;
+      if (cad != null && !cad.isBlank()) {
+        return (ver != null && !ver.isBlank()) ? cad + "/" + ver : cad;
+      }
+    }
+    return null;
   }
 }

--- a/src/main/java/app/freerouting/management/jobs/RoutingJobSchedulerActionThread.java
+++ b/src/main/java/app/freerouting/management/jobs/RoutingJobSchedulerActionThread.java
@@ -2,6 +2,7 @@ package app.freerouting.management.jobs;
 
 import app.freerouting.Freerouting;
 import app.freerouting.analytics.FRAnalytics;
+import app.freerouting.analytics.model.JobLifecycleStatus;
 import app.freerouting.autoroute.pipeline.BatchAutorouter;
 import app.freerouting.autoroute.pipeline.BatchOptimizer;
 import app.freerouting.autoroute.pipeline.RoutingPipeline;
@@ -95,6 +96,24 @@ public class RoutingJobSchedulerActionThread extends StoppableThread {
     if (routerEnabled) {
       FRAnalytics.autorouterStarted();
     }
+
+    FRAnalytics.recordJobLifecycle(
+        job.id.toString(),
+        job.sessionId != null ? job.sessionId.toString() : null,
+        JobLifecycleStatus.STARTED,
+        FRAnalytics.getCurrentPipeline(),
+        FRAnalytics.getCurrentActorType(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        job.getDetectedHost(),
+        null,
+        null);
 
     RoutingPipeline pipeline = RoutingPipeline.createForHeadless(job);
     pipeline.addBoardUpdatedEventListener(event -> setJobOutput(job));
@@ -203,6 +222,50 @@ public class RoutingJobSchedulerActionThread extends StoppableThread {
             + ", finished at UTC: "
             + job.finishedAt.toString()
             + ").");
+
+    JobLifecycleStatus lifecycleStatus =
+        switch (job.state) {
+          case COMPLETED -> JobLifecycleStatus.SUCCEEDED;
+          case TIMED_OUT -> JobLifecycleStatus.TIMED_OUT;
+          case CANCELLED -> JobLifecycleStatus.CANCELLED;
+          default -> JobLifecycleStatus.FAILED;
+        };
+
+    var finalBoardStats = job.board != null ? job.board.getStatistics() : null;
+    Integer netsTotal =
+        finalBoardStats != null && finalBoardStats.nets != null
+            ? finalBoardStats.nets.totalCount
+            : null;
+    Integer netsIncomplete =
+        finalBoardStats != null && finalBoardStats.connections != null
+            ? finalBoardStats.connections.incompleteCount
+            : null;
+    Integer clearanceViolations =
+        finalBoardStats != null && finalBoardStats.clearanceViolations != null
+            ? finalBoardStats.clearanceViolations.totalCount
+            : null;
+    Float normalizedScore =
+        finalBoardStats != null && job.routerSettings != null
+            ? finalBoardStats.getNormalizedScore(job.routerSettings.scoring)
+            : null;
+
+    FRAnalytics.recordJobLifecycle(
+        job.id.toString(),
+        job.sessionId != null ? job.sessionId.toString() : null,
+        lifecycleStatus,
+        FRAnalytics.getCurrentPipeline(),
+        FRAnalytics.getCurrentActorType(),
+        details.length() > 0 ? details.toString().trim() : null,
+        netsTotal,
+        netsIncomplete,
+        clearanceViolations,
+        normalizedScore,
+        durationSec,
+        (double) job.resourceUsage.cpuTimeUsed,
+        (double) job.resourceUsage.peakMemoryUsed,
+        job.getDetectedHost(),
+        null,
+        null);
   }
 
   private void monitorCpuAndMemoryUsage(RoutingJob job) {

--- a/src/main/java/app/freerouting/management/sessions/SessionManager.java
+++ b/src/main/java/app/freerouting/management/sessions/SessionManager.java
@@ -2,6 +2,7 @@ package app.freerouting.management.sessions;
 
 import static app.freerouting.Freerouting.globalSettings;
 
+import app.freerouting.analytics.FRAnalytics;
 import app.freerouting.core.Session;
 import java.util.Arrays;
 import java.util.Map;
@@ -91,6 +92,13 @@ public final class SessionManager {
     }
     sessions.put(session.id.toString(), session);
     globalSettings.statistics.incrementSessionsTotal();
+    FRAnalytics.recordSessionLifecycle(
+        session.id.toString(),
+        "SESSION_CREATED",
+        FRAnalytics.getCurrentPipeline(),
+        FRAnalytics.getCurrentActorType(),
+        host,
+        userId);
     return session;
   }
 
@@ -101,6 +109,13 @@ public final class SessionManager {
    */
   public void removeSession(String sessionId) {
     sessions.remove(sessionId);
+    FRAnalytics.recordSessionLifecycle(
+        sessionId,
+        "SESSION_CLOSED",
+        FRAnalytics.getCurrentPipeline(),
+        FRAnalytics.getCurrentActorType(),
+        null,
+        null);
   }
 
   /** Returns the number of currently registered sessions. */

--- a/src/main/java/app/freerouting/settings/RuntimeEnvironment.java
+++ b/src/main/java/app/freerouting/settings/RuntimeEnvironment.java
@@ -46,6 +46,12 @@ public class RuntimeEnvironment implements Serializable {
   @SerializedName("host")
   public transient String host = "N/A";
 
+  @SerializedName("pipeline_type")
+  public String pipelineType;
+
+  @SerializedName("actor_type")
+  public String actorType;
+
   /**
    * Measures a single-threaded CPU throughput score by running a lightweight synthetic
    * micro-benchmark (~15 ms) exercising EDA geometric operations (2D bounding-box overlap, 2D

--- a/src/test/java/app/freerouting/analytics/ProcessEnvironmentDetectorTest.java
+++ b/src/test/java/app/freerouting/analytics/ProcessEnvironmentDetectorTest.java
@@ -1,0 +1,121 @@
+package app.freerouting.analytics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import app.freerouting.analytics.model.ActorType;
+import app.freerouting.analytics.model.JobLifecycleStatus;
+import app.freerouting.analytics.model.PipelineType;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ProcessEnvironmentDetectorTest {
+
+  @Test
+  void testDetectPipelineType() {
+    assertEquals(
+        PipelineType.MCP,
+        ProcessEnvironmentDetector.detectPipelineType(true, true, true, false, false));
+
+    assertEquals(
+        PipelineType.GUI,
+        ProcessEnvironmentDetector.detectPipelineType(false, false, false, true, false));
+
+    assertEquals(
+        PipelineType.API,
+        ProcessEnvironmentDetector.detectPipelineType(false, false, true, false, false));
+
+    assertEquals(
+        PipelineType.CLI,
+        ProcessEnvironmentDetector.detectPipelineType(false, false, false, false, true));
+  }
+
+  @Test
+  void testDetectActorTypeForMcp() {
+    assertEquals(
+        ActorType.AGENT,
+        ProcessEnvironmentDetector.detectActorType(PipelineType.MCP, false, true, ""));
+  }
+
+  @Test
+  void testDetectActorTypeForHeadlessFlags() {
+    assertEquals(
+        ActorType.AUTOMATED_BATCH,
+        ProcessEnvironmentDetector.detectActorType(
+            PipelineType.CLI, false, true, "-de board.dsn -do board.ses -mp 100 -dct 0"));
+
+    assertEquals(
+        ActorType.AUTOMATED_BATCH,
+        ProcessEnvironmentDetector.detectActorType(
+            PipelineType.CLI, false, true, "--gui.enabled=false -de /data/board.dsn"));
+  }
+
+  @Test
+  void testParentProcessDetectionSafeExecution() {
+    // Verifies that getParentProcessCommand executes without throwing exceptions on any OS
+    String cmd = ProcessEnvironmentDetector.getParentProcessCommand();
+    assertNotNull(cmd);
+  }
+
+  @Test
+  void testFRAnalyticsExecutionContextAndLifecycleMethods() {
+    FRAnalytics.setExecutionContext(PipelineType.CLI, ActorType.AUTOMATED_BATCH, "KiCad", "9.0");
+
+    assertEquals(PipelineType.CLI, FRAnalytics.getCurrentPipeline());
+    assertEquals(ActorType.AUTOMATED_BATCH, FRAnalytics.getCurrentActorType());
+    assertEquals("KiCad", FRAnalytics.getCurrentIntegrationTool());
+    assertEquals("9.0", FRAnalytics.getCurrentIntegrationVersion());
+
+    // Verify calling lifecycle methods does not throw exceptions when analytics is null/disabled
+    FRAnalytics.recordBatchJobSummary(
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        "test_board.dsn",
+        0,
+        JobLifecycleStatus.SUCCEEDED,
+        null,
+        100,
+        0,
+        0,
+        99.5f,
+        10,
+        12.5,
+        8.0,
+        512.0,
+        "KiCad",
+        "9.0");
+
+    FRAnalytics.recordJobLifecycle(
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        JobLifecycleStatus.STARTED,
+        PipelineType.API,
+        ActorType.HUMAN,
+        null,
+        50,
+        5,
+        0,
+        null,
+        null,
+        null,
+        null,
+        "EasyEDA",
+        "1.0",
+        UUID.randomUUID());
+
+    FRAnalytics.recordSessionLifecycle(
+        UUID.randomUUID().toString(),
+        "SESSION_CREATED",
+        PipelineType.MCP,
+        ActorType.AGENT,
+        "claude-desktop",
+        UUID.randomUUID());
+
+    FRAnalytics.recordStructuredError(
+        "MCP",
+        "TOOL_EXECUTION_FAILED",
+        "Tool invocation error",
+        new RuntimeException("Test exception"),
+        "corr-12345");
+  }
+}

--- a/src/test/java/app/freerouting/analytics/ProcessEnvironmentDetectorTest.java
+++ b/src/test/java/app/freerouting/analytics/ProcessEnvironmentDetectorTest.java
@@ -34,7 +34,7 @@ class ProcessEnvironmentDetectorTest {
   void testDetectActorTypeForMcp() {
     assertEquals(
         ActorType.AGENT,
-        ProcessEnvironmentDetector.detectActorType(PipelineType.MCP, false, true, ""));
+        ProcessEnvironmentDetector.detectActorType(PipelineType.MCP, false, true, "", false));
   }
 
   @Test
@@ -42,12 +42,20 @@ class ProcessEnvironmentDetectorTest {
     assertEquals(
         ActorType.AUTOMATED_BATCH,
         ProcessEnvironmentDetector.detectActorType(
-            PipelineType.CLI, false, true, "-de board.dsn -do board.ses -mp 100 -dct 0"));
+            PipelineType.CLI, false, true, "-de board.dsn -do board.ses -mp 100 -dct 0", false));
 
     assertEquals(
         ActorType.AUTOMATED_BATCH,
         ProcessEnvironmentDetector.detectActorType(
-            PipelineType.CLI, false, true, "--gui.enabled=false -de /data/board.dsn"));
+            PipelineType.CLI, false, true, "--gui.enabled=false -de /data/board.dsn", false));
+  }
+
+  @Test
+  void testDetectActorTypeForCi() {
+    assertEquals(
+        ActorType.CI_CD,
+        ProcessEnvironmentDetector.detectActorType(
+            PipelineType.CLI, false, true, "-de board.dsn", true));
   }
 
   @Test


### PR DESCRIPTION
## Summary of Changes

This pull request implements the Phase 1 dual-user telemetry & observability architecture, distinguishing between human engineers, AI agents, and automated training/CI clusters across all execution pipelines.

### Core Changes

1. **Pipeline & Actor Taxonomy:**
   - Introduced `PipelineType` (`GUI`, `CLI`, `API`, `MCP`).
   - Introduced `ActorType` (`HUMAN`, `AGENT`, `AUTOMATED_BATCH`, `CI_CD`).
   - Introduced `JobLifecycleStatus` (`STARTED`, `SUCCEEDED`, `FAILED`, `TIMED_OUT`, `CANCELLED`).

2. **Environment & Host CAD / Agent Attribution:**
   - Added `ProcessEnvironmentDetector` to inspect OS parent processes (`ProcessHandle.current().parent()`), container environments, and CI indicators.
   - Automatically detects host CAD environments (`KiCad`, `EasyEDA`, `Fusion 360`, etc.) and AI agent hosts (`claude-desktop`, `cursor`, `cline`, `windsurf`, etc.).

3. **Lifecycle & Consolidated Batch Telemetry:**
   - `FRAnalytics`: Added `recordJobLifecycle(...)`, `recordSessionLifecycle(...)`, and `recordBatchJobSummary(...)`.
   - All outgoing anonymous tracking actions (`trackAnonymousAction`) and identify traits (`identify`) are automatically annotated with `pipeline`, `actor_type`, and `integration_tool`.
   - Headless CLI and containerized batch runs now emit a consolidated `batch_job_summary` event upon completion containing peak heap usage, CPU time, and normalized score.

4. **Structured Error Observability:**
   - Added `FRAnalytics.recordStructuredError(...)` with categorical error taxonomy (`SYSTEM`, `PARSER`, `ROUTING`, `DRC`, `MCP`, `API`).
   - Wired into `McpControllerV1` for RPC method validation, tool dispatch failures, and HTTP errors.

5. **Testing & Quality Gates:**
   - Added `ProcessEnvironmentDetectorTest` covering actor and pipeline detection.
   - All unit tests and strict package boundary tests (`ModuleBoundariesArchTest`) pass. Spotless formatting verified.
