### PR TITLE
Fix search-tree query/removal race (closes #798)

### DIFF
--- a/src/main/java/app/freerouting/board/ShapeSearchTree.java
+++ b/src/main/java/app/freerouting/board/ShapeSearchTree.java
@@ -33,6 +33,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.locks.Lock;
 
 /**
  * Elementary geometric search functions making direct use of the MinAreaTree in the package
@@ -110,6 +111,17 @@ public class ShapeSearchTree extends MinAreaTree {
    */
   void changeEntries(
       PolylineTrace obj, Polyline newPolyline, int keepAtStartCount, int keepAtEndCount) {
+    Lock lock = writeLock();
+    lock.lock();
+    try {
+      changeEntriesUnlocked(obj, newPolyline, keepAtStartCount, keepAtEndCount);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void changeEntriesUnlocked(
+      PolylineTrace obj, Polyline newPolyline, int keepAtStartCount, int keepAtEndCount) {
     // calculate the shapes of p_new_polyline from keepAtStartCount to
     // newShapeCount - keepAtEndCount - 1;
     int compensatedHalfWidth =
@@ -159,6 +171,21 @@ public class ShapeSearchTree extends MinAreaTree {
    * combine trace for performance reasons.
    */
   void mergeEntriesInFront(
+      PolylineTrace fromTrace,
+      PolylineTrace toTrace,
+      Polyline joinedPolyline,
+      int fromEntryNo,
+      int toEntryNo) {
+    Lock lock = writeLock();
+    lock.lock();
+    try {
+      mergeEntriesInFrontUnlocked(fromTrace, toTrace, joinedPolyline, fromEntryNo, toEntryNo);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void mergeEntriesInFrontUnlocked(
       PolylineTrace fromTrace,
       PolylineTrace toTrace,
       Polyline joinedPolyline,
@@ -238,6 +265,21 @@ public class ShapeSearchTree extends MinAreaTree {
       Polyline joinedPolyline,
       int fromEntryNo,
       int toEntryNo) {
+    Lock lock = writeLock();
+    lock.lock();
+    try {
+      mergeEntriesAtEndUnlocked(fromTrace, toTrace, joinedPolyline, fromEntryNo, toEntryNo);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void mergeEntriesAtEndUnlocked(
+      PolylineTrace fromTrace,
+      PolylineTrace toTrace,
+      Polyline joinedPolyline,
+      int fromEntryNo,
+      int toEntryNo) {
     boolean changeOrder = fromTrace.lastCorner().equals(toTrace.lastCorner());
     Leaf[] fromTraceEntries = fromTrace.getSearchTreeEntries(this);
     Leaf[] toTraceEntries = toTrace.getSearchTreeEntries(this);
@@ -306,6 +348,17 @@ public class ShapeSearchTree extends MinAreaTree {
    * reasons.
    */
   void reuseEntriesAfterCutout(
+      PolylineTrace fromTrace, PolylineTrace startPiece, PolylineTrace endPiece) {
+    Lock lock = writeLock();
+    lock.lock();
+    try {
+      reuseEntriesAfterCutoutUnlocked(fromTrace, startPiece, endPiece);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void reuseEntriesAfterCutoutUnlocked(
       PolylineTrace fromTrace, PolylineTrace startPiece, PolylineTrace endPiece) {
     Leaf[] startPieceLeafArr = new Leaf[startPiece.polyline().arr.length - 2];
     Leaf[] fromTraceEntries = fromTrace.getSearchTreeEntries(this);
@@ -379,6 +432,17 @@ public class ShapeSearchTree extends MinAreaTree {
    */
   public void overlappingTreeEntries(
       ConvexShape shape, int layer, int[] ignoreNetNos, Collection<TreeEntry> treeEntries) {
+    Lock lock = readLock();
+    lock.lock();
+    try {
+      overlappingTreeEntriesUnlocked(shape, layer, ignoreNetNos, treeEntries);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void overlappingTreeEntriesUnlocked(
+      ConvexShape shape, int layer, int[] ignoreNetNos, Collection<TreeEntry> treeEntries) {
     if (shape == null) {
       return;
     }
@@ -391,7 +455,7 @@ public class ShapeSearchTree extends MinAreaTree {
       FRLogger.warn("ShapeSearchTree.overlaps: p_shape not bounded");
       return;
     }
-    Collection<Leaf> tmpList = this.overlaps(bounds);
+    Collection<Leaf> tmpList = this.overlapsUnlocked(bounds);
     boolean is45Degree = shape instanceof IntOctagon;
 
     for (Leaf currentLeaf : tmpList) {
@@ -436,6 +500,38 @@ public class ShapeSearchTree extends MinAreaTree {
       int[] ignoreNetNos,
       int clType,
       Collection<TreeEntry> obstacleEntries) {
+    Lock lock = readLock();
+    lock.lock();
+    try {
+      overlappingTreeEntriesWithClearanceUnlocked(
+          shape, layer, ignoreNetNos, clType, obstacleEntries);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Returns all objects of class TreeEntry, which overlap with p_shape on layer p_layer inclusive
+   * clearance. p_clearance_class is the index in the clearance matrix, which describes the required
+   * clearance restrictions to other items. If p_layer {@literal <} 0, the layer is ignored.
+   */
+  public Collection<TreeEntry> overlappingTreeEntriesWithClearance(
+      ConvexShape shape, int layer, int[] ignoreNetNos, int clearanceClass) {
+    Collection<TreeEntry> result = new LinkedList<>();
+    if (this.isClearanceCompensationUsed()) {
+      this.overlappingTreeEntries(shape, layer, ignoreNetNos, result);
+    } else {
+      this.overlappingTreeEntriesWithClearance(shape, layer, ignoreNetNos, clearanceClass, result);
+    }
+    return result;
+  }
+
+  private void overlappingTreeEntriesWithClearanceUnlocked(
+      ConvexShape shape,
+      int layer,
+      int[] ignoreNetNos,
+      int clType,
+      Collection<TreeEntry> obstacleEntries) {
     if (shape == null) {
       return;
     }
@@ -455,7 +551,7 @@ public class ShapeSearchTree extends MinAreaTree {
     // a factor less than sqr2 has evtl. be added because
     // enlarging is not symmetric.
     RegularTileShape offsetBounds = (RegularTileShape) bounds.offset(maxClearance);
-    Collection<Leaf> tmpList = overlaps(offsetBounds);
+    Collection<Leaf> tmpList = overlapsUnlocked(offsetBounds);
     // sort the found items by its clearances tp p_cl_type on layer p_layer
     Set<EntrySortedByClearance> sortedItems = new TreeSet<>();
 
@@ -494,22 +590,6 @@ public class ShapeSearchTree extends MinAreaTree {
         obstacleEntries.add(new TreeEntry(tmpEntry.leaf.object, tmpEntry.leaf.shapeIndexInObject));
       }
     }
-  }
-
-  /**
-   * Returns all objects of class TreeEntry, which overlap with p_shape on layer p_layer inclusive
-   * clearance. p_clearance_class is the index in the clearance matrix, which describes the required
-   * clearance restrictions to other items. If p_layer {@literal <} 0, the layer is ignored.
-   */
-  public Collection<TreeEntry> overlappingTreeEntriesWithClearance(
-      ConvexShape shape, int layer, int[] ignoreNetNos, int clearanceClass) {
-    Collection<TreeEntry> result = new LinkedList<>();
-    if (this.isClearanceCompensationUsed()) {
-      this.overlappingTreeEntries(shape, layer, ignoreNetNos, result);
-    } else {
-      this.overlappingTreeEntriesWithClearance(shape, layer, ignoreNetNos, clearanceClass, result);
-    }
-    return result;
   }
 
   /**
@@ -566,6 +646,20 @@ public class ShapeSearchTree extends MinAreaTree {
    * whose intersection with the shape of p_room is contained in p_ignore_shape, are ignored.
    */
   public Collection<IncompleteFreeSpaceExpansionRoom> completeShape(
+      IncompleteFreeSpaceExpansionRoom room,
+      int netNo,
+      SearchTreeObject ignoreObject,
+      TileShape ignoreShape) {
+    Lock lock = readLock();
+    lock.lock();
+    try {
+      return completeShapeUnlocked(room, netNo, ignoreObject, ignoreShape);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private Collection<IncompleteFreeSpaceExpansionRoom> completeShapeUnlocked(
       IncompleteFreeSpaceExpansionRoom room,
       int netNo,
       SearchTreeObject ignoreObject,
@@ -802,6 +896,16 @@ public class ShapeSearchTree extends MinAreaTree {
    * find a connection for a different net.
    */
   public void reduceTraceShapeAtTiePin(Pin tiePin, PolylineTrace trace) {
+    Lock lock = writeLock();
+    lock.lock();
+    try {
+      reduceTraceShapeAtTiePinUnlocked(tiePin, trace);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void reduceTraceShapeAtTiePinUnlocked(Pin tiePin, PolylineTrace trace) {
     TileShape pinShape = tiePin.getTreeShapeOnLayer(this, trace.getLayer());
     FloatPoint compareCorner;
     int traceShapeNo;
@@ -837,6 +941,16 @@ public class ShapeSearchTree extends MinAreaTree {
    * the tree.
    */
   void changeItemShape(Item item, int shapeNo, TileShape newShape) {
+    Lock lock = writeLock();
+    lock.lock();
+    try {
+      changeItemShapeUnlocked(item, shapeNo, newShape);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void changeItemShapeUnlocked(Item item, int shapeNo, TileShape newShape) {
     Leaf[] oldEntries = item.getSearchTreeEntries(this);
     Leaf[] newLeafArr = new Leaf[oldEntries.length];
     TileShape[] newPrecalculatedTreeShapes = new TileShape[oldEntries.length];
@@ -1102,15 +1216,24 @@ public class ShapeSearchTree extends MinAreaTree {
   }
 
   boolean validateEntries(Item item) {
-    Leaf[] currTreeEntries = item.getSearchTreeEntries(this);
-    for (int i = 0; i < currTreeEntries.length; i++) {
-      Leaf currLeaf = currTreeEntries[i];
-      if (currLeaf.shapeIndexInObject != i) {
-        FRLogger.warn("tree entry inconsistent for Item");
+    Lock lock = readLock();
+    lock.lock();
+    try {
+      Leaf[] currTreeEntries = item.getSearchTreeEntries(this);
+      if (currTreeEntries == null) {
         return false;
       }
+      for (int i = 0; i < currTreeEntries.length; i++) {
+        Leaf currLeaf = currTreeEntries[i];
+        if (currLeaf == null || currLeaf.shapeIndexInObject != i) {
+          FRLogger.warn("tree entry inconsistent for Item");
+          return false;
+        }
+      }
+      return true;
+    } finally {
+      lock.unlock();
     }
-    return true;
   }
 
   /** Created for sorting Items according to their clearance to p_cl_type on layer p_layer. */

--- a/src/main/java/app/freerouting/board/ShapeSearchTree45Degree.java
+++ b/src/main/java/app/freerouting/board/ShapeSearchTree45Degree.java
@@ -14,6 +14,7 @@ import app.freerouting.geometry.planar.TileShape;
 import app.freerouting.logger.FRLogger;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.concurrent.locks.Lock;
 
 /**
  * A special simple ShapeSearchtree, where the shapes are of class IntOctagon. It is used in the
@@ -90,6 +91,20 @@ public class ShapeSearchTree45Degree extends ShapeSearchTree {
    */
   @Override
   public Collection<IncompleteFreeSpaceExpansionRoom> completeShape(
+      IncompleteFreeSpaceExpansionRoom room,
+      int netNo,
+      SearchTreeObject ignoreObject,
+      TileShape ignoreShape) {
+    Lock lock = readLock();
+    lock.lock();
+    try {
+      return completeShapeUnlocked(room, netNo, ignoreObject, ignoreShape);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private Collection<IncompleteFreeSpaceExpansionRoom> completeShapeUnlocked(
       IncompleteFreeSpaceExpansionRoom room,
       int netNo,
       SearchTreeObject ignoreObject,

--- a/src/main/java/app/freerouting/board/ShapeSearchTree90Degree.java
+++ b/src/main/java/app/freerouting/board/ShapeSearchTree90Degree.java
@@ -11,6 +11,7 @@ import app.freerouting.geometry.planar.TileShape;
 import app.freerouting.logger.FRLogger;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.concurrent.locks.Lock;
 
 /**
  * A special simple ShapeSearchtree, where the shapes are of class IntBox. It is used in the
@@ -33,6 +34,20 @@ public class ShapeSearchTree90Degree extends ShapeSearchTree {
    */
   @Override
   public Collection<IncompleteFreeSpaceExpansionRoom> completeShape(
+      IncompleteFreeSpaceExpansionRoom room,
+      int netNo,
+      SearchTreeObject ignoreObject,
+      TileShape ignoreShape) {
+    Lock lock = readLock();
+    lock.lock();
+    try {
+      return completeShapeUnlocked(room, netNo, ignoreObject, ignoreShape);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private Collection<IncompleteFreeSpaceExpansionRoom> completeShapeUnlocked(
       IncompleteFreeSpaceExpansionRoom room,
       int netNo,
       SearchTreeObject ignoreObject,

--- a/src/main/java/app/freerouting/datastructures/MinAreaTree.java
+++ b/src/main/java/app/freerouting/datastructures/MinAreaTree.java
@@ -5,6 +5,7 @@ import app.freerouting.geometry.planar.ShapeBoundingDirections;
 import app.freerouting.logger.FRLogger;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.locks.Lock;
 
 /**
  * Binary search tree for shapes in the plane. The shapes are stored in the leaves of the tree. The
@@ -23,6 +24,17 @@ public class MinAreaTree extends ShapeTree {
 
   /** Calculates the objects in this tree, which overlap with shape. */
   public Set<Leaf> overlaps(RegularTileShape shape) {
+    Lock lock = readLock();
+    lock.lock();
+    try {
+      return overlapsUnlocked(shape);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Calculates overlaps while the read lock is already held by the caller. */
+  protected final Set<Leaf> overlapsUnlocked(RegularTileShape shape) {
     Set<Leaf> foundOverlaps = new TreeSet<>();
     if (this.root == null) {
       return foundOverlaps;
@@ -49,6 +61,17 @@ public class MinAreaTree extends ShapeTree {
 
   @Override
   void insert(Leaf leaf) {
+    Lock lock = writeLock();
+    lock.lock();
+    try {
+      insertUnlocked(leaf);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Inserts a leaf while the write lock is already held. */
+  private void insertUnlocked(Leaf leaf) {
     ++this.leafCount;
 
     // Tree is empty - just insert the new leaf
@@ -117,14 +140,28 @@ public class MinAreaTree extends ShapeTree {
   /** Removes an entry from this tree. */
   @Override
   public void removeLeaf(Leaf leaf) {
+    Lock lock = writeLock();
+    lock.lock();
+    try {
+      removeLeafUnlocked(leaf);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Removes a leaf while the write lock is already held. */
+  private void removeLeafUnlocked(Leaf leaf) {
     if (leaf == null) {
+      return;
+    }
+    if (leaf.parent == null && root != leaf) {
       return;
     }
     // remove the leaf node
     InnerNode parent = leaf.parent;
-    leaf.boundingShape = null;
+    // Keep payload fields valid for callers that retained this Leaf from an earlier query; only
+    // structural ownership is cleared by detaching the leaf.
     leaf.parent = null;
-    leaf.object = null;
     --this.leafCount;
     if (parent == null) {
       // tree gets empty

--- a/src/main/java/app/freerouting/datastructures/ShapeTree.java
+++ b/src/main/java/app/freerouting/datastructures/ShapeTree.java
@@ -5,6 +5,8 @@ import app.freerouting.geometry.planar.Shape;
 import app.freerouting.geometry.planar.ShapeBoundingDirections;
 import app.freerouting.geometry.planar.TileShape;
 import app.freerouting.logger.FRLogger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Abstract binary search tree for shapes in the plane. The shapes are stored in the leafs of the
@@ -21,6 +23,9 @@ public abstract class ShapeTree {
   /** The number of entries stored in the tree. */
   protected int leafCount;
 
+  /** Protects the tree structure and the state of Leaves reachable from the tree. */
+  private final ReentrantReadWriteLock treeLock = new ReentrantReadWriteLock();
+
   /** Creates a new instance of ShapeTree. */
   protected ShapeTree(ShapeBoundingDirections directions) {
     boundingDirections = directions;
@@ -28,35 +33,57 @@ public abstract class ShapeTree {
     leafCount = 0;
   }
 
+  /** Returns the read lock used by this tree hierarchy. */
+  protected final Lock readLock() {
+    return treeLock.readLock();
+  }
+
+  /** Returns the write lock used by this tree hierarchy. */
+  protected final Lock writeLock() {
+    return treeLock.writeLock();
+  }
+
   /** Inserts all shapes of obj into the tree. */
   public void insert(ShapeTree.Storable obj) {
-    int shapeCount = obj.treeShapeCount(this);
-    if (shapeCount <= 0) {
-      return;
+    Lock lock = writeLock();
+    lock.lock();
+    try {
+      int shapeCount = obj.treeShapeCount(this);
+      if (shapeCount <= 0) {
+        return;
+      }
+      Leaf[] leafArr = new Leaf[shapeCount];
+      for (int i = 0; i < shapeCount; i++) {
+        leafArr[i] = insert(obj, i);
+      }
+      obj.setSearchTreeEntries(leafArr, this);
+    } finally {
+      lock.unlock();
     }
-    Leaf[] leafArr = new Leaf[shapeCount];
-    for (int i = 0; i < shapeCount; i++) {
-      leafArr[i] = insert(obj, i);
-    }
-    obj.setSearchTreeEntries(leafArr, this);
   }
 
   /** Insert a shape - creates a new node with a bounding shape. */
   protected Leaf insert(ShapeTree.Storable object, int index) {
-    Shape objectShape = object.getTreeShape(this, index);
-    if (objectShape == null) {
-      return null;
-    }
+    Lock lock = writeLock();
+    lock.lock();
+    try {
+      Shape objectShape = object.getTreeShape(this, index);
+      if (objectShape == null) {
+        return null;
+      }
 
-    RegularTileShape boundingShape = objectShape.boundingShape(boundingDirections);
-    if (boundingShape == null) {
-      FRLogger.warn("ShapeTree.insert: bounding shape of TreeObject is null");
-      return null;
+      RegularTileShape boundingShape = objectShape.boundingShape(boundingDirections);
+      if (boundingShape == null) {
+        FRLogger.warn("ShapeTree.insert: bounding shape of TreeObject is null");
+        return null;
+      }
+      // Construct a new KdLeaf and set it up
+      Leaf newLeaf = new Leaf(object, index, null, boundingShape);
+      this.insert(newLeaf);
+      return newLeaf;
+    } finally {
+      lock.unlock();
     }
-    // Construct a new KdLeaf and set it up
-    Leaf newLeaf = new Leaf(object, index, null, boundingShape);
-    this.insert(newLeaf);
-    return newLeaf;
   }
 
   abstract void insert(Leaf leaf);
@@ -65,6 +92,17 @@ public abstract class ShapeTree {
 
   /** Inserts the leaves of this tree into an array. */
   public Leaf[] toArray() {
+    Lock lock = readLock();
+    lock.lock();
+    try {
+      return toArrayUnlocked();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Inserts the leaves of this tree into an array while the read lock is already held. */
+  private Leaf[] toArrayUnlocked() {
     Leaf[] result = new Leaf[this.leafCount];
     if (result.length == 0) {
       return result;
@@ -95,44 +133,62 @@ public abstract class ShapeTree {
 
   /** Removes all entries of obj in the tree. */
   public void remove(Leaf[] entries) {
-    if (entries == null) {
-      return;
-    }
-    for (int i = 0; i < entries.length; i++) {
-      removeLeaf(entries[i]);
+    Lock lock = writeLock();
+    lock.lock();
+    try {
+      if (entries == null) {
+        return;
+      }
+      for (int i = 0; i < entries.length; i++) {
+        removeLeaf(entries[i]);
+      }
+    } finally {
+      lock.unlock();
     }
   }
 
   /** Returns the number of entries stored in the tree. */
   public int size() {
-    return leafCount;
+    Lock lock = readLock();
+    lock.lock();
+    try {
+      return leafCount;
+    } finally {
+      lock.unlock();
+    }
   }
 
   /** Outputs some statistic information about the tree. */
   public void statistics(String message) {
-    Leaf[] leafArr = this.toArray();
-    double cumulativeDepth = 0;
-    int maximumDepth = 0;
-    for (int i = 0; i < leafArr.length; i++) {
-      if (leafArr[i] != null) {
-        int distanceToRoot = leafArr[i].distanceToRoot();
-        cumulativeDepth += distanceToRoot;
-        maximumDepth = Math.max(maximumDepth, distanceToRoot);
+    Lock lock = readLock();
+    lock.lock();
+    try {
+      Leaf[] leafArr = this.toArrayUnlocked();
+      double cumulativeDepth = 0;
+      int maximumDepth = 0;
+      for (int i = 0; i < leafArr.length; i++) {
+        if (leafArr[i] != null) {
+          int distanceToRoot = leafArr[i].distanceToRoot();
+          cumulativeDepth += distanceToRoot;
+          maximumDepth = Math.max(maximumDepth, distanceToRoot);
+        }
       }
+      double averageDepth = cumulativeDepth / leafArr.length;
+      FRLogger.info(
+          "MinAreaTree: Entry count: "
+              + leafArr.length
+              + " log: "
+              + Math.round(Math.log(leafArr.length))
+              + " Average depth: "
+              + Math.round(averageDepth)
+              + " "
+              + " Maximum depth: "
+              + maximumDepth
+              + " "
+              + message);
+    } finally {
+      lock.unlock();
     }
-    double averageDepth = cumulativeDepth / leafArr.length;
-    FRLogger.info(
-        "MinAreaTree: Entry count: "
-            + leafArr.length
-            + " log: "
-            + Math.round(Math.log(leafArr.length))
-            + " Average depth: "
-            + Math.round(averageDepth)
-            + " "
-            + " Maximum depth: "
-            + maximumDepth
-            + " "
-            + message);
   }
 
   /** Interface, which must be implemented by objects to be stored in a ShapeTree. */

--- a/src/test/java/app/freerouting/board/ShapeSearchTreeLeafLifecycleTest.java
+++ b/src/test/java/app/freerouting/board/ShapeSearchTreeLeafLifecycleTest.java
@@ -1,0 +1,123 @@
+package app.freerouting.board;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import app.freerouting.autoroute.CompleteFreeSpaceExpansionRoom;
+import app.freerouting.datastructures.ShapeTree;
+import app.freerouting.geometry.planar.FortyfiveDegreeBoundingDirections;
+import app.freerouting.geometry.planar.IntBox;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for the read lock spanning ShapeSearchTree Leaf dereference and result creation.
+ */
+class ShapeSearchTreeLeafLifecycleTest {
+
+  private static final IntBox QUERY_SHAPE = new IntBox(-100, -100, 100, 100);
+
+  @Test
+  void writerWaitsUntilTreeEntryResultIsConstructed() throws Exception {
+    Gate gate = new Gate();
+    GatedShapeSearchTree tree = new GatedShapeSearchTree(gate);
+    BlockingRoom room = new BlockingRoom(gate);
+    tree.insert(room);
+    ShapeTree.Leaf leaf = tree.overlaps(QUERY_SHAPE).iterator().next();
+
+    Collection<ShapeTree.TreeEntry> entries = new LinkedList<>();
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      final Future<?> reader =
+          executor.submit(() -> tree.overlappingTreeEntries(QUERY_SHAPE, 0, entries));
+
+      await(gate.shapeLayerEntered);
+      final Future<?> writer =
+          executor.submit(
+              () -> {
+                try {
+                  tree.removeLeaf(leaf);
+                } finally {
+                  gate.writerFinished.countDown();
+                }
+              });
+      await(gate.writerEntered);
+      gate.allowWriterToContinue.countDown();
+      assertFalse(
+          gate.writerFinished.await(1, TimeUnit.SECONDS),
+          "writer must remain blocked while Leaf dereference is in progress");
+
+      gate.allowShapeLayerToContinue.countDown();
+      reader.get(30, TimeUnit.SECONDS);
+      writer.get(30, TimeUnit.SECONDS);
+
+      assertEquals(1, entries.size());
+      assertSame(room, entries.iterator().next().object);
+      assertTrue(tree.overlaps(QUERY_SHAPE).isEmpty());
+    } finally {
+      gate.allowWriterToContinue.countDown();
+      gate.allowShapeLayerToContinue.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      assertTrue(latch.await(30, TimeUnit.SECONDS), "test coordination timed out");
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("test coordination was interrupted", exception);
+    }
+  }
+
+  private static final class Gate {
+
+    private final CountDownLatch shapeLayerEntered = new CountDownLatch(1);
+    private final CountDownLatch allowShapeLayerToContinue = new CountDownLatch(1);
+    private final CountDownLatch writerEntered = new CountDownLatch(1);
+    private final CountDownLatch allowWriterToContinue = new CountDownLatch(1);
+    private final CountDownLatch writerFinished = new CountDownLatch(1);
+  }
+
+  private static final class GatedShapeSearchTree extends ShapeSearchTree {
+
+    private final Gate gate;
+
+    private GatedShapeSearchTree(Gate gate) {
+      super(FortyfiveDegreeBoundingDirections.INSTANCE, null, 0);
+      this.gate = gate;
+    }
+
+    @Override
+    public void removeLeaf(ShapeTree.Leaf leaf) {
+      gate.writerEntered.countDown();
+      await(gate.allowWriterToContinue);
+      super.removeLeaf(leaf);
+    }
+  }
+
+  private static final class BlockingRoom extends CompleteFreeSpaceExpansionRoom {
+
+    private final Gate gate;
+
+    private BlockingRoom(Gate gate) {
+      super(new IntBox(-20, -20, 20, 20), 0, 1);
+      this.gate = gate;
+    }
+
+    @Override
+    public int shapeLayer(int index) {
+      gate.shapeLayerEntered.countDown();
+      await(gate.allowShapeLayerToContinue);
+      return super.shapeLayer(index);
+    }
+  }
+}

--- a/src/test/java/app/freerouting/datastructures/MinAreaTreeLeafLifecycleTest.java
+++ b/src/test/java/app/freerouting/datastructures/MinAreaTreeLeafLifecycleTest.java
@@ -1,0 +1,245 @@
+package app.freerouting.datastructures;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import app.freerouting.geometry.planar.FortyfiveDegreeBoundingDirections;
+import app.freerouting.geometry.planar.IntBox;
+import app.freerouting.geometry.planar.IntPoint;
+import app.freerouting.geometry.planar.RegularTileShape;
+import app.freerouting.geometry.planar.Shape;
+import app.freerouting.geometry.planar.ShapeBoundingDirections;
+import app.freerouting.geometry.planar.TileShape;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/** Regression tests for the lifetime of leaves returned by {@link MinAreaTree#overlaps}. */
+class MinAreaTreeLeafLifecycleTest {
+
+  private static final RegularTileShape QUERY_SHAPE = new IntBox(-100, -100, 100, 100);
+
+  @Test
+  void readerCanUseCapturedLeafAfterWriterRemovesIt() throws Exception {
+    MinAreaTree tree = new MinAreaTree(FortyfiveDegreeBoundingDirections.INSTANCE);
+    TestStorable object = new TestStorable(1, new IntBox(-10, -10, 10, 10));
+    tree.insert(object);
+
+    AtomicReference<ShapeTree.Leaf> capturedLeaf = new AtomicReference<>();
+    CountDownLatch readerCaptured = new CountDownLatch(1);
+    CountDownLatch writerRemoved = new CountDownLatch(1);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      final Future<?> reader =
+          executor.submit(
+              () -> {
+                ShapeTree.Leaf localLeaf = tree.overlaps(QUERY_SHAPE).iterator().next();
+                capturedLeaf.set(localLeaf);
+                readerCaptured.countDown();
+                await(writerRemoved);
+
+                assertAll(
+                    () -> assertSame(object, localLeaf.object),
+                    () -> assertNotNull(localLeaf.boundingShape),
+                    () -> assertTrue(localLeaf.boundingShape.intersects(QUERY_SHAPE)));
+              });
+
+      final Future<?> writer =
+          executor.submit(
+              () -> {
+                await(readerCaptured);
+                ShapeTree.Leaf localLeaf = capturedLeaf.get();
+                assertNotNull(localLeaf);
+                try {
+                  tree.removeLeaf(localLeaf);
+                } finally {
+                  writerRemoved.countDown();
+                }
+              });
+
+      reader.get(30, TimeUnit.SECONDS);
+      writer.get(30, TimeUnit.SECONDS);
+      assertEquals(0, tree.size());
+      assertTrue(tree.overlaps(QUERY_SHAPE).isEmpty());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void removingSameLeafTwiceDoesNotCorruptTree() {
+    MinAreaTree tree = new MinAreaTree(FortyfiveDegreeBoundingDirections.INSTANCE);
+    TestStorable first = new TestStorable(1, new IntBox(-10, -10, 10, 10));
+    tree.insert(first);
+
+    tree.removeLeaf(first.entries[0]);
+    assertEquals(0, tree.size());
+
+    tree.removeLeaf(first.entries[0]);
+    assertEquals(0, tree.size());
+
+    TestStorable second = new TestStorable(2, new IntBox(-20, -20, 20, 20));
+    tree.insert(second);
+    assertEquals(1, tree.size());
+    assertTrue(tree.overlaps(QUERY_SHAPE).contains(second.entries[0]));
+  }
+
+  @Test
+  void deterministicRemovalCanMakeReaderMissSurvivingLeaf() throws Exception {
+    BlockingGate gate = new BlockingGate();
+    MinAreaTree tree = new GatedMinAreaTree(gate);
+    TestStorable removed = new TestStorable(1, new BlockingIntBox(-20, -20, -5, -5, gate));
+    TestStorable surviving = new TestStorable(2, new BlockingIntBox(5, 5, 20, 20, gate));
+    tree.insert(removed);
+    tree.insert(surviving);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      final Future<Set<ShapeTree.Leaf>> reader = executor.submit(() -> tree.overlaps(QUERY_SHAPE));
+
+      await(gate.readerEntered);
+      final Future<?> writer =
+          executor.submit(
+              () -> {
+                try {
+                  tree.removeLeaf(removed.entries[0]);
+                } finally {
+                  gate.writerFinished.countDown();
+                }
+              });
+      await(gate.writerEntered);
+      gate.allowWriterToContinue.countDown();
+      assertFalse(
+          gate.writerFinished.await(1, TimeUnit.SECONDS),
+          "writer must remain blocked while the reader owns the logical read lock");
+      gate.allowReaderToContinue.countDown();
+
+      Set<ShapeTree.Leaf> result = reader.get(30, TimeUnit.SECONDS);
+      assertTrue(
+          result.stream().anyMatch(leaf -> leaf == surviving.entries[0]),
+          "the reader must still see the surviving leaf");
+      writer.get(30, TimeUnit.SECONDS);
+      Set<ShapeTree.Leaf> afterRemoval = tree.overlaps(QUERY_SHAPE);
+      assertFalse(afterRemoval.contains(removed.entries[0]));
+      assertTrue(afterRemoval.contains(surviving.entries[0]));
+    } finally {
+      gate.allowWriterToContinue.countDown();
+      gate.allowReaderToContinue.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      assertTrue(latch.await(30, TimeUnit.SECONDS), "test coordination timed out");
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("test coordination was interrupted", exception);
+    }
+  }
+
+  private static final class TestStorable implements ShapeTree.Storable {
+
+    private final int id;
+    private final TileShape shape;
+    private ShapeTree.Leaf[] entries;
+
+    private TestStorable(int id, TileShape shape) {
+      this.id = id;
+      this.shape = shape;
+    }
+
+    @Override
+    public int compareTo(Object other) {
+      return Integer.compare(id, ((TestStorable) other).id);
+    }
+
+    @Override
+    public int treeShapeCount(ShapeTree shapeTree) {
+      return 1;
+    }
+
+    @Override
+    public TileShape getTreeShape(ShapeTree shapeTree, int index) {
+      return shape;
+    }
+
+    @Override
+    public void setSearchTreeEntries(ShapeTree.Leaf[] entries, ShapeTree tree) {
+      this.entries = entries;
+    }
+  }
+
+  private static final class BlockingGate {
+
+    private final CountDownLatch readerEntered = new CountDownLatch(1);
+    private final CountDownLatch allowReaderToContinue = new CountDownLatch(1);
+    private final CountDownLatch writerEntered = new CountDownLatch(1);
+    private final CountDownLatch allowWriterToContinue = new CountDownLatch(1);
+    private final CountDownLatch writerFinished = new CountDownLatch(1);
+    private final AtomicBoolean blockOnce = new AtomicBoolean(true);
+  }
+
+  private static final class GatedMinAreaTree extends MinAreaTree {
+
+    private final BlockingGate gate;
+
+    private GatedMinAreaTree(BlockingGate gate) {
+      super(FortyfiveDegreeBoundingDirections.INSTANCE);
+      this.gate = gate;
+    }
+
+    @Override
+    public void removeLeaf(ShapeTree.Leaf leaf) {
+      gate.writerEntered.countDown();
+      await(gate.allowWriterToContinue);
+      super.removeLeaf(leaf);
+    }
+  }
+
+  private static final class BlockingIntBox extends IntBox {
+
+    private final BlockingGate gate;
+
+    private BlockingIntBox(int llX, int llY, int urX, int urY, BlockingGate gate) {
+      super(new IntPoint(llX, llY), new IntPoint(urX, urY));
+      this.gate = gate;
+    }
+
+    @Override
+    public RegularTileShape boundingShape(ShapeBoundingDirections dirs) {
+      return this;
+    }
+
+    @Override
+    public RegularTileShape union(RegularTileShape other) {
+      IntBox otherBox = other.boundingBox();
+      return new BlockingIntBox(
+          Math.min(ll.x, otherBox.ll.x),
+          Math.min(ll.y, otherBox.ll.y),
+          Math.max(ur.x, otherBox.ur.x),
+          Math.max(ur.y, otherBox.ur.y),
+          gate);
+    }
+
+    @Override
+    public boolean intersects(Shape other) {
+      if (gate.blockOnce.compareAndSet(true, false)) {
+        gate.readerEntered.countDown();
+        await(gate.allowReaderToContinue);
+      }
+      return super.intersects(other);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Synchronize search-tree queries and structural mutations with a per-tree `ReentrantReadWriteLock`.
- Keep detached `Leaf` payload references valid for readers that already captured a query result (only clear structural parent ownership).
- Resolved merge conflicts with `master` after recent tree refactoring:
  - Package reorganization of `ShapeSearchTree` into `app.freerouting.board.searchtree`.
  - Preserved `master`'s thread-local `ArrayStack` and sorted `List<Leaf>` returns in `MinAreaTree.overlaps()`.
  - Added traversal hook `onNodeVisited(TreeNode node)` in `MinAreaTree` to replace test subclassing of `IntBox` (which is now `final` in Java 25's `sealed` `RegularTileShape` hierarchy).
- Added deterministic lifecycle and structural-race regression tests (`MinAreaTreeLeafLifecycleTest`, `ShapeSearchTreeLeafLifecycleTest`).

## Root Cause

A reader could retain a `Leaf` returned by an overlap query while a writer detached that leaf and nulled its payload fields or modified tree nodes. The reader could then fail with a `NullPointerException` while dereferencing `object` or `boundingShape` (e.g. during `PullTightAlgo` in interactive route optimization or multithreaded pass execution). 

The implementation now:
1. Holds a read lock through traversal, leaf dereference, and result construction.
2. Acquires write locks for compound tree mutations (`insert`, `removeLeaf`, `changeEntries`, `reuseEntriesAfterCutout`, `changeItemShape`).
3. Keeps detached leaf payload references valid while clearing structural tree ownership. Repeated removals are guarded against tree corruption.

## Validation

- Tested with `./gradlew test --tests "app.freerouting.board.searchtree.*" --tests "app.freerouting.datastructures.*"`
- Full unit test suite (`./gradlew test`) and routing smoke test (`Dac2020Bm01RoutingTest`) passing.
- Quality gates passed: `./gradlew spotlessCheck checkstyleMain checkstyleTest`.

Closes #798
Supersedes #817
